### PR TITLE
More clojure.core-like functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ pom.xml.asc
 /.nrepl-port
 /.repl*
 out
+
+.idea
+*.iml

--- a/project.clj
+++ b/project.clj
@@ -7,8 +7,8 @@
   :test-paths ["test"]
   :dependencies [
                  [org.clojure/clojure "1.10.0" :scope "provided"]
-                 [org.clojure/clojurescript "1.10.516" :scope "provided" ]
-                 [io.replikativ/incognito "0.2.5-SNAPSHOT"]
+                 [org.clojure/clojurescript "1.10.516" :scope "provided"]
+                 [io.replikativ/incognito "0.2.5"]
                  [fress "0.3.1"]
                  [org.clojure/core.async "0.4.490"]
                  [org.clojure/data.fressian "0.2.1"] ;; for filestore

--- a/src/konserve/cache.cljc
+++ b/src/konserve/cache.cljc
@@ -53,11 +53,11 @@
   "Updates a position described by key-vec by applying up-fn and storing
   the result atomically. Returns a vector [old new] of the previous
   value and the result of applying up-fn (the newly stored value)."
-  [store key-vec fn]
+  [store key-vec fn & args]
   (go-locked
    store (first key-vec)
    (let [cache (:cache store)
-         [old new] (<! (-update-in store key-vec fn))]
+         [old new] (<! (-update-in store key-vec fn args))]
      (swap! cache cache/evict (first key-vec))
      [old new])))
 

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -86,10 +86,10 @@
   "Updates a position described by key-vec by applying up-fn and storing
   the result atomically. Returns a vector [old new] of the previous
   value and the result of applying up-fn (the newly stored value)."
-  [store key-vec fn]
+  [store key-vec fn & args]
   (go-locked
    store (first key-vec)
-   (<! (-update-in store key-vec fn))))
+   (<! (-update-in store key-vec fn args))))
 
 (defn assoc-in
   "Associates the key-vec to the value, any missing collections for

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -1,5 +1,5 @@
 (ns konserve.core
-  (:refer-clojure :exclude [get get-in update-in assoc-in exists? dissoc])
+  (:refer-clojure :exclude [get get-in update update-in assoc assoc-in exists? dissoc])
   (:require [konserve.protocols :refer [-exists? -get-in -assoc-in
                                         -update-in -dissoc -bget -bassoc]]
             [hasch.core :refer [uuid]]
@@ -31,7 +31,7 @@
         (put! c :unlocked)
         (clojure.core/get (swap! locks (fn [old]
                                          (if (old key) old
-                                             (assoc old key c))))
+                                             (clojure.core/assoc old key c))))
              key))))
 
 #?(:clj
@@ -91,6 +91,13 @@
    store (first key-vec)
    (<! (-update-in store key-vec fn args))))
 
+(defn update
+  "Updates a position described by key by applying up-fn and storing
+  the result atomically. Returns a vector [old new] of the previous
+  value and the result of applying up-fn (the newly stored value)."
+  [store key fn & args]
+  (apply update-in store [key] fn args))
+
 (defn assoc-in
   "Associates the key-vec to the value, any missing collections for
   the key-vec (nested maps and vectors) are newly created."
@@ -98,6 +105,12 @@
   (go-locked
    store (first key-vec)
    (<! (-assoc-in store key-vec val))))
+
+(defn assoc
+ "Associates the key-vec to the value, any missing collections for
+ the key-vec (nested maps and vectors) are newly created."
+ [store key val]
+ (assoc-in store [key] val))
 
 (defn dissoc
   "Removes an entry from the store. "

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -271,8 +271,8 @@
     (time (->>  (range 5000)
                 (map #(assoc-in store [%] v))
                 async/merge
-                #_(async/pipeline-blocking 4 res identity)
-                ))) ;; 38 secs
+                #_(async/pipeline-blocking 4 res identity))))
+                 ;; 38 secs
   (go (println "2000" (<! (get-in store [2000]))))
 
   (let [res (chan (async/sliding-buffer 1))
@@ -395,5 +395,5 @@
     (println "another lock on foo"))
 
   (time (doseq [i (range 10000)]
-          (spit (str "/tmp/store/" i) (pr-str (range i)))))
-  )
+          (spit (str "/tmp/store/" i) (pr-str (range i))))))
+

--- a/src/konserve/indexeddb.cljs
+++ b/src/konserve/indexeddb.cljs
@@ -52,7 +52,8 @@
               (close! res)))
       res))
 
