### PR TITLE
Ignore ephemeral NFS files

### DIFF
--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -669,8 +669,11 @@
    :write-handlers empty
    :buffer-size    1 MB
    :config         config} "
-  [path & {:keys [detect-old-file-schema? config]
-           :or {detect-old-file-schema? false}
+  [path & {:keys [detect-old-file-schema? ephemeral? config]
+           :or {detect-old-file-schema? false
+                ephemeral? (fn [^Path path]
+                             (some #(re-matches % (-> path .getFileName .toString))
+                                   [#"\.nfs.*"]))}
            :as params}]
   ;; check config
   (let [store-config (merge {:default-serializer :FressianSerializer
@@ -685,9 +688,6 @@
                                                          :lock-blob? true}
                                                         config)}
                             (dissoc params :config))
-        ephemeral? (fn [^Path path]
-                     (some #(re-matches % (-> path .getFileName .toString))
-                           [#"\.nfs.*"]))
         detect-old-blob (when detect-old-file-schema?
                           (atom (detect-old-file-schema path)))
         _                  (when detect-old-file-schema?

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -26,12 +26,6 @@
    [sun.nio.ch FileLockImpl]
    (java.util Date UUID)))
 
-(def ^:dynamic *ephemeral?*
-  "Decides if a path is ephemeral, based on its filename."
-  (fn [^Path path]
-    (some #(re-matches % (-> path .getFileName .toString))
-          [#"\.nfs.*"])))
-
 (def ^:dynamic *sync-translation*
   (merge *default-sync-translation*
          '{AsynchronousFileChannel FileChannel}))
@@ -69,14 +63,17 @@
       (catch Exception e
         e))))
 
-(defn list-files [directory]
+(defn list-files
   "Lists all files on the first level of a directory."
-  (let [root (Paths/get directory (into-array String []))
-        ds (Files/newDirectoryStream root)
-        files (mapv (fn [^Path path]
-                      (str (.relativize root path))) (remove *ephemeral?* ds))]
-    (.close ds)
-    files))
+  ([directory]
+   (list-files directory (fn [_] false)))
+  ([directory ephemeral?]
+   (let [root (Paths/get directory (into-array String []))
+         ds (Files/newDirectoryStream root)
+         files (mapv (fn [^Path path] (str (.relativize root path)))
+                     (remove ephemeral? ds))]
+     (.close ds)
+     files)))
 
 (defn count-konserve-keys [dir]
   "Counts konserve files in the directory."
@@ -96,7 +93,7 @@
 
 (declare migrate-old-files migrate-file-v2 migrate-file-v1)
 
-(defrecord BackingFilestore [base detected-old-blobs]
+(defrecord BackingFilestore [base detected-old-blobs ephemeral?]
   PBackingStore
   (-create-blob [_this store-key env]
     (let [{:keys [sync?]} env
@@ -140,7 +137,7 @@
 
   (-keys [_this env]
     (async+sync (:sync? env) *default-sync-translation*
-                (go-try- (into [] (list-files base)))))
+                (go-try- (into [] (list-files base ephemeral?)))))
 
   (-copy [_this from to env]
     (async+sync (:sync? env) *default-sync-translation*
@@ -688,12 +685,15 @@
                                                          :lock-blob? true}
                                                         config)}
                             (dissoc params :config))
+        ephemeral? (fn [^Path path]
+                     (some #(re-matches % (-> path .getFileName .toString))
+                           [#"\.nfs.*"]))
         detect-old-blob (when detect-old-file-schema?
                           (atom (detect-old-file-schema path)))
         _                  (when detect-old-file-schema?
                              (when-not (empty? @detect-old-blob)
                                (info (count @detect-old-blob) "files in old storage schema detected. Migration for each key will happen transparently the first time a key is accessed. Invoke konserve.core/keys to do so at once. Once all keys are migrated you can deactivate this initial check by setting detect-old-file-schema to false.")))
-        backing            (BackingFilestore. path detect-old-blob)]
+        backing            (BackingFilestore. path detect-old-blob ephemeral?)]
     (connect-default-store backing store-config)))
 
 (comment

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -5,7 +5,7 @@
    [konserve.encryptor :refer [null-encryptor]]
    [konserve.impl.default :refer [update-blob connect-default-store key->store-key store-key->uuid-key]]
    [konserve.protocols :refer [-deserialize]]
-   [clojure.string :refer [includes? ends-with?]]
+   [clojure.string :refer [includes? ends-with? starts-with?]]
    [konserve.impl.storage-layout :refer [PBackingStore
                                          -keys
                                          PBackingBlob -close -get-lock -sync
@@ -67,8 +67,9 @@
   "Lists all files on the first level of a directory."
   (let [root (Paths/get directory (into-array String []))
         ds (Files/newDirectoryStream root)
+        ephemeral? (fn [^Path path] (starts-with? (.getFileName path) ".nfs"))
         files (mapv (fn [^Path path]
-                      (str (.relativize root path))) ds)]
+                      (str (.relativize root path))) (remove ephemeral? ds))]
     (.close ds)
     files))
 

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -26,6 +26,9 @@
    [sun.nio.ch FileLockImpl]
    (java.util Date UUID)))
 
+(def ^:dynamic *ephemeral?*
+  (fn [^Path path] (some #(starts-with? (.getFileName path) %) [".nfs"])))
+
 (def ^:dynamic *sync-translation*
   (merge *default-sync-translation*
          '{AsynchronousFileChannel FileChannel}))
@@ -67,9 +70,8 @@
   "Lists all files on the first level of a directory."
   (let [root (Paths/get directory (into-array String []))
         ds (Files/newDirectoryStream root)
-        ephemeral? (fn [^Path path] (starts-with? (.getFileName path) ".nfs"))
         files (mapv (fn [^Path path]
-                      (str (.relativize root path))) (remove ephemeral? ds))]
+                      (str (.relativize root path))) (remove *ephemeral?* ds))]
     (.close ds)
     files))
 

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -27,7 +27,7 @@
    (java.util Date UUID)))
 
 (def ^:dynamic *ephemeral?*
-  "Decides if a file is ephemeral, based on its base name."
+  "Decides if a path is ephemeral, based on its filename."
   (fn [^Path path]
     (some #(re-matches % (-> path .getFileName .toString))
           [#"\.nfs.*"])))

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -5,7 +5,7 @@
    [konserve.encryptor :refer [null-encryptor]]
    [konserve.impl.default :refer [update-blob connect-default-store key->store-key store-key->uuid-key]]
    [konserve.protocols :refer [-deserialize]]
-   [clojure.string :refer [includes? ends-with? starts-with?]]
+   [clojure.string :refer [includes? ends-with?]]
    [konserve.impl.storage-layout :refer [PBackingStore
                                          -keys
                                          PBackingBlob -close -get-lock -sync
@@ -27,7 +27,10 @@
    (java.util Date UUID)))
 
 (def ^:dynamic *ephemeral?*
-  (fn [^Path path] (some #(starts-with? (.getFileName path) %) [".nfs"])))
+  "Decides if a file is ephemeral, based on its base name."
+  (fn [^Path path]
+    (some #(re-matches % (-> path .getFileName .toString))
+          [#"\.nfs.*"])))
 
 (def ^:dynamic *sync-translation*
   (merge *default-sync-translation*


### PR DESCRIPTION
Meant to fix #67. `clojure -M:test -m kaocha.runner` reports 0 failures.