### PR TITLE
Fix native-image compilation. And formatting.

### DIFF
--- a/src/konserve/compressor.cljc
+++ b/src/konserve/compressor.cljc
@@ -18,16 +18,15 @@
     (throw (ex-info "Unsupported LZ4 compressor." {:bytes bytes}))))
 
 #?(:clj
-(defrecord Lz4Compressor [serializer]
-  PStoreSerializer
-  (-deserialize [_ read-handlers bytes]
-    (let [lz4-byte (LZ4FrameInputStream. bytes)]
-      (-deserialize serializer read-handlers lz4-byte)))
-  (-serialize [_ bytes write-handlers val]
-    (let [lz4-byte (LZ4FrameOutputStream. bytes)]
-      (-serialize serializer lz4-byte write-handlers val)
-      (.flush lz4-byte))))
-)
+   (defrecord Lz4Compressor [serializer]
+     PStoreSerializer
+     (-deserialize [_ read-handlers bytes]
+       (let [lz4-byte (LZ4FrameInputStream. bytes)]
+         (-deserialize serializer read-handlers lz4-byte)))
+     (-serialize [_ bytes write-handlers val]
+       (let [lz4-byte (LZ4FrameOutputStream. bytes)]
+         (-serialize serializer lz4-byte write-handlers val)
+         (.flush lz4-byte)))))
 
 (defn null-compressor [serializer]
   (NullCompressor. serializer))
@@ -36,10 +35,8 @@
   (UnsupportedLZ4Compressor. serializer))
 
 #?(:clj
-(defn lz4-compressor [serializer]
-  (Lz4Compressor. serializer))
-
-)
+   (defn lz4-compressor [serializer]
+     (Lz4Compressor. serializer)))
 
 #?(:clj
    (defmacro native-image-build? []

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -61,14 +61,16 @@
                         (-> serializer
                             compressor
                             encryptor
-                          (-serialize nil write-handlers value)))
+                            (-serialize nil write-handlers value)))
                       :clj
                       (fn [value]
                         (let [bos (ByteArrayOutputStream.)]
                           (try (-serialize (encryptor (compressor serializer))
                                            bos write-handlers value)
-                            (.toByteArray bos)
-                            (finally (.close bos))))))
+                               (.toByteArray bos)
+                               (finally
+                                 (.close bos))))))
+
           meta  (up-fn-meta old-meta)
           value (when (= operation :write-edn)
                   (if-not (empty? rkey)
@@ -82,7 +84,7 @@
               (trace "backing up to blob: " backup-store-key " for key " key)
               (<?- (-copy backing store-key backup-store-key env)))
           meta-arr             (to-array meta)
-          meta-size            (alength meta-arr)
+          meta-size            (count meta-arr)
           header               (create-header version
                                               serializer compressor encryptor meta-size)
           new-blob             (<?- (-create-blob backing new-store-key env))]

--- a/src/konserve/indexeddb.cljs
+++ b/src/konserve/indexeddb.cljs
@@ -6,225 +6,223 @@
                                         PStoreSerializer -serialize -deserialize]]
             [konserve.serializers :as ser]))
 