-  (-update-in [this key-vec up-fn]
+  (-update-in [this key-vec up-fn] (-update-in this key-vec up-fn []))
+  (-update-in [this key-vec up-fn up-fn-args]
     (let [[fkey & rkey] key-vec
           res (chan)
           tx (.transaction db #js [store-name] "readwrite")
@@ -71,8 +72,8 @@
                 (let [old (when-let [r (.-result req)]
                             (-deserialize serializer read-handlers (aget r "edn_value")))
                       up (if-not (empty? rkey)
-                           (update-in old rkey up-fn)
-                           (up-fn old))]
+                           (apply update-in old rkey up-fn up-fn-args)
+                           (apply up-fn old up-fn-args))]
                   (let [up-req (.put obj-store
                                      (clj->js {:key (pr-str fkey)
                                                :edn_value

--- a/src/konserve/memory.cljc
+++ b/src/konserve/memory.cljc
@@ -10,8 +10,9 @@
   PEDNAsyncKeyValueStore
   (-exists? [this key] (go (if (@state key) true false)))
   (-get-in [this key-vec] (go (get-in @state key-vec)))
-  (-update-in [this key-vec up-fn] (go [(get-in @state key-vec)
-                                        (get-in (swap! state update-in key-vec up-fn) key-vec)]))
+  (-update-in [this key-vec up-fn] (-update-in this key-vec up-fn []))
+  (-update-in [this key-vec up-fn args] (go [(get-in @state key-vec)
+                                             (get-in (apply swap! state update-in key-vec up-fn args) key-vec)]))
   (-assoc-in [this key-vec val] (-update-in this key-vec (fn [_] val)))
   (-dissoc [this key] (go (swap! state dissoc key) nil))
 
@@ -50,6 +51,6 @@
 
 
   (<!! (-bassoc store "foo" (io/input-stream (byte-array 10 (byte 42)))))
-  (<!! (-bget store "foo" identity))
+  (<!! (-bget store "foo" identity)))
 
-  )
+

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -5,7 +5,7 @@
   "Allows to access a store similar to hash-map in EDN."
   (-exists? [this key] "Checks whether value is in the store.")
   (-get-in [this key-vec] "Returns the value stored described by key-vec or nil if the path is not resolvable.")
-  (-update-in [this key-vec up-fn] "Updates a position described by key-vec by applying up-fn and storing the result atomically. Returns a vector [old new] of the previous value and the result of applying up-fn (the newly stored value)." )
+  (-update-in [this key-vec up-fn] [this key-vec up-fn up-fn-args] "Updates a position described by key-vec by applying up-fn and storing the result atomically. Returns a vector [old new] of the previous value and the result of applying up-fn (the newly stored value).")
   (-assoc-in [this key-vec val])
   (-dissoc [this key]))
 

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -21,7 +21,7 @@
   "SUBJECT TO CHANGE. Low-Level JSON implementation to give native performance. Might be merged into EDN later, when we find a comparable EDN solution. Assumes all values are JSON. "
   (-jget-in [this key-vec] "Returns the value stored described by key-vec or nil if the path is not resolvable.")
   (-jassoc-in [this key-vec value] "Associates the key-vec to the value, any missing collections for the key-vec (nested maps and vectors) are newly created.")
-  (-jupdate-in [this key-vec up-fn] "Updates a position described by key-vec by applying up-fn and storing the result atomically. Returns a vector [old new] of the previous value and the result of applying up-fn (the newly stored value)." ))
+  (-jupdate-in [this key-vec up-fn] "Updates a position described by key-vec by applying up-fn and storing the result atomically. Returns a vector [old new] of the previous value and the result of applying up-fn (the newly stored value)."))
 
 
 (defprotocol PBinaryAsyncKeyValueStore

--- a/test/konserve/core_test.clj
+++ b/test/konserve/core_test.clj
@@ -1,5 +1,5 @@
 (ns konserve.core-test
-  (:refer-clojure :exclude [get-in update-in assoc-in dissoc exists?])
+  (:refer-clojure :exclude [get get-in update-in assoc-in dissoc exists?])
   (:require [clojure.test :refer :all]
             [clojure.core.async :refer [<!! go]]
             [konserve.core :refer :all]
@@ -13,8 +13,10 @@
       (is (= (<!! (get-in store [:foo]))
              nil))
       (<!! (assoc-in store [:foo] :bar))
-      (is (= (<!! (get-in store [:foo]))
+      (is (= (<!! (get store :foo))
              :bar))
+      (is (= :default
+             (<!! (get-in store [:fuu] :default))))
       (<!! (assoc-in store [:baz] {:bar 42}))
       (is (= (<!! (get-in store [:baz :bar]))
              42))

--- a/test/konserve/core_test.clj
+++ b/test/konserve/core_test.clj
@@ -1,5 +1,5 @@
 (ns konserve.core-test
-  (:refer-clojure :exclude [get get-in update-in assoc-in dissoc exists?])
+  (:refer-clojure :exclude [get get-in update update-in assoc assoc-in dissoc exists?])
   (:require [clojure.test :refer :all]
             [clojure.core.async :refer [<!! go]]
             [konserve.core :refer :all]
@@ -12,11 +12,16 @@
     (let [store (<!! (new-mem-store))]
       (is (= (<!! (get-in store [:foo]))
              nil))
-      (<!! (assoc-in store [:foo] :bar))
+      (<!! (assoc store :foo :bar))
       (is (= (<!! (get store :foo))
              :bar))
+      (<!! (assoc-in store [:foo] :bar2))
+      (is (= :bar2 (<!! (get store :foo))))
       (is (= :default
              (<!! (get-in store [:fuu] :default))))
+      (<!! (update store :foo name))
+      (is (= "bar2"
+             (<!! (get store :foo))))
       (<!! (assoc-in store [:baz] {:bar 42}))
       (is (= (<!! (get-in store [:baz :bar]))
              42))

--- a/test/konserve/core_test.clj
+++ b/test/konserve/core_test.clj
@@ -20,6 +20,12 @@
       (<!! (assoc-in store [:baz] {:bar 42}))
       (is (= (<!! (get-in store [:baz :bar]))
              42))
+      (<!! (update-in store [:baz :bar] inc))
+      (is (= (<!! (get-in store [:baz :bar]))
+             43))
+      (<!! (update-in store [:baz :bar] + 2 3))
+      (is (= (<!! (get-in store [:baz :bar]))
+             48))
       (<!! (dissoc store :foo))
       (is (= (<!! (get-in store [:foo]))
              nil))
@@ -70,5 +76,5 @@
       (delete-store folder)
       (let [store (<!! (new-fs-store folder))]
         (is (= (<!! (list-keys store))
-               #{}))
-        ))))
+               #{}))))))
+

--- a/test/konserve/filestore_migration_test.clj
+++ b/test/konserve/filestore_migration_test.clj
@@ -1,5 +1,5 @@
 (ns konserve.filestore-migration-test
-  (:refer-clojure :exclude [get get-in update-in assoc-in dissoc exists? bget bassoc])
+  (:refer-clojure :exclude [get get-in update update-in assoc assoc-in dissoc exists? bget bassoc])
   (:require [clojure.test :refer :all]
             [konserve.old-filestore :as old-store]
             [clojure.core.async :refer [<!! >!! chan go]]

--- a/test/konserve/filestore_migration_test.clj
+++ b/test/konserve/filestore_migration_test.clj
@@ -1,5 +1,5 @@
 (ns konserve.filestore-migration-test
-  (:refer-clojure :exclude [get-in update-in assoc-in dissoc exists? bget bassoc])
+  (:refer-clojure :exclude [get get-in update-in assoc-in dissoc exists? bget bassoc])
   (:require [clojure.test :refer :all]
             [konserve.old-filestore :as old-store]
             [clojure.core.async :refer [<!! >!! chan go]]

--- a/test/konserve/old_filestore.clj
+++ b/test/konserve/old_filestore.clj
@@ -160,7 +160,8 @@
                                 :exception e})))))
       res-ch))
 
-  (-update-in [this key-vec up-fn]
+  (-update-in [this key-vec up-fn] (-update-in this key-vec up-fn []))
+  (-update-in [this key-vec up-fn up-fn-args]
     (async/thread
       (let [[fkey & rkey] key-vec
             fn (uuid fkey)
@@ -181,8 +182,8 @@
               dos (DataOutputStream. fos)
               fd (.getFD fos)
               new (if-not (empty? rkey)
-                    (update-in old rkey up-fn)
-                    (up-fn old))]
+                    (apply update-in old rkey up-fn up-fn-args)
+                    (apply up-fn old up-fn-args))]
           (if (instance? Throwable old)
             old ;; return read error
             (try

--- a/test/konserve/serializers_test.clj
+++ b/test/konserve/serializers_test.clj
@@ -1,5 +1,5 @@
 (ns konserve.serializers-test
-  (:refer-clojure :exclude [get get-in update-in assoc-in dissoc exists?])
+  (:refer-clojure :exclude [get get-in update update-in assoc assoc-in dissoc exists?])
   (:require [clojure.test :refer :all]
             [clojure.core.async :refer [<!!]]
             [konserve.core :refer :all]

--- a/test/konserve/serializers_test.clj
+++ b/test/konserve/serializers_test.clj
@@ -1,5 +1,5 @@
 (ns konserve.serializers-test
-  (:refer-clojure :exclude [get-in update-in assoc-in dissoc exists?])
+  (:refer-clojure :exclude [get get-in update-in assoc-in dissoc exists?])
   (:require [clojure.test :refer :all]
             [clojure.core.async :refer [<!!]]
             [konserve.core :refer :all]


### PR DESCRIPTION
Work in Progress

- [x] There is no `get`, `assoc` and `update` function. 
  - [x] `get`
  - [x] `assoc`
  - [x] `update`
  - These should be trivial without touching any interface. 
- [x] The `update-in` function does not have the optional arguments for the function.
   - clojure.core: `(update-in m ks f & args)`
- [x] `get-in` does not have an optional argument for a default value.

Closes https://github.com/replikativ/konserve/issues/24