### PR TITLE
Compliance tests for failures

### DIFF
--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -10,11 +10,8 @@
 (deftype UnknownType [])
 
 (defn exception? [thing]
-  (let [ex (type thing)]
-    (or (= clojure.lang.ExceptionInfo ex) 
-        (= java.lang.Exception ex) 
-        (= java.lang.Throwable ex))))
-
+  (instance? Throwable thing))
+  
 (defn compliance-test [store]
   (testing "Test the core API."
     (is (= (<!! (get store :foo))

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -63,7 +63,10 @@
          list-keys)))
     
     (let [params (clojure.core/keys store)
-          corruptor (fn [s k] (clojure.core/assoc-in s [k] (UnknownType.)))
+          corruptor (fn [s k] 
+                        (if (= (type (k s)) clojure.lang.Atom)
+                          (clojure.core/assoc-in s [k] (atom {})) 
+                          (clojure.core/assoc-in s [k] (UnknownType.))))
           corrupt (reduce corruptor store params)]
       (is (exception? (<!! (get corrupt :bad))))
       (is (exception? (<!! (get-meta corrupt :bad))))


### PR DESCRIPTION
- Ensure all protocol methods throw errors 
- Ensure all protocol methods throw their errors using the async channel