-#_
-(defrecord IndexedDBKeyValueStore [db store-name serializer read-handlers write-handlers locks version]
-  PEDNKeyValueStore
-  (-exists? [_this key]
-    (let [res       (chan)
-          tx        (.transaction db #js [store-name])
-          obj-store (.objectStore tx store-name)
-          req       (.openCursor obj-store (pr-str key))]
-      (set! (.-onerror req)
-            (fn [e]
-              (put! res (ex-info "Cannot check for existence."
-                                 {:type  :access-error
-                                  :key   key
-                                  :error (.-target e)}))
-              (close! res)))
-      (set! (.-onsuccess req)
-            (fn [e]
-              (put! res (if (.-result (.-target e))
-                          true false))
-              (close! res)))
-      res))
+#_(defrecord IndexedDBKeyValueStore [db store-name serializer read-handlers write-handlers locks version]
+    PEDNKeyValueStore
+    (-exists? [_this key]
+      (let [res       (chan)
+            tx        (.transaction db #js [store-name])
+            obj-store (.objectStore tx store-name)
+            req       (.openCursor obj-store (pr-str key))]
+        (set! (.-onerror req)
+              (fn [e]
+                (put! res (ex-info "Cannot check for existence."
+                                   {:type  :access-error
+                                    :key   key
+                                    :error (.-target e)}))
+                (close! res)))
+        (set! (.-onsuccess req)
+              (fn [e]
+                (put! res (if (.-result (.-target e))
+                            true false))
+                (close! res)))
+        res))
 
-  (-get-meta [_this key]
-    (let [res       (chan)
-          tx        (.transaction db #js [store-name])
-          obj-store (.objectStore tx store-name)
-          req       (.get obj-store (pr-str key))]
-      (set! (.-onerror req)
-            (fn [e]
-              (put! res (ex-info "Cannot read edn value."
-                                 {:type  :read-error
-                                  :key   key
-                                  :error (.-target e)}))
-              (close! res)))
-      (set! (.-onsuccess req)
-            (fn [e] (when-let [r (.-result req)]
-                      (put! res (-deserialize serializer read-handlers (aget r "meta"))))
-              (close! res)))
-      res))
+    (-get-meta [_this key]
+      (let [res       (chan)
+            tx        (.transaction db #js [store-name])
+            obj-store (.objectStore tx store-name)
+            req       (.get obj-store (pr-str key))]
+        (set! (.-onerror req)
+              (fn [e]
+                (put! res (ex-info "Cannot read edn value."
+                                   {:type  :read-error
+                                    :key   key
+                                    :error (.-target e)}))
+                (close! res)))
+        (set! (.-onsuccess req)
+              (fn [e] (when-let [r (.-result req)]
+                        (put! res (-deserialize serializer read-handlers (aget r "meta"))))
+                (close! res)))
+        res))
 
-  (-get [this key]
-    (let [res       (chan)
-          tx        (.transaction db #js [store-name])
-          obj-store (.objectStore tx store-name)
-          req       (.get obj-store (pr-str key))]
-      (set! (.-onerror req)
-            (fn [e]
-              (put! res (ex-info "Cannot read edn value."
-                                 {:type  :read-error
-                                  :key   key
-                                  :error (.-target e)}))
-              (close! res)))
-      (set! (.-onsuccess req)
-            (fn [e] (when-let [r (.-result req)]
-                      (put! res (-deserialize serializer read-handlers (aget r "edn_value"))))
-              (close! res)))
-      res))
+    (-get [this key]
+      (let [res       (chan)
+            tx        (.transaction db #js [store-name])
+            obj-store (.objectStore tx store-name)
+            req       (.get obj-store (pr-str key))]
+        (set! (.-onerror req)
+              (fn [e]
+                (put! res (ex-info "Cannot read edn value."
+                                   {:type  :read-error
+                                    :key   key
+                                    :error (.-target e)}))
+                (close! res)))
+        (set! (.-onsuccess req)
+              (fn [e] (when-let [r (.-result req)]
+                        (put! res (-deserialize serializer read-handlers (aget r "edn_value"))))
+                (close! res)))
+        res))
 
-  (-assoc-in [this key-vec meta-up val] (-update-in this key-vec meta-up (fn [_] val) []))
-  (-update-in [_this key-vec meta-up up-fn args]
-    (let [[fkey & rkey] key-vec
-          res           (chan)
-          tx            (.transaction db #js [store-name] "readwrite")
-          obj-store     (.objectStore tx store-name)
-          req           (.get obj-store (pr-str fkey))]
-      (set! (.-onerror req)
-            (fn [e]
-              (put! res (ex-info "Cannot read edn value."
-                                 {:type  :read-error
-                                  :key   key-vec
-                                  :error (.-target e)}))
-              (close! res)))
-      (set! (.-onsuccess req)
-            (fn read-old [e]
-              (try
-                (let [[old-meta old] (when-let [r (.-result req)]
-                                       [(-deserialize serializer read-handlers (aget r "meta")) (-deserialize serializer read-handlers (aget r "edn_value"))])
-                      edn-meta       (meta-up old-meta)
-                      edn-value      (if-not (empty? rkey)
-                                       (apply update-in old rkey up-fn args)
-                                       (apply up-fn old args))]
-                  (let [up-req (.put obj-store
-                                     (clj->js {:key (pr-str fkey)
-                                               :version version
-                                               :meta
-                                               (-serialize serializer nil write-handlers edn-meta)
-                                               :edn_value
-                                               (-serialize serializer nil write-handlers edn-value)}))]
-                    (set! (.-onerror up-req)
-                          (fn [e]
-                            (put! res (ex-info "Cannot write edn value."
-                                               {:type  :write-error
-                                                :key   key-vec
-                                                :error (.-target e)}))
-                            (close! res)))
-                    (set! (.-onsuccess up-req)
-                          (fn [e]
-                            (put! res [(get-in old rkey) edn-value])
-                            (close! res)))))
-                (catch :default e
-                  (put! res (ex-info "Cannot parse edn value."
-                                     {:type  :read-error
-                                      :key   key-vec
-                                      :error e}))
-                  (close! res)))))
-      res))
+    (-assoc-in [this key-vec meta-up val] (-update-in this key-vec meta-up (fn [_] val) []))
+    (-update-in [_this key-vec meta-up up-fn args]
+      (let [[fkey & rkey] key-vec
+            res           (chan)
+            tx            (.transaction db #js [store-name] "readwrite")
+            obj-store     (.objectStore tx store-name)
+            req           (.get obj-store (pr-str fkey))]
+        (set! (.-onerror req)
+              (fn [e]
+                (put! res (ex-info "Cannot read edn value."
+                                   {:type  :read-error
+                                    :key   key-vec
+                                    :error (.-target e)}))
+                (close! res)))
+        (set! (.-onsuccess req)
+              (fn read-old [e]
+                (try
+                  (let [[old-meta old] (when-let [r (.-result req)]
+                                         [(-deserialize serializer read-handlers (aget r "meta")) (-deserialize serializer read-handlers (aget r "edn_value"))])
+                        edn-meta       (meta-up old-meta)
+                        edn-value      (if-not (empty? rkey)
+                                         (apply update-in old rkey up-fn args)
+                                         (apply up-fn old args))]
+                    (let [up-req (.put obj-store
+                                       (clj->js {:key (pr-str fkey)
+                                                 :version version
+                                                 :meta
+                                                 (-serialize serializer nil write-handlers edn-meta)
+                                                 :edn_value
+                                                 (-serialize serializer nil write-handlers edn-value)}))]
+                      (set! (.-onerror up-req)
+                            (fn [e]
+                              (put! res (ex-info "Cannot write edn value."
+                                                 {:type  :write-error
+                                                  :key   key-vec
+                                                  :error (.-target e)}))
+                              (close! res)))
+                      (set! (.-onsuccess up-req)
+                            (fn [e]
+                              (put! res [(get-in old rkey) edn-value])
+                              (close! res)))))
+                  (catch :default e
+                    (put! res (ex-info "Cannot parse edn value."
+                                       {:type  :read-error
+                                        :key   key-vec
+                                        :error e}))
+                    (close! res)))))
+        res))
 
-  (-dissoc [_this key]
-    (let [res       (chan)
-          tx        (.transaction db #js [store-name] "readwrite")
-          obj-store (.objectStore tx store-name)
-          up-req    (.delete obj-store (pr-str key))]
-      (set! (.-onerror up-req)
-            (fn [e]
-              (put! res (ex-info "Cannot write edn value."
-                                 {:type  :write-error
-                                  :key   key
-                                  :error (.-target e)}))
-              (close! res)))
-      (set! (.-onsuccess up-req)
-            (fn [e]
-              (close! res)))
-      res))
+    (-dissoc [_this key]
+      (let [res       (chan)
+            tx        (.transaction db #js [store-name] "readwrite")
+            obj-store (.objectStore tx store-name)
+            up-req    (.delete obj-store (pr-str key))]
+        (set! (.-onerror up-req)
+              (fn [e]
+                (put! res (ex-info "Cannot write edn value."
+                                   {:type  :write-error
+                                    :key   key
+                                    :error (.-target e)}))
+                (close! res)))
+        (set! (.-onsuccess up-req)
+              (fn [e]
+                (close! res)))
+        res))
 
-  PBinaryKeyValueStore
-  (-bget [_this key lock-cb]
-    (let [res       (chan)
-          tx        (.transaction db #js [store-name])
-          obj-store (.objectStore tx store-name)
-          req       (.get obj-store (pr-str key))]
-      (set! (.-onerror req)
-            (fn [e]
-              (go
-                (>! res (<!
-                         (lock-cb (ex-info "Cannot read binary value."
-                                           {:type  :read-error
-                                            :key   key
-                                            :error (.-target e)}))))
-                (close! res))))
-      (set! (.-onsuccess req)
-            (fn [e] (when-let [r (.-result req)]
-                      (put! res (lock-cb (aget r "value"))))
+    PBinaryKeyValueStore
+    (-bget [_this key lock-cb]
+      (let [res       (chan)
+            tx        (.transaction db #js [store-name])
+            obj-store (.objectStore tx store-name)
+            req       (.get obj-store (pr-str key))]
+        (set! (.-onerror req)
+              (fn [e]
+                (go
+                  (>! res (<!
+                           (lock-cb (ex-info "Cannot read binary value."
+                                             {:type  :read-error
+                                              :key   key
+                                              :error (.-target e)}))))
+                  (close! res))))
+        (set! (.-onsuccess req)
+              (fn [e] (when-let [r (.-result req)]
+                        (put! res (lock-cb (aget r "value"))))
                 ;; returns nil
-              (close! res)))
-      res))
-  (-bassoc [this key meta-up blob]
-    (let [res       (chan)
-          tx        (.transaction db #js [store-name] "readwrite")
-          obj-store (.objectStore tx store-name)
-          req       (.get obj-store (pr-str key))]
-      (set! (.-onerror req)
-            (fn [e]
-              (put! res (ex-info "Cannot read edn value."
-                                 {:type  :read-error
-                                  :key   key
-                                  :error (.-target e)}))
-              (close! res)))
-      (set! (.-onsuccess req)
-            (fn read-old [e]
-              (try
-                (let [old-meta (when-let [r (.-result req)]
-                                 (-deserialize serializer read-handlers (aget r "meta")))
-                      edn-meta (meta-up old-meta)]
-                  (let [up-req (.put obj-store
-                                     (clj->js {:key   (pr-str key)
-                                               :meta
-                                               (-serialize serializer nil write-handlers edn-meta)
-                                               :version version
-                                               :value blob}))]
-                    (set! (.-onerror up-req)
-                          (fn [e]
-                            (put! res (ex-info "Cannot write binary value."
-                                               {:type  :write-error
-                                                :key   key
-                                                :error (.-target e)}))
-                            (close! res)))
-                    (set! (.-onsuccess up-req)
-                          (fn [e] (close! res)))))
-                (catch :default e
-                  (put! res (ex-info "Cannot parse edn value."
-                                     {:type  :read-error
-                                      :key   key
-                                      :error e}))
-                  (close! res)))))
-      res)))
+                (close! res)))
+        res))
+    (-bassoc [this key meta-up blob]
+      (let [res       (chan)
+            tx        (.transaction db #js [store-name] "readwrite")
+            obj-store (.objectStore tx store-name)
+            req       (.get obj-store (pr-str key))]
+        (set! (.-onerror req)
+              (fn [e]
+                (put! res (ex-info "Cannot read edn value."
+                                   {:type  :read-error
+                                    :key   key
+                                    :error (.-target e)}))
+                (close! res)))
+        (set! (.-onsuccess req)
+              (fn read-old [e]
+                (try
+                  (let [old-meta (when-let [r (.-result req)]
+                                   (-deserialize serializer read-handlers (aget r "meta")))
+                        edn-meta (meta-up old-meta)]
+                    (let [up-req (.put obj-store
+                                       (clj->js {:key   (pr-str key)
+                                                 :meta
+                                                 (-serialize serializer nil write-handlers edn-meta)
+                                                 :version version
+                                                 :value blob}))]
+                      (set! (.-onerror up-req)
+                            (fn [e]
+                              (put! res (ex-info "Cannot write binary value."
+                                                 {:type  :write-error
+                                                  :key   key
+                                                  :error (.-target e)}))
+                              (close! res)))
+                      (set! (.-onsuccess up-req)
+                            (fn [e] (close! res)))))
+                  (catch :default e
+                    (put! res (ex-info "Cannot parse edn value."
+                                       {:type  :read-error
+                                        :key   key
+                                        :error e}))
+                    (close! res)))))
+        res)))
 
-#_
-(defn new-indexeddb-store
-  "Create an IndexedDB backed edn store with read-handlers according to
+#_(defn new-indexeddb-store
+    "Create an IndexedDB backed edn store with read-handlers according to
   incognito.
 
   Be careful not to mix up edn and JSON values."
-  [name & {:keys [read-handlers write-handlers serializer version]
-           :or {read-handlers (atom {})
-                write-handlers (atom {})
-                serializer (ser/string-serializer)
-                version 1}}]
-  (let [res (chan)
-        req (.open js/window.indexedDB name 1)]
-    (set! (.-onerror req)
-          (fn [e]
-            (put! res (ex-info "Cannot open IndexedDB store."
-                               {:type :db-error
-                                :error (.-target e)}))
-            (close! res)))
-    (set! (.-onsuccess req)
-          (fn success-handler [e]
-            (put! res (map->IndexedDBKeyValueStore {:db (.-result req)
-                                                    :serializer serializer
-                                                    :store-name name
-                                                    :read-handlers read-handlers
-                                                    :write-handlers write-handlers
-                                                    :locks (atom {})
-                                                    :version version}))))
-    (set! (.-onupgradeneeded req)
-          (fn upgrade-handler [e]
-            (let [db (-> e .-target .-result)]
-              (.createObjectStore db name #js {:keyPath "key"}))))
-    res))
+    [name & {:keys [read-handlers write-handlers serializer version]
+             :or {read-handlers (atom {})
+                  write-handlers (atom {})
+                  serializer (ser/string-serializer)
+                  version 1}}]
+    (let [res (chan)
+          req (.open js/window.indexedDB name 1)]
+      (set! (.-onerror req)
+            (fn [e]
+              (put! res (ex-info "Cannot open IndexedDB store."
+                                 {:type :db-error
+                                  :error (.-target e)}))
+              (close! res)))
+      (set! (.-onsuccess req)
+            (fn success-handler [e]
+              (put! res (map->IndexedDBKeyValueStore {:db (.-result req)
+                                                      :serializer serializer
+                                                      :store-name name
+                                                      :read-handlers read-handlers
+                                                      :write-handlers write-handlers
+                                                      :locks (atom {})
+                                                      :version version}))))
+      (set! (.-onupgradeneeded req)
+            (fn upgrade-handler [e]
+              (let [db (-> e .-target .-result)]
+                (.createObjectStore db name #js {:keyPath "key"}))))
+      res))
 
 (comment
     ;;new-gc

--- a/src/konserve/serializers.cljc
+++ b/src/konserve/serializers.cljc
@@ -4,27 +4,27 @@
             [incognito.fressian :refer [incognito-read-handlers incognito-write-handlers]]
             [incognito.edn :refer [read-string-safe]])
   #?(:clj (:import ;[java.io FileOutputStream FileInputStream DataInputStream DataOutputStream]
-                   [org.fressian.handlers WriteHandler ReadHandler])))
+           [org.fressian.handlers WriteHandler ReadHandler])))
 
 (defrecord FressianSerializer [custom-read-handlers custom-write-handlers]
   #?@(:cljs (INamed ;clojure.lang.Named
              (-name [_] "FressianSerializer")
-             (-namespace [_]"konserve.serializers")))
+             (-namespace [_] "konserve.serializers")))
   PStoreSerializer
   (-deserialize [_ read-handlers bytes]
     (let [handlers #?(:cljs (merge custom-read-handlers (incognito-read-handlers read-handlers))
                       :clj (-> (merge fress/clojure-read-handlers
                                       custom-read-handlers
                                       (incognito-read-handlers read-handlers))
-                                      fress/associative-lookup))]
+                               fress/associative-lookup))]
       (fress/read bytes :handlers handlers)))
   (-serialize [_ bytes write-handlers val]
     (let [handlers #?(:clj (-> (merge
                                 fress/clojure-write-handlers
                                 custom-write-handlers
                                 (incognito-write-handlers write-handlers))
-                             fress/associative-lookup
-                             fress/inheritance-lookup)
+                               fress/associative-lookup
+                               fress/inheritance-lookup)
                       :cljs (merge custom-write-handlers
                                    (incognito-write-handlers write-handlers)))]
       #?(:clj (let [writer (fress/create-writer bytes :handlers handlers)]
@@ -38,7 +38,7 @@
 (defrecord StringSerializer []
   #?@(:cljs (INamed
              (-name [_] "StringSerializer")
-             (-namespace [_]"konserve.serializers")))
+             (-namespace [_] "konserve.serializers")))
   PStoreSerializer
   (-deserialize [_ read-handlers s]
     (read-string-safe @read-handlers s))
@@ -53,7 +53,7 @@
 (defn construct->class [m]
   (->> (map (fn [[k v]] [#?(:clj (class v)
                             :cljs (type v)) k]) m)
-    (into {})))
+       (into {})))
 
 (def byte->serializer
   {0 (string-serializer)
@@ -66,7 +66,7 @@
   (->> (map (fn [[_ v]]
               [#?(:clj (-> v class .getSimpleName keyword)
                   :cljs (-> v name keyword)) v]) m)
-    (into {})))
+       (into {})))
 
 (def key->serializer
   (construct->keys byte->serializer))

