### PR TITLE
Fix get-in for JVM filestore, naming tweak.

### DIFF
--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -181,10 +181,9 @@
                    (let [bais (ByteArrayInputStream. (.array bb))]
                      (try
                        (let [value (-deserialize serializer read-handlers bais)]
-                         (put! res-ch
-                               (if (not-empty rkey)
-                                 (get-in value rkey)
-                                 value)))
+                         (if-let [value (if (not-empty rkey) (get-in value rkey))]
+                           (put! res-ch value)
+                           (close! res-ch)))
                        (catch Exception e
                          (ex-info "Could not read key."
                                   {:type      :read-error

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -12,9 +12,9 @@
 
 (defprotocol PStoreSerializer
   "Decouples serialization format from storage."
-  (-serialize [this output-stream read-handlers val]
+  (-serialize [this output-stream write-handlers val]
     "For the JVM we use streams, while for JavaScript we return the value for now.")
-  (-deserialize [this write-handlers input-stream]))
+  (-deserialize [this read-handlers input-stream]))
 
 
 (defprotocol PJSONAsyncKeyValueStore


### PR DESCRIPTION
This also corrects some of the indentation, since parinfer mode doesn't
like it when the indentation is off. Also fix a naming bug in the
PStoreSerializer protocol, which was confusing me when I was trying to
write code against that protocol.

* src/konserve/filestore.clj (read-key): `get-in` `rkey` from the result
  we read, if it's not empty.
* src/konserve/protocols.clj (PStoreSerializer): fix names for handlers.