### PR TITLE
restore indexeddb using js/Blob

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        org.clojure/clojurescript {:mvn/version "1.11.51"}
+        org.clojure/clojurescript {:mvn/version "1.11.60"}
         org.clojure/data.fressian {:mvn/version "1.0.0"} ;; for filestore
         fress/fress {:mvn/version "0.4.0"}
         io.replikativ/incognito {:mvn/version "0.3.66"}
@@ -27,6 +27,10 @@
                   :main-opts ["-e" "(set! *warn-on-reflection* true)"]}
            :node-test {:extra-paths ["test"]
                        :main-opts ["-m" "cljs.main" "-t" "node" "-m" "konserve.node-runner"]}
+           :idb-c {:extra-paths ["test"]
+                   :main-opts ["-m" "cljs.main" "-c" "konserve.indexeddb-test"]}
+           :idb-r {:extra-paths ["test"]
+                   :main-opts ["-m" "cljs.main" "-r"]}
            :build  {:deps       {io.github.seancorfield/build-clj {:git/tag "v0.8.2"
                                                                    :git/sha "0ffdb4c"}
                                  borkdude/gh-release-artifact     {:git/url "https://github.com/borkdude/gh-release-artifact"

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -45,6 +45,8 @@
     :else (throw (ex-info (str "Invalid konserve store key: " store-key)
                           {:key store-key}))))
 
+#?(:cljs (extend-type js/Uint8Array ICounted (-count [this] (alength this))))
+
 (defn update-blob
   "This function writes first the meta-size, then the meta-data and then the
   actual updated data into the underlying backing store."

--- a/src/konserve/indexeddb.cljs
+++ b/src/konserve/indexeddb.cljs
@@ -3,7 +3,7 @@
             [konserve.compressor]
             [konserve.encryptor]
             [konserve.impl.defaults :as defaults]
-            [konserve.impl.storage-layout :as storage-layout :refer [PBackingStore]]
+            [konserve.impl.storage-layout :as storage-layout]
             [konserve.serializers]
             [konserve.utils :refer [with-promise]]))
 