--- a/src/konserve/utils.cljc
+++ b/src/konserve/utils.cljc
@@ -22,23 +22,23 @@
     (clojure.core/assoc old :last-write (now))))
 
 #?(:clj
-(defmacro async+sync
-  [sync? async->sync async-code]
-  (let [async->sync (if (symbol? async->sync)
-                      (or (resolve async->sync)
-                          (when-let [_ns (or (get-in &env [:ns :use-macros async->sync])
-                                             (get-in &env [:ns :uses async->sync]))]
-                            (resolve (symbol (str _ns) (str async->sync)))))
-                      async->sync)]
-    (assert (some? async->sync))
-    `(if ~sync?
-       ~(clojure.walk/postwalk (fn [n]
-                                 (if-not (meta n)
-                                   (async->sync n n) ;; primitives have no metadata
-                                   (with-meta (async->sync n n)
-                                     (update (meta n) :tag (fn [t] (async->sync t t))))))
-                               async-code)
-       ~async-code))))
+   (defmacro async+sync
+     [sync? async->sync async-code]
+     (let [async->sync (if (symbol? async->sync)
+                         (or (resolve async->sync)
+                             (when-let [_ns (or (get-in &env [:ns :use-macros async->sync])
+                                                (get-in &env [:ns :uses async->sync]))]
+                               (resolve (symbol (str _ns) (str async->sync)))))
+                         async->sync)]
+       (assert (some? async->sync))
+       `(if ~sync?
+          ~(clojure.walk/postwalk (fn [n]
+                                    (if-not (meta n)
+                                      (async->sync n n) ;; primitives have no metadata
+                                      (with-meta (async->sync n n)
+                                        (update (meta n) :tag (fn [t] (async->sync t t))))))
+                                  async-code)
+          ~async-code))))
 
 (def ^:dynamic *default-sync-translation*
   '{go-try try

--- a/test/konserve/cache_test.cljs
+++ b/test/konserve/cache_test.cljs
@@ -10,60 +10,60 @@
 (deftest cache-PEDNKeyValueStore-test
   (fstore/delete-store store-path)
   (async done
-   (go
-    (let [opts {:sync? false}
-          test-store (<! (fstore/connect-fs-store store-path :opts opts))
-          store (k/ensure-cache test-store)]
-      (is (nil? (<! (k/get store :foo nil opts)) ))
-      (is (false? (<! (k/exists? store :foo opts))))
-      (is [nil :bar] (<! (k/assoc store :foo :bar opts)))
-      (is (true? (<! (k/exists? store :foo))))
-      (is (= :bar (<! (k/get store :foo nil opts))))
-      (is (= [nil :bar2] (<! (k/assoc-in store [:foo] :bar2 opts))))
-      (is (= :bar2 (<! (k/get store :foo nil opts))))
-      (is (= :default (<! (k/get-in store [:fuu] :default opts))))
-      (is (= :bar2 (<! (k/get store :foo nil opts))))
-      (is (= :default (<! (k/get-in store [:fuu] :default opts))))
-      (is (= [:bar2 "bar2"] (<! (k/update-in store [:foo] name opts))))
-      (is (= "bar2" (<! (k/get store :foo nil opts))))
-      (is (=  [nil {:bar 42}] (<! (k/assoc-in store [:baz] {:bar 42} opts))))
-      (is (= 42 (<! (k/get-in store [:baz :bar] nil opts))))
-      (is (= [{:bar 42} {:bar 43}] (<! (k/update-in store [:baz :bar] inc opts))))
-      (is (= 43 (<! (k/get-in store [:baz :bar] nil opts))))
-      (is (= [{:bar 43} {:bar 48}] (<! (k/update-in store [:baz :bar] (fn [x] (+ x 2 3)) opts))))
-      (is (= 48 (<! (k/get-in store [:baz :bar] nil opts))))
-      (is (true? (<! (k/dissoc store :foo opts))))
-      (is (nil? (<! (k/get-in store [:foo] nil opts))))
-      (done)))))
+         (go
+           (let [opts {:sync? false}
+                 test-store (<! (fstore/connect-fs-store store-path :opts opts))
+                 store (k/ensure-cache test-store)]
+             (is (nil? (<! (k/get store :foo nil opts))))
+             (is (false? (<! (k/exists? store :foo opts))))
+             (is [nil :bar] (<! (k/assoc store :foo :bar opts)))
+             (is (true? (<! (k/exists? store :foo))))
+             (is (= :bar (<! (k/get store :foo nil opts))))
+             (is (= [nil :bar2] (<! (k/assoc-in store [:foo] :bar2 opts))))
+             (is (= :bar2 (<! (k/get store :foo nil opts))))
+             (is (= :default (<! (k/get-in store [:fuu] :default opts))))
+             (is (= :bar2 (<! (k/get store :foo nil opts))))
+             (is (= :default (<! (k/get-in store [:fuu] :default opts))))
+             (is (= [:bar2 "bar2"] (<! (k/update-in store [:foo] name opts))))
+             (is (= "bar2" (<! (k/get store :foo nil opts))))
+             (is (=  [nil {:bar 42}] (<! (k/assoc-in store [:baz] {:bar 42} opts))))
+             (is (= 42 (<! (k/get-in store [:baz :bar] nil opts))))
+             (is (= [{:bar 42} {:bar 43}] (<! (k/update-in store [:baz :bar] inc opts))))
+             (is (= 43 (<! (k/get-in store [:baz :bar] nil opts))))
+             (is (= [{:bar 43} {:bar 48}] (<! (k/update-in store [:baz :bar] (fn [x] (+ x 2 3)) opts))))
+             (is (= 48 (<! (k/get-in store [:baz :bar] nil opts))))
+             (is (true? (<! (k/dissoc store :foo opts))))
+             (is (nil? (<! (k/get-in store [:foo] nil opts))))
+             (done)))))
 
 (deftest cache-PBin-test
   (fstore/delete-store store-path)
   (async done
-    (let [opts {:sync? false}
-          data [:this/is 'some/fressian "data 😀😀😀" (js/Date.) #{true false nil}]
-          bytes (fress/write data)
-          test-data (promise-chan)
-          locked-cb (fn [{readable :input-stream}]
-                      (put! test-data (fress/read (.read readable)))
-                      (.destroy readable))]
-      (go
-        (let [store (k/ensure-cache (<! (fstore/connect-fs-store store-path :opts opts)))]
-          (is (true? (<! (k/bassoc store :key bytes opts))))
-          (<! (k/bget store :key locked-cb opts))
-          (is (= data (<! test-data)))
-          (done))))))
+         (let [opts {:sync? false}
+               data [:this/is 'some/fressian "data 😀😀😀" (js/Date.) #{true false nil}]
+               bytes (fress/write data)
+               test-data (promise-chan)
+               locked-cb (fn [{readable :input-stream}]
+                           (put! test-data (fress/read (.read readable)))
+                           (.destroy readable))]
+           (go
+             (let [store (k/ensure-cache (<! (fstore/connect-fs-store store-path :opts opts)))]
+               (is (true? (<! (k/bassoc store :key bytes opts))))
+               (<! (k/bget store :key locked-cb opts))
+               (is (= data (<! test-data)))
+               (done))))))
 
 (deftest cache-PKeyIterable-test
   (fstore/delete-store store-path)
   (async done
-    (go
-      (let [opts {:sync? false}
-            store (k/ensure-cache (<! (fstore/connect-fs-store store-path :opts opts)))]
-        (is (= #{} (<! (k/keys store opts))))
-        (is (= [nil 42] (<! (k/assoc-in store [:value-blob] 42 opts))))
-        (is (true? (<! (k/bassoc store :bin-blob #js[255 255 255] opts))))
-        (let [store-keys (<! (k/keys store opts))]
-          (is (every? inst? (map :last-write store-keys)))
-          (is (= #{{:key :bin-blob :type :binary} {:key :value-blob :type :edn}}
-                 (set (map #(dissoc % :last-write) store-keys)))))
-        (done)))))
+         (go
+           (let [opts {:sync? false}
+                 store (k/ensure-cache (<! (fstore/connect-fs-store store-path :opts opts)))]
+             (is (= #{} (<! (k/keys store opts))))
+             (is (= [nil 42] (<! (k/assoc-in store [:value-blob] 42 opts))))
+             (is (true? (<! (k/bassoc store :bin-blob #js[255 255 255] opts))))
+             (let [store-keys (<! (k/keys store opts))]
+               (is (every? inst? (map :last-write store-keys)))
+               (is (= #{{:key :bin-blob :type :binary} {:key :value-blob :type :edn}}
+                      (set (map #(dissoc % :last-write) store-keys)))))
+             (done)))))

--- a/test/konserve/gc_test.cljs
+++ b/test/konserve/gc_test.cljs
@@ -8,40 +8,40 @@
 
 (deftest memory-store-gc-test
   (async done
-   (go
-    (testing "Test the GC."
-      (let [store (<! (new-mem-store))]
-        (<! (k/assoc store :foo :bar))
-        (<! (k/assoc-in store [:foo] :bar2))
-        (<! (k/assoc-in store [:foo2] :bar2))
-        (<! (k/assoc-in store [:foo3] :bar2))
-        (<! (timeout 1))
-        (let [ts (js/Date.)
-              whitelist #{:baz}]
-          (<! (k/update-in store [:foo] name))
-          (<! (k/assoc-in store [:baz] {:bar 42}))
-          (<! (k/update-in store [:baz :bar] inc))
-          (<! (k/update-in store [:baz :bar] #(+ % 2 3)))
-          (<! (k/bassoc store :binbar (js/Buffer.from  (into-array (range 10)))))
-          (is (= #{:foo2 :foo3} (<! (gc/sweep! store whitelist ts))))))
-      (done)))))
+         (go
+           (testing "Test the GC."
+             (let [store (<! (new-mem-store))]
+               (<! (k/assoc store :foo :bar))
+               (<! (k/assoc-in store [:foo] :bar2))
+               (<! (k/assoc-in store [:foo2] :bar2))
+               (<! (k/assoc-in store [:foo3] :bar2))
+               (<! (timeout 1))
+               (let [ts (js/Date.)
+                     whitelist #{:baz}]
+                 (<! (k/update-in store [:foo] name))
+                 (<! (k/assoc-in store [:baz] {:bar 42}))
+                 (<! (k/update-in store [:baz :bar] inc))
+                 (<! (k/update-in store [:baz :bar] #(+ % 2 3)))
+                 (<! (k/bassoc store :binbar (js/Buffer.from  (into-array (range 10)))))
+                 (is (= #{:foo2 :foo3} (<! (gc/sweep! store whitelist ts))))))
+             (done)))))
 
 (deftest file-store-gc-test
   (async done
-   (go
-    (let [folder "/tmp/konserve-gc"
-          _(delete-store folder)
-          store (<! (connect-fs-store folder))]
-      (<! (k/assoc store :foo :bar))
-      (<! (k/assoc-in store [:foo] :bar2))
-      (<! (k/assoc-in store [:foo2] :bar2))
-      (<! (k/assoc-in store [:foo3] :bar2))
-      (let [ts        (js/Date.)
-            whitelist #{:baz}]
-        (<! (k/update-in store [:foo] name))
-        (<! (k/assoc-in store [:baz] {:bar 42}))
-        (<! (k/update-in store [:baz :bar] inc))
-        (<! (k/update-in store [:baz :bar] #(+ % 2 3)))
-        (<! (k/bassoc store :binbar (js/Buffer.from  (into-array (range 10)))))
-        (is (= #{:foo2 :foo3} (<! (gc/sweep! store whitelist ts))))))
-    (done))))
+         (go
+           (let [folder "/tmp/konserve-gc"
+                 _ (delete-store folder)
+                 store (<! (connect-fs-store folder))]
+             (<! (k/assoc store :foo :bar))
+             (<! (k/assoc-in store [:foo] :bar2))
+             (<! (k/assoc-in store [:foo2] :bar2))
+             (<! (k/assoc-in store [:foo3] :bar2))
+             (let [ts        (js/Date.)
+                   whitelist #{:baz}]
+               (<! (k/update-in store [:foo] name))
+               (<! (k/assoc-in store [:baz] {:bar 42}))
+               (<! (k/update-in store [:baz :bar] inc))
+               (<! (k/update-in store [:baz :bar] #(+ % 2 3)))
+               (<! (k/bassoc store :binbar (js/Buffer.from  (into-array (range 10)))))
+               (is (= #{:foo2 :foo3} (<! (gc/sweep! store whitelist ts))))))
+           (done))))

--- a/test/konserve/node_filestore_test.cljs
+++ b/test/konserve/node_filestore_test.cljs
@@ -46,55 +46,55 @@
 
 (deftest existing-store-async-test
   (async done
-   (go
-    (let [opts {:sync? false}
-          store (<! (filestore/connect-fs-store store-path :opts opts))]
-      (is (= [nil {:a 42 :b "a string"}] (<! (p/-assoc-in store [:my-db] identity {:a 42 :b "a string"} opts))))
-      (let [store' (<! (filestore/connect-fs-store store-path :opts opts))]
-        (is (= [{:a 42 :b "a string"} {:a 42 :b "a string" :c 'sym}]
-               (<! (p/-update-in store' [:my-db] identity (fn [m] (assoc m :c 'sym)) opts))))
-        (done))))))
+         (go
+           (let [opts {:sync? false}
+                 store (<! (filestore/connect-fs-store store-path :opts opts))]
+             (is (= [nil {:a 42 :b "a string"}] (<! (p/-assoc-in store [:my-db] identity {:a 42 :b "a string"} opts))))
+             (let [store' (<! (filestore/connect-fs-store store-path :opts opts))]
+               (is (= [{:a 42 :b "a string"} {:a 42 :b "a string" :c 'sym}]
+                      (<! (p/-update-in store' [:my-db] identity (fn [m] (assoc m :c 'sym)) opts))))
+               (done))))))
 
 (deftest PEDNKeyValueStore-async-test
   (async done
-   (go
-    (let [opts {:sync? false}
-          store (<! (filestore/connect-fs-store store-path :opts opts))]
-      (is (false? (<! (p/-exists? store :bar opts))))
-      (is (= :not-found (<! (p/-get-in store [:bar] :not-found opts))))
-      (is (= [nil 42] (<! (p/-assoc-in store [:bar] identity 42 opts))))
-      (is (true? (<! (p/-exists? store :bar opts))))
-      (is (= 42 (<! (p/-get-in store [:bar] :not-found opts))))
-      (is (= [42 43] (<! (p/-update-in store [:bar] identity inc opts))))
-      (is (= nil (<! (p/-get-meta store :bar opts))))
-      (is (= [43 44] (<! (p/-update-in store [:bar] #(assoc % :foo :baz) inc opts))))
-      (is (= {:foo :baz} (<! (p/-get-meta store :bar opts))))
-      (is (= [44 45] (<! (p/-update-in store [:bar] (fn [_] nil) inc opts))))
-      (is (= nil (<! (p/-get-meta store :bar opts))))
-      (is (= 45 (<! (p/-get-in store [:bar] :not-found opts))))
-      (is (= [nil {::foo 99}] (<! (p/-assoc-in store [:bar] identity {::foo 99} opts)))) ;; assoc-in overwrites
-      (is (= [{::foo 99} {::foo 100}] (<! (p/-update-in store [:bar ::foo] identity inc opts))))
-      (is (= [{::foo 100} {}] (<! (p/-update-in store [:bar] identity #(dissoc % ::foo) opts))))
-      (is (true? (<! (p/-dissoc store :bar opts))))
-      (is (false? (<! (p/-exists? store :bar opts))))
-      (done)))))
+         (go
+           (let [opts {:sync? false}
+                 store (<! (filestore/connect-fs-store store-path :opts opts))]
+             (is (false? (<! (p/-exists? store :bar opts))))
+             (is (= :not-found (<! (p/-get-in store [:bar] :not-found opts))))
+             (is (= [nil 42] (<! (p/-assoc-in store [:bar] identity 42 opts))))
+             (is (true? (<! (p/-exists? store :bar opts))))
+             (is (= 42 (<! (p/-get-in store [:bar] :not-found opts))))
+             (is (= [42 43] (<! (p/-update-in store [:bar] identity inc opts))))
+             (is (= nil (<! (p/-get-meta store :bar opts))))
+             (is (= [43 44] (<! (p/-update-in store [:bar] #(assoc % :foo :baz) inc opts))))
+             (is (= {:foo :baz} (<! (p/-get-meta store :bar opts))))
+             (is (= [44 45] (<! (p/-update-in store [:bar] (fn [_] nil) inc opts))))
+             (is (= nil (<! (p/-get-meta store :bar opts))))
+             (is (= 45 (<! (p/-get-in store [:bar] :not-found opts))))
+             (is (= [nil {::foo 99}] (<! (p/-assoc-in store [:bar] identity {::foo 99} opts)))) ;; assoc-in overwrites
+             (is (= [{::foo 99} {::foo 100}] (<! (p/-update-in store [:bar ::foo] identity inc opts))))
+             (is (= [{::foo 100} {}] (<! (p/-update-in store [:bar] identity #(dissoc % ::foo) opts))))
+             (is (true? (<! (p/-dissoc store :bar opts))))
+             (is (false? (<! (p/-exists? store :bar opts))))
+             (done)))))
 
 ; TODO what are bget semantics (stream & chan behaviors) when called on a deleted store
 (deftest PBinaryKeyValueStore-async-test
   (async done
-   (let [opts {:sync? false}
-         data [:this/is 'some/fressian "data 😀😀😀" (js/Date.) #{true false nil}]
-         bytes (fress/write data)
-         test-data (chan)
-         locked-cb (fn [{readable :input-stream size :size}]
-                     (put! test-data (fress/read (.read readable)))
-                     (.destroy readable))]
-     (go
-      (let [store (<! (filestore/connect-fs-store store-path :opts opts))]
-        (is (true? (<! (p/-bassoc store :key identity bytes opts))))
-        (<! (p/-bget store :key locked-cb opts))
-        (is (= data (<! test-data)))
-        (done))))))
+         (let [opts {:sync? false}
+               data [:this/is 'some/fressian "data 😀😀😀" (js/Date.) #{true false nil}]
+               bytes (fress/write data)
+               test-data (chan)
+               locked-cb (fn [{readable :input-stream size :size}]
+                           (put! test-data (fress/read (.read readable)))
+                           (.destroy readable))]
+           (go
+             (let [store (<! (filestore/connect-fs-store store-path :opts opts))]
+               (is (true? (<! (p/-bassoc store :key identity bytes opts))))
+               (<! (p/-bget store :key locked-cb opts))
+               (is (= data (<! test-data)))
+               (done))))))
 
 (deftest PKeyIterable-sync-test
   (let [opts {:sync? true}
@@ -107,16 +107,16 @@
 
 (deftest PKeyIterable-async-test
   (async done
-   (go
-    (let [opts {:sync? false}
-          store (<! (filestore/connect-fs-store store-path :opts opts))]
-      (is (= #{} (<! (k/keys store opts))))
-      (is (= [nil 42] (<! (k/assoc-in store [:value-blob] 42 opts))))
-      (is (true? (<! (k/bassoc store :bin-blob #js[255 255 255] opts))))
-      (is (= #{{:key :bin-blob :type :binary} {:key :value-blob :type :edn}}
-             (set (map #(dissoc % :last-write) (<! (k/keys store opts))))))
-      (is (every? inst? (map :last-write (<! (k/keys store opts)))))
-      (done)))))
+         (go
+           (let [opts {:sync? false}
+                 store (<! (filestore/connect-fs-store store-path :opts opts))]
+             (is (= #{} (<! (k/keys store opts))))
+             (is (= [nil 42] (<! (k/assoc-in store [:value-blob] 42 opts))))
+             (is (true? (<! (k/bassoc store :bin-blob #js[255 255 255] opts))))
+             (is (= #{{:key :bin-blob :type :binary} {:key :value-blob :type :edn}}
+                    (set (map #(dissoc % :last-write) (<! (k/keys store opts))))))
+             (is (every? inst? (map :last-write (<! (k/keys store opts)))))
+             (done)))))
 
 (deftest append-store-sync-test
   (let [opts {:sync? true}
@@ -132,41 +132,40 @@
 
 (deftest append-store-async-test
   (async done
-    (go
-     (let [opts {:sync? false}
-           store (<! (filestore/connect-fs-store store-path :opts opts))]
-       (is (uuid? (second (<! (k/append store :foolog {:bar 42} opts)))))
-       (is (uuid? (second (<! (k/append store :foolog {:bar 43} opts)))))
-       (is (= '({:bar 42} {:bar 43}) (<! (k/log store :foolog opts))))
-       (is (=  [{:bar 42} {:bar 43}] (<! (k/reduce-log store :foolog conj [] opts))))
-       (let [{:keys [key type last-write] :as metadata} (<! (k/get-meta store :foolog :not-found opts))]
-         (is (= key :foolog))
-         (is (= type :append-log))
-         (is (inst? last-write)))
-       (done)))))
-
+         (go
+           (let [opts {:sync? false}
+                 store (<! (filestore/connect-fs-store store-path :opts opts))]
+             (is (uuid? (second (<! (k/append store :foolog {:bar 42} opts)))))
+             (is (uuid? (second (<! (k/append store :foolog {:bar 43} opts)))))
+             (is (= '({:bar 42} {:bar 43}) (<! (k/log store :foolog opts))))
+             (is (=  [{:bar 42} {:bar 43}] (<! (k/reduce-log store :foolog conj [] opts))))
+             (let [{:keys [key type last-write] :as metadata} (<! (k/get-meta store :foolog :not-found opts))]
+               (is (= key :foolog))
+               (is (= type :append-log))
+               (is (inst? last-write)))
+             (done)))))
 
 (def path (js/require "path"))
 
 ;; lock used for reading/update blobs, list-keys
 (deftest lock-acquisition-test
   (async done
-    (go
-     (let [opts {:sync? false}
-           store (<! (filestore/connect-fs-store store-path :opts opts))
-           key :key
-           key-file-path (path.join store-path (d/key->store-key key))]
-       (testing "no lock, writes ok"
-         (is (= [nil 42] (<! (k/assoc-in store [key] 42 opts))))
-         (is (= 42 (<! (k/get-in store [key] :not-found opts)))))
-       (let [fc (<! (filestore/open-async-file-channel key-file-path))
-             lock (<! (.lock fc))]
-         (testing "held lock blocks reads + writes"
-           (is (instance? js/Error (<! (k/update-in store [key] inc opts)))))
-         (testing "lock is released within the retry period, op succeeds"
-           (let [op-chan (k/update-in store [key] inc opts)]
-             (<! (timeout 50))
-             (<! (.release lock))
-             (is (= [42 43] (<! op-chan)))))
-         (is (nil? (<! (.close fc)))))
-       (done)))))
+         (go
+           (let [opts {:sync? false}
+                 store (<! (filestore/connect-fs-store store-path :opts opts))
+                 key :key
+                 key-file-path (path.join store-path (d/key->store-key key))]
+             (testing "no lock, writes ok"
+               (is (= [nil 42] (<! (k/assoc-in store [key] 42 opts))))
+               (is (= 42 (<! (k/get-in store [key] :not-found opts)))))
+             (let [fc (<! (filestore/open-async-file-channel key-file-path))
+                   lock (<! (.lock fc))]
+               (testing "held lock blocks reads + writes"
+                 (is (instance? js/Error (<! (k/update-in store [key] inc opts)))))
+               (testing "lock is released within the retry period, op succeeds"
+                 (let [op-chan (k/update-in store [key] inc opts)]
+                   (<! (timeout 50))
+                   (<! (.release lock))
+                   (is (= [42 43] (<! op-chan)))))
+               (is (nil? (<! (.close fc)))))
+             (done)))))

--- a/test/konserve/node_runner.cljs
+++ b/test/konserve/node_runner.cljs
@@ -10,11 +10,10 @@
   ([] (run-tests nil))
   ([opts]
    (cljs.test/run-tests (merge (cljs.test/empty-env) opts)
-      'konserve.cache-test
-      'konserve.gc-test
-      'konserve.node-filestore-test
-      'konserve.serializers-test)))
-
+                        'konserve.cache-test
+                        'konserve.gc-test
+                        'konserve.node-filestore-test
+                        'konserve.serializers-test)))
 
 ; clj -M:test -m cljs.main  -t node  -o out/runner.js -c konserve.node-runner
 (defn -main [& args]

--- a/test/konserve/serializers_test.cljs
+++ b/test/konserve/serializers_test.cljs
@@ -28,12 +28,12 @@
 
 (deftest serializers-test
   (async done
-   (go
-    (let [store-path "/tmp/konserve-fs-serializer-node-test"
-          _(filestore/delete-store store-path)
-          ser (fressian-serializer custom-read-handler custom-write-handler)
-          store (<! (filestore/connect-fs-store store-path :serializers {:FressianSerializer ser}))
-          mt (MyType. :a/b "c")]
-      (is (= [nil mt] (<! (k/assoc-in store [:my-type] mt))))
-      (is (= mt (<! (k/get-in store [:my-type]))))
-      (done)))))
+         (go
+           (let [store-path "/tmp/konserve-fs-serializer-node-test"
+                 _ (filestore/delete-store store-path)
+                 ser (fressian-serializer custom-read-handler custom-write-handler)
+                 store (<! (filestore/connect-fs-store store-path :serializers {:FressianSerializer ser}))
+                 mt (MyType. :a/b "c")]
+             (is (= [nil mt] (<! (k/assoc-in store [:my-type] mt))))
+             (is (= mt (<! (k/get-in store [:my-type]))))
+             (done)))))


### PR DESCRIPTION
Replace `alength` call with `count` to remove reflection error with native-image and retain portability. 