@@ -39,7 +39,7 @@
   (with-promise out
     (let [p (js/window.indexedDB.databases)]
       (.then p #(put! out %))
-      (.catch p #(put! out (ex-info (str "error listing databases")
+      (.catch p #(put! out (ex-info "error listing databases"
                                     {:cause %
                                      :caller 'konserve.indexeddb/list-dbs}))))))
 
@@ -268,7 +268,7 @@
 
 (defn connect-idb-store
   "Connect to a IndexedDB backed KV store with the given db name.
-   Optional serializer, read-handlers, write-handlers, buffer-size and config.
+   Optional serializer, read-handlers, write-handlers.
 
    This implementation stores all values as js/Blobs in an IndexedDB
    object store instance. The object store itself is nameless, and there
@@ -296,16 +296,15 @@
    value offset in the same way that the filestore implementations are. Consumers
    must discard the amount of bytes found in the :offset key of the locked-cb
    arg map. See: https://developer.mozilla.org/en-US/docs/Web/API/Blob/stream"
-  [db-name & {:keys [config] :as params}]
+  [db-name & {:as params}]
   (let [store-config (merge {:default-serializer :FressianSerializer
                              :compressor         konserve.compressor/null-compressor
                              :encryptor          konserve.encryptor/null-encryptor
                              :read-handlers      (atom {})
                              :write-handlers     (atom {})
-                             :config             (merge {:sync-blob? true
-                                                         :in-place? true
-                                                         :lock-blob? true}
-                                                        config)}
+                             :config             {:sync-blob? true
+                                                  :in-place? true
+                                                  :lock-blob? true}}
                             (dissoc params :config))
         backing            (IndexedDBackingStore. db-name nil)]
     (defaults/connect-default-store backing store-config)))

--- a/src/konserve/indexeddb.cljs
+++ b/src/konserve/indexeddb.cljs
@@ -10,65 +10,73 @@
 (defn- connect-to-idb [db-name]
   (let [req (js/window.indexedDB.open db-name 1)]
     (with-promise out
-      (set! (.-onblocked req) (fn [event] (put! out [event])))
-      (set! (.-onerror req) (fn [event] (put! out [event])))
+      (set! (.-onblocked req)
+            #(put! out (ex-info "connecting to indexed-db blocked"
+                                {:cause %
+                                 :caller 'konserve.indexeddb/connect-to-idb})))
+      (set! (.-onerror req)
+            #(put! out (ex-info "error connecting to indexed-db"
+                                {:cause %
+                                 :caller 'konserve.indexeddb/connect-to-idb})))
       (set! (.-onsuccess req)
-        (fn [event] (put! out [nil (-> event .-target .-result)])))
+            #(put! out (-> % .-target .-result)))
       (set! (.-onupgradeneeded req)
-        (fn [ev]
-          (if (== 1 (.-oldVersion ev))
-            (throw (js/Error. "upgrade not supported at this time"))
-            (let [db (-> ev .-target .-result)
-                  store (.createObjectStore db "")]
-              (set! (-> ev .-target .-transaction) #(put! out [nil db])))))))))
-
-(defn- IDBRequest->ch [req]
-  (with-promise out
-    (set! (.-onerror req) (fn [event] (put! out [event])))
-    (set! (.-onsuccess req) (fn [event] (put! out [nil event])))))
+            (fn [ev]
+              (if (== 1 (.-oldVersion ev))
+                (throw (js/Error. "upgrade not supported at this time"))
+                (-> ev .-target .-result (.createObjectStore ""))))))))
 
 (defn delete-idb [db-name]
-  (IDBRequest->ch (js/window.indexedDB.deleteDatabase db-name)))
+  (let [req (js/window.indexedDB.deleteDatabase db-name)]
+    (with-promise out
+      (set! (.-onsuccess req) #(close! out))
+      (set! (.-onerror req)
+            #(put! out (ex-info (str "error deleting indexed-db with name '" db-name "'")
+                                {:cause %
+                                 :caller 'konserve.indexeddb/delete-idb}))))))
 
 (defn list-dbs []
   (with-promise out
     (let [p (js/window.indexedDB.databases)]
-      (.then p #(put! out [nil %]))
-      (.catch p #(put! out [%])))))
+      (.then p #(put! out %))
+      (.catch p #(put! out (ex-info (str "error listing databases")
+                                    {:cause %
+                                     :caller 'konserve.indexeddb/list-dbs}))))))
 
 (defn db-exists? [db-name]
   (with-promise out
     (take! (list-dbs)
-      (fn [[err ok :as res]]
-        (if err
-          (put! out false)
-          (put! out (reduce (fn [acc o]
-                          (if (= db-name (goog.object.get o "name"))
-                            (reduced true)
-                            false))
-                        false
-                        ok)))))))
-
-(defn- blob->arraybuf [blob]
-  (with-promise out
-    (if (nil? blob)
-      (put! out [nil])
-      (let [p (.arrayBuffer blob)]
-        (.then p #(put! out [nil %]))
-        (.catch p #(put! out [%]))))))
+           (fn [res]
+             (if (instance? js/Error res)
+               (put! out false)
+               (put! out (reduce (fn [acc o]
+                                   (if (= db-name (goog.object.get o "name"))
+                                     (reduced true)
+                                     false))
+                                 false
+                                 res)))))))
 
 (defn read-blob [db key]
-  (with-promise out
-    (take! (IDBRequest->ch (.get (.objectStore (.transaction db #js[""]) "") key))
-      (fn [[err ok :as res]]
-        (if err
-          (put! out res)
-          (let [blob (-> ok .-target .-result)]
-            (put! out [nil blob])))))))
+  (let [req (.get (.objectStore (.transaction db #js[""]) "") key)]
+    (with-promise out
+      (set! (.-onsuccess req)
+            (fn [ev]
+              (if-some [v (-> ev .-target .-result)]
+                (put! out v)
+                (close! out))))
+      (set! (.-onerror req)
+            #(put! out (ex-info (str "error reading blob at key '" key "'")
+                                {:cause %
+                                 :caller 'konserve.indexeddb/read-blob}))))))
 
 (defn write-blob [db key blob]
-  (let [ostore (.objectStore (.transaction db #js[""] "readwrite") "")]
-    (IDBRequest->ch (.put ostore blob key))))
+  (let [req (.put (.objectStore (.transaction db #js[""] "readwrite") "") blob key)]
+    (with-promise out
+      (set! (.-onsuccess req) #(close! out))
+      (set! (.-onerror req)
+            #(put! out (ex-info (str "error writing blob at key '" key "'")
+                                {:cause %
+                                 :caller 'konserve.indexeddb/write-blob}))))))
 
 ;;==============================================================================
 
@@ -80,12 +88,12 @@
         blob (js/Blob. bin #js{:type "application/octet-stream"})]
     (with-promise out
       (take! (write-blob db key blob)
-        (fn [[err]]
-          (if err
-            (put! out (ex-info "error writing blob to objectStore"
-                               {:cause err
-                                :caller (symbol ::flush-blob)}))
-            (close! out)))))))
+             (fn [err]
+               (if err
+                 (put! out (ex-info (str "error writing blob to objectStore at key '" key "'")
+                                    {:cause err
+                                     :caller 'konserve.indexeddb/flush-blob}))
+                 (close! out)))))))
 
 (defn- get-buf
   "this ensures that blobs are cached on BackingBlobs as ArrayBuffers and read
@@ -93,51 +101,49 @@
   [^BackingBlob {:keys [db key buf] :as bb}]
   (with-promise out
     (if (some? buf)
-      (put! out [nil buf])
+      (put! out buf)
       (take! (read-blob db key)
-        (fn [[err blob :as res]]
-          (if err
-            (put! out res)
-            (take! (blob->arraybuf blob)
-              (fn [[err ok :as res]]
-                (if err
-                  (put! out res)
-                  (do
-                    (set! (.-buf bb) ok)
-                    (put! out res)))))))))))
+             (fn [res]
+               (if (instance? js/Error res)
+                 (put! out res)
+                 (let [p (.arrayBuffer res)]
+                   (.catch p #(put! out %))
+                   (.then p #(do
+                               (set! (.-buf bb) %)
+                               (put! out %))))))))))
 
 (defn- read-header
   [^BackingBlob {:keys [db key buf] :as this}]
   (with-promise out
     (take! (get-buf this)
-      (fn [[err ok :as res]]
-        (if err
-          (put! out (ex-info "error reading blob from objectStore"
-                             {:cause err
-                              :caller (symbol ::read-header)}))
-          (let [view (js/Uint8Array. ok)
-                header (.slice view 0 storage-layout/header-size)]
-            (put! out header)))))))
+           (fn [res]
+             (if (instance? js/Error res)
+               (put! out (ex-info "error reading blob from objectStore"
+                                  {:cause res
+                                   :caller 'konserve.indexeddb/read-header}))
+               (let [view (js/Uint8Array. res)
+                     header (.slice view 0 storage-layout/header-size)]
+                 (put! out header)))))))
 
 (defn- read-binary
   [^BackingBlob {:keys [db key buf] :as this} meta-size locked-cb]
   (with-promise out
     (take! (read-blob db key)
-      (fn [[err blob :as res]]
-        (if err
-          (put! out (ex-info "error reading blob from objectStore"
-                             {:cause err
-                              :caller (symbol ::read-binary)}))
-          (do
-            (locked-cb {:input-stream (.stream blob)
-                        :size (.-size blob)
-                        :offset (+ meta-size storage-layout/header-size)})
-            (close! out)))))))
+           (fn [res]
+             (if (instance? js/Error res)
+               (put! out (ex-info "error reading blob from objectStore"
+                                  {:cause res
+                                   :caller 'konserve.indexeddb/read-binary}))
+               (do
+                 (locked-cb {:input-stream (.stream res)
+                             :size (.-size res)
+                             :offset (+ meta-size storage-layout/header-size)})
+                 (close! out)))))))
 
 (defrecord ^{:doc "buf is cached data that has been read from the db,
                    & {header metadata value} are bin data to be written.
                    If a write begins, buf is discarded."}
-  BackingBlob [db key buf header metadata value]
+ BackingBlob [db key buf header metadata value]
   storage-layout/PBackingBlob
   (-get-lock [this _env]
     (let [lock (reify
@@ -183,89 +189,78 @@
 (defrecord IndexedDBackingStore [db-name db]
   Object
   ;; needed to unref conn before can cycle database construction
-  (close [_] (go (when (some? db)(.close db))))
+  (close [_] (go (when (some? db) (.close db))))
   storage-layout/PBackingStore
   (-create-blob [this store-key env]
     (assert (not (:sync? env)))
     (go (open-backing-blob db store-key)))
   (-delete-blob [this key env]
     (assert (not (:sync? env)))
-    (with-promise out
-      (let [tx (.transaction db #js[""] "readwrite")
-            ostore (.objectStore tx "")]
-        (take! (IDBRequest->ch (.delete ostore key))
-          (fn [[err]]
-            (if err
-              (put! out (ex-info "error deleting blob"
-                                 {:cause err
-                                  :caller (symbol ::-delete-blob)}))
-              (close! out)))))))
+    (let [req (.delete (.objectStore (.transaction db #js[""] "readwrite") "") key)]
+      (with-promise out
+        (set! (.-onsuccess req) #(close! out))
+        (set! (.-onerror req)
+              #(put! out (ex-info (str "error deleting blob at key '" key "'")
+                                  {:cause %
+                                   :caller 'konserve.indexeddb/-delete-blob}))))))
   (-migratable [this key store-key env] (go false))
-  (-blob-exists? [this store-key env]
+  (-blob-exists? [this key env]
     (assert (not (:sync? env)))
-    (with-promise out
-      (let [tx (.transaction db #js[""])
-            ostore (.objectStore tx "")]
-        (take! (IDBRequest->ch (.getKey ostore store-key))
-          (fn [[err ok]]
-            (if err
-              (put! out (ex-info "error getting key from objectStore"
-                                 {:cause err
-                                  :caller (symbol ::-blob-exists?)}))
-              (let [res (-> ok .-target .-result boolean)]
-                (put! out res))))))))
+    (let [req (.getKey (.objectStore (.transaction db #js[""]) "") key)]
+      (with-promise out
+        (set! (.-onsuccess req) #(put! out (-> % .-target .-result boolean)))
+        (set! (.-onerror req)
+              #(put! out (ex-info (str "error getting key in objectStore '" key "'")
+                                  {:cause %
+                                   :caller 'konserve.indexeddb/-blob-exists?}))))))
   (-keys [this env]
     (assert (not (:sync? env)))
-    (with-promise out
-      (let [tx (.transaction db #js[""])
-            ostore (.objectStore tx "")]
-        (take! (IDBRequest->ch (.getAllKeys ostore))
-          (fn [[err ok]]
-            (if err
-              (put! out (ex-info "error listing keys in objectStore"
-                                 {:cause err
-                                  :caller (symbol ::-keys)}))
-              (let [ks (-> ok .-target .-result)]
-                (put! out ks))))))))
+    (let [req (.getAllKeys (.objectStore (.transaction db #js[""]) ""))]
+      (with-promise out
+        (set! (.-onsuccess req) #(put! out (-> % .-target .-result)))
+        (set! (.-onerror req)
+              #(put! out (ex-info "error listing keys in objectStore"
+                                  {:cause %
+                                   :caller 'konserve.indexeddb/-keys}))))))
   (-copy [this from to env]
     (assert (not (:sync? env)))
     (with-promise out
       (take! (read-blob db from)
-        (fn [[err blob]]
-          (if err
-            (put! out (ex-info "error reading blob from objectStore"
-                               {:cause err
-                                :caller (symbol ::-copy)}))
-            (take! (write-blob db to blob)
-             (fn [[err]]
-               (if err
-                 (put! out (ex-info "error writing blob to objectStore"
-                                    {:cause err
-                                     :caller (symbol ::-copy)}))
-                 (close! out)))))))))
+             (fn [res]
+               (if (instance? js/Error res)
+                 (put! out (ex-info "error reading blob from objectStore"
+                                    {:cause res
+                                     :caller 'konserve.indexeddb/-copy}))
+                 (take! (write-blob db to res)
+                        (fn [?err]
+                          (if ?err
+                            (put! out (ex-info "error writing blob to objectStore"
+                                               {:cause ?err
+                                                :caller 'konserve.indexeddb/-copy}))
+                            (close! out)))))))))
   (-create-store [this env]
     (assert (not (:sync? env)))
     (with-promise out
       (take! (connect-to-idb db-name)
-        (fn [[err db]]
-          (if err
-            (put! out (ex-info "error connecting to database"
-                               {:cause err
-                                :caller (symbol ::-create-store)}))
-            (do
-              (set! (.-db this) db)
-              (put! out this)))))))
+             (fn [res]
+               (if (instance? js/Error res)
+                 (put! out (ex-info "error connecting to database"
+                                    {:cause res
+                                     :caller 'konserve.indexeddb/-create-store}))
+                 (do
+                   (set! (.-db this) res)
+                   (put! out this)))))))
   (-delete-store [this env]
     (assert (not (:sync? env)))
     (with-promise out
       (.close db)
       (take! (delete-idb db-name)
-        (fn [[err]]
-          (if err
-            (put! out (ex-info "error deleting database"
-                               {:cause err
-                                :caller (symbol ::-delete-store)}))
-            (close! out))))))
+             (fn [?err]
+               (if ?err
+                 (put! out (ex-info "error deleting store"
+                                    {:cause ?err
+                                     :caller 'konserve.indexeddb/-delete-store}))
+                 (close! out))))))
   (-store-exists? [this env]
     (assert (not (:sync? env)))
     (db-exists? db-name))

--- a/test/konserve/indexeddb_test.cljs
+++ b/test/konserve/indexeddb_test.cljs
@@ -1,0 +1,127 @@
+(ns konserve.indexeddb-test
+  (:require [cljs.core.async :refer [go take! <! >! put! take! close!]]
+            [cljs.test :refer-macros [deftest is testing async]]
+            [fress.api :as fress]
+            [konserve.core :as k]
+            [konserve.indexeddb :as idb]
+            [konserve.protocols :as p])
+  (:import [goog.userAgent]))
+
+(when-not ^boolean goog.userAgent.GECKO
+  (deftest lifecycle-test
+    "test creation & deletion of databases"
+    (async done
+     (go
+      (let [db-name "lifecycle-db"]
+        (when (is (false? (<! (idb/db-exists? db-name))))
+          (let [[err ok] (<! (idb/connect-to-idb db-name))]
+            (is (nil? err))
+            (is (true? (<! (idb/db-exists? db-name))))
+            (.close ok)
+            (is (nil? (first (<! (idb/delete-idb db-name)))))
+            (is (false? (<! (idb/db-exists? db-name))))))
+        (done))))))
+
+(deftest blob-io-test
+  "test simulating fs with js/Blobs"
+  (let [db-name "blob-io-test"
+        key "test-blob"
+        data [:this/is 'some/fressian "data 😀😀😀" (js/Date.) #{true false nil}]
+        bytes (fress/write data)]
+    (async done
+     (go
+      (<! (idb/delete-idb db-name))
+      (let [[err db] (<! (idb/connect-to-idb db-name))]
+        (when (is (nil? err))
+          (let [bb (idb/open-backing-blob db key)]
+            (is (nil? (:buf bb)))
+            (is [nil] (<! (idb/get-buf bb)))
+            (is (nil? (:buf bb)))
+            (set! (.-buf bb) bytes)
+            (is (nil? (first (<! (.force bb)))))
+            (let [[err ok] (<! (idb/get-buf bb))]
+              (is (nil? err))
+              (is (some? (:buf bb)))
+              (is (identical? (:buf bb) ok))
+              (is (= data (fress/read ok)))))
+          (.close db)))
+      (testing "we've closed conn, but kv should still exist"
+        (let [[err db] (<! (idb/connect-to-idb db-name))]
+          (when (is (nil? err))
+            (let [bb (idb/open-backing-blob db key)
+                  [err ok] (<! (idb/get-buf bb))]
+              (is (nil? err))
+              (is (= data (fress/read ok)))
+              (testing "a second identical blob peacefully co-exists"
+                (let [key' "test-blob'"
+                      bb' (idb/open-backing-blob db key')]
+                  (set! (.-buf bb') bytes)
+                  (is (nil? (first (<! (.force bb')))))
+                  (let [[err ok] (<! (idb/get-buf bb))
+                        [err' ok'] (<! (idb/get-buf bb'))]
+                    (is (nil? err))
+                    (is (nil? err'))
+                    (is (= data (fress/read ok) (fress/read ok')))))))
+            (.close db))))
+      (done)))))
+
+(deftest PEDNKeyValueStore-async-test
+  (async done
+   (go
+    (let [db-name "pednkv-test"
+          _(<! (idb/delete-idb db-name))
+          opts {:sync? false}
+          {backing :backing :as store} (<! (idb/connect-idb-store db-name :opts opts))]
+      (is (false? (<! (p/-exists? store :bar opts))))
+      (is (= :not-found (<! (p/-get-in store [:bar] :not-found opts))))
+      (is (= [nil 42] (<! (p/-assoc-in store [:bar] identity 42 opts))))
+      (is (true? (<! (p/-exists? store :bar opts))))
+      (is (= 42 (<! (p/-get-in store [:bar] :not-found opts))))
+      (is (= [42 43] (<! (p/-update-in store [:bar] identity inc opts))))
+      (is (= nil (<! (p/-get-meta store :bar opts))))
+      (is (= [43 44] (<! (p/-update-in store [:bar] #(assoc % :foo :baz) inc opts))))
+      (is (= {:foo :baz} (<! (p/-get-meta store :bar opts))))
+      (is (= [44 45] (<! (p/-update-in store [:bar] (fn [_] nil) inc opts))))
+      (is (= nil (<! (p/-get-meta store :bar opts))))
+      (is (= 45 (<! (p/-get-in store [:bar] :not-found opts))))
+      (is (= [nil {::foo 99}] (<! (p/-assoc-in store [:bar] identity {::foo 99} opts)))) ;; assoc-in overwrites
+      (is (= [{::foo 99} {::foo 100}] (<! (p/-update-in store [:bar ::foo] identity inc opts))))
+      (is (= [{::foo 100} {}] (<! (p/-update-in store [:bar] identity #(dissoc % ::foo) opts))))
+      (is (true? (<! (p/-dissoc store :bar opts))))
+      (is (false? (<! (p/-exists? store :bar opts))))
+      (.close backing)
+      (done)))))
+
+(deftest PKeyIterable-async-test
+  (async done
+   (go
+    (let [db-name "pkeyiterable-test"
+          _(<! (idb/delete-idb db-name))
+          opts {:sync? false}
+          {backing :backing :as store} (<! (idb/connect-idb-store db-name :opts opts))]
+      (is (= #{} (<! (k/keys store opts))))
+      (is (= [nil 42] (<! (k/assoc-in store [:value-blob] 42 opts))))
+      (is (true? (<! (k/bassoc store :bin-blob #js[255 255 255] opts))))
+      (is (= #{{:key :bin-blob :type :binary} {:key :value-blob :type :edn}}
+             (set (map #(dissoc % :last-write) (<! (k/keys store opts))))))
+      (is (every? inst? (map :last-write (<! (k/keys store opts)))))
+      (.close backing)
+      (done)))))
+
+(deftest append-store-async-test
+  (async done
+    (go
+     (let [db-name "append-test"
+           _(<! (idb/delete-idb db-name))
+           opts {:sync? false}
+           {backing :backing :as store} (<! (idb/connect-idb-store db-name :opts opts))]
+       (is (uuid? (second (<! (k/append store :foolog {:bar 42} opts)))))
+       (is (uuid? (second (<! (k/append store :foolog {:bar 43} opts)))))
+       (is (= '({:bar 42} {:bar 43}) (<! (k/log store :foolog opts))))
+       (is (=  [{:bar 42} {:bar 43}] (<! (k/reduce-log store :foolog conj [] opts))))
+       (let [{:keys [key type last-write] :as metadata} (<! (k/get-meta store :foolog :not-found opts))]
+         (is (= key :foolog))
+         (is (= type :append-log))
+         (is (inst? last-write)))
+       (.close backing)
+       (done)))))

--- a/test/konserve/indexeddb_test.cljs
+++ b/test/konserve/indexeddb_test.cljs
@@ -9,119 +9,81 @@
 
 (when-not ^boolean goog.userAgent.GECKO
   (deftest lifecycle-test
-    "test creation & deletion of databases"
     (async done
-     (go
-      (let [db-name "lifecycle-db"]
-        (when (is (false? (<! (idb/db-exists? db-name))))
-          (let [[err ok] (<! (idb/connect-to-idb db-name))]
-            (is (nil? err))
-            (is (true? (<! (idb/db-exists? db-name))))
-            (.close ok)
-            (is (nil? (first (<! (idb/delete-idb db-name)))))
-            (is (false? (<! (idb/db-exists? db-name))))))
-        (done))))))
-
-(deftest blob-io-test
-  "test simulating fs with js/Blobs"
-  (let [db-name "blob-io-test"
-        key "test-blob"
-        data [:this/is 'some/fressian "data 😀😀😀" (js/Date.) #{true false nil}]
-        bytes (fress/write data)]
-    (async done
-     (go
-      (<! (idb/delete-idb db-name))
-      (let [[err db] (<! (idb/connect-to-idb db-name))]
-        (when (is (nil? err))
-          (let [bb (idb/open-backing-blob db key)]
-            (is (nil? (:buf bb)))
-            (is [nil] (<! (idb/get-buf bb)))
-            (is (nil? (:buf bb)))
-            (set! (.-buf bb) bytes)
-            (is (nil? (first (<! (.force bb)))))
-            (let [[err ok] (<! (idb/get-buf bb))]
-              (is (nil? err))
-              (is (some? (:buf bb)))
-              (is (identical? (:buf bb) ok))
-              (is (= data (fress/read ok)))))
-          (.close db)))
-      (testing "we've closed conn, but kv should still exist"
-        (let [[err db] (<! (idb/connect-to-idb db-name))]
-          (when (is (nil? err))
-            (let [bb (idb/open-backing-blob db key)
-                  [err ok] (<! (idb/get-buf bb))]
-              (is (nil? err))
-              (is (= data (fress/read ok)))
-              (testing "a second identical blob peacefully co-exists"
-                (let [key' "test-blob'"
-                      bb' (idb/open-backing-blob db key')]
-                  (set! (.-buf bb') bytes)
-                  (is (nil? (first (<! (.force bb')))))
-                  (let [[err ok] (<! (idb/get-buf bb))
-                        [err' ok'] (<! (idb/get-buf bb'))]
-                    (is (nil? err))
-                    (is (nil? err'))
-                    (is (= data (fress/read ok) (fress/read ok')))))))
-            (.close db))))
-      (done)))))
+           (go
+             (let [db-name "lifecycle-db"]
+               (<! (idb/delete-idb db-name))
+               (testing "test creation & deletion of databases"
+                 (when (is (false? (<! (idb/db-exists? db-name))))
+                   (let [res (<! (idb/connect-to-idb db-name))]
+                     (when (is (instance? js/IDBDatabase res))
+                       (is (true? (<! (idb/db-exists? db-name))))
+                       (.close res)
+                       (is (nil? (first (<! (idb/delete-idb db-name)))))
+                       (is (false? (<! (idb/db-exists? db-name))))))))
+               (<! (idb/delete-idb db-name))
+               (done))))))
 
 (deftest PEDNKeyValueStore-async-test
   (async done
-   (go
-    (let [db-name "pednkv-test"
-          _(<! (idb/delete-idb db-name))
-          opts {:sync? false}
-          {backing :backing :as store} (<! (idb/connect-idb-store db-name :opts opts))]
-      (is (false? (<! (p/-exists? store :bar opts))))
-      (is (= :not-found (<! (p/-get-in store [:bar] :not-found opts))))
-      (is (= [nil 42] (<! (p/-assoc-in store [:bar] identity 42 opts))))
-      (is (true? (<! (p/-exists? store :bar opts))))
-      (is (= 42 (<! (p/-get-in store [:bar] :not-found opts))))
-      (is (= [42 43] (<! (p/-update-in store [:bar] identity inc opts))))
-      (is (= nil (<! (p/-get-meta store :bar opts))))
-      (is (= [43 44] (<! (p/-update-in store [:bar] #(assoc % :foo :baz) inc opts))))
-      (is (= {:foo :baz} (<! (p/-get-meta store :bar opts))))
-      (is (= [44 45] (<! (p/-update-in store [:bar] (fn [_] nil) inc opts))))
-      (is (= nil (<! (p/-get-meta store :bar opts))))
-      (is (= 45 (<! (p/-get-in store [:bar] :not-found opts))))
-      (is (= [nil {::foo 99}] (<! (p/-assoc-in store [:bar] identity {::foo 99} opts)))) ;; assoc-in overwrites
-      (is (= [{::foo 99} {::foo 100}] (<! (p/-update-in store [:bar ::foo] identity inc opts))))
-      (is (= [{::foo 100} {}] (<! (p/-update-in store [:bar] identity #(dissoc % ::foo) opts))))
-      (is (true? (<! (p/-dissoc store :bar opts))))
-      (is (false? (<! (p/-exists? store :bar opts))))
-      (.close backing)
-      (done)))))
+         (go
+           (let [db-name "pednkv-test"
+                 _ (<! (idb/delete-idb db-name))
+                 opts {:sync? false}
+                 {backing :backing :as store} (<! (idb/connect-idb-store db-name :opts opts))]
+             (is (false? (<! (p/-exists? store :bar opts))))
+             (is (= :not-found (<! (p/-get-in store [:bar] :not-found opts))))
+             (is (= [nil 42] (<! (p/-assoc-in store [:bar] identity 42 opts))))
+             (is (true? (<! (p/-exists? store :bar opts))))
+             (is (= 42 (<! (p/-get-in store [:bar] :not-found opts))))
+             (is (= [42 43] (<! (p/-update-in store [:bar] identity inc opts))))
+             (is (= nil (<! (p/-get-meta store :bar opts))))
+             (is (= [43 44] (<! (p/-update-in store [:bar] #(assoc % :foo :baz) inc opts))))
+             (is (= {:foo :baz} (<! (p/-get-meta store :bar opts))))
+             (is (= [44 45] (<! (p/-update-in store [:bar] (fn [_] nil) inc opts))))
+             (is (= nil (<! (p/-get-meta store :bar opts))))
+             (is (= 45 (<! (p/-get-in store [:bar] :not-found opts))))
+             (is (= [nil {::foo 99}] (<! (p/-assoc-in store [:bar] identity {::foo 99} opts)))) ;; assoc-in overwrites
+             (is (= [{::foo 99} {::foo 100}] (<! (p/-update-in store [:bar ::foo] identity inc opts))))
+             (is (= [{::foo 100} {}] (<! (p/-update-in store [:bar] identity #(dissoc % ::foo) opts))))
+             (is (true? (<! (p/-dissoc store :bar opts))))
+             (is (false? (<! (p/-exists? store :bar opts))))
+             (.close backing)
+             (<! (idb/delete-idb db-name))
+             (done)))))
 
 (deftest PKeyIterable-async-test
   (async done
-   (go
-    (let [db-name "pkeyiterable-test"
-          _(<! (idb/delete-idb db-name))
-          opts {:sync? false}
-          {backing :backing :as store} (<! (idb/connect-idb-store db-name :opts opts))]
-      (is (= #{} (<! (k/keys store opts))))
-      (is (= [nil 42] (<! (k/assoc-in store [:value-blob] 42 opts))))
-      (is (true? (<! (k/bassoc store :bin-blob #js[255 255 255] opts))))
-      (is (= #{{:key :bin-blob :type :binary} {:key :value-blob :type :edn}}
-             (set (map #(dissoc % :last-write) (<! (k/keys store opts))))))
-      (is (every? inst? (map :last-write (<! (k/keys store opts)))))
-      (.close backing)
-      (done)))))
+         (go
+           (let [db-name "pkeyiterable-test"
+                 _ (<! (idb/delete-idb db-name))
+                 opts {:sync? false}
+                 {backing :backing :as store} (<! (idb/connect-idb-store db-name :opts opts))]
+             (is (= #{} (<! (k/keys store opts))))
+             (is (= [nil 42] (<! (k/assoc-in store [:value-blob] 42 opts))))
+             (is (true? (<! (k/bassoc store :bin-blob #js[255 255 255] opts))))
+             (is (= #{{:key :bin-blob :type :binary} {:key :value-blob :type :edn}}
+                    (set (map #(dissoc % :last-write) (<! (k/keys store opts))))))
+             (is (every? inst? (map :last-write (<! (k/keys store opts)))))
+             (.close backing)
+             (<! (idb/delete-idb db-name))
+             (done)))))
 
 (deftest append-store-async-test
   (async done
-    (go
-     (let [db-name "append-test"
-           _(<! (idb/delete-idb db-name))
-           opts {:sync? false}
-           {backing :backing :as store} (<! (idb/connect-idb-store db-name :opts opts))]
-       (is (uuid? (second (<! (k/append store :foolog {:bar 42} opts)))))
-       (is (uuid? (second (<! (k/append store :foolog {:bar 43} opts)))))
-       (is (= '({:bar 42} {:bar 43}) (<! (k/log store :foolog opts))))
-       (is (=  [{:bar 42} {:bar 43}] (<! (k/reduce-log store :foolog conj [] opts))))
-       (let [{:keys [key type last-write] :as metadata} (<! (k/get-meta store :foolog :not-found opts))]
-         (is (= key :foolog))
-         (is (= type :append-log))
-         (is (inst? last-write)))
-       (.close backing)
-       (done)))))
+         (go
+           (let [db-name "append-test"
+                 _ (<! (idb/delete-idb db-name))
+                 opts {:sync? false}
+                 {backing :backing :as store} (<! (idb/connect-idb-store db-name :opts opts))]
+             (is (uuid? (second (<! (k/append store :foolog {:bar 42} opts)))))
+             (is (uuid? (second (<! (k/append store :foolog {:bar 43} opts)))))
+             (is (= '({:bar 42} {:bar 43}) (<! (k/log store :foolog opts))))
+             (is (=  [{:bar 42} {:bar 43}] (<! (k/reduce-log store :foolog conj [] opts))))
+             (let [{:keys [key type last-write] :as metadata} (<! (k/get-meta store :foolog :not-found opts))]
+               (is (= key :foolog))
+               (is (= type :append-log))
+               (is (inst? last-write)))
+             (.close backing)
+             (<! (idb/delete-idb db-name))
+             (done)))))


### PR DESCRIPTION
At least on my machine, there is a weird interaction between timbre & core.async where cljsc fails at producing a transit cache, probably from a resolution issue while expanding go macros. Whats worse is that cljs.main will choke on this silently, due to what I guess is a concurrency bug somewhere in cljs.main itself.

This means that there is no one-liner (at least that i could find) that can run the tests without 3rd party tools. I regret this but fixing the above is a timespend i dont have atm. What you can do is compile the test in one step & the run them in a 2nd step at the repl.

All that said, this is a working implementation that reuses the default store same as the filesystem. I put details in the docstring to `connect-idb-store`. In a follow-up PR I'd like to parameterize the tests such that they know nothing about stores operated on so that pedn/serialization/gc/cache tests can be run on both node & idb with shared code