### PR TITLE
Add AES encryption with geheimnis.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,6 +7,7 @@
         io.replikativ/incognito {:mvn/version "0.3.66"}
         io.replikativ/hasch {:mvn/version "0.3.7"}
         io.replikativ/superv.async {:mvn/version "0.3.43"}
+        io.replikativ/geheimnis {:mvn/version "0.1.1"}
         org.clojars.mmb90/cljs-cache {:mvn/version "0.1.4"}
         com.github.pkpkpk/cljs-node-io {:mvn/version "2.0.332"}
         org.lz4/lz4-java {:mvn/version "1.8.0"}

--- a/src/konserve/compressor.cljc
+++ b/src/konserve/compressor.cljc
@@ -59,3 +59,8 @@
 
 (def compressor->byte
   (invert-map byte->compressor))
+
+(defn get-compressor [type]
+  (case type
+    :lz4 lz4-compressor
+    null-compressor))

--- a/src/konserve/encryptor.cljc
+++ b/src/konserve/encryptor.cljc
@@ -1,6 +1,8 @@
 (ns konserve.encryptor
   (:require [konserve.protocols :refer [PStoreSerializer -serialize -deserialize]]
-            [konserve.utils :refer [invert-map]]))
+            [konserve.utils :refer [invert-map]]
+            [geheimnis.aes :refer [encrypt decrypt]])
+  (:import [java.io ByteArrayInputStream ByteArrayOutputStream]))
 
 (defrecord NullEncryptor [serializer]
   PStoreSerializer
@@ -9,11 +11,40 @@
   (-serialize [_ bytes write-handlers val]
     (-serialize serializer bytes write-handlers val)))
 
-(defn null-encryptor [serializer]
-  (NullEncryptor. serializer))
+(defn null-encryptor [_config]
+  (fn [serializer]
+    (NullEncryptor. serializer)))
+
+(defrecord AESEncryptor [serializer key]
+  PStoreSerializer
+  (-deserialize [_ read-handlers bytes]
+    (let [decrypted (decrypt key (.readAllBytes ^ByteArrayInputStream bytes))]
+      (-deserialize serializer read-handlers (ByteArrayInputStream. decrypted))))
+  (-serialize [_ bytes write-handlers val]
+    #?(:cljs (encrypt key (-serialize serializer bytes write-handlers val))
+       :clj (let [bos (ByteArrayOutputStream.)
+                  _ (-serialize serializer bos write-handlers val)
+                  ba (.toByteArray bos)
+                  encrypted ^bytes (encrypt key ba)]
+              (.write ^ByteArrayOutputStream bytes encrypted)))))
+
+(defn aes-encryptor [config]
+  (let [{:keys [key]} config]
+    (if (nil? key)
+      (throw (ex-info "AES key not provided."
+                      {:type   :aes-encryptor-key-missing
+                       :config config}))
+      (fn [serializer]
+        (AESEncryptor. serializer key)))))
 
 (def byte->encryptor
-  {0 null-encryptor})
+  {0 null-encryptor
+   1 aes-encryptor})
 
 (def encryptor->byte
   (invert-map byte->encryptor))
+
+(defn get-encryptor [type]
+  (case type
+    :aes aes-encryptor
+    null-encryptor))

--- a/test/konserve/encryptor_test.cljc
+++ b/test/konserve/encryptor_test.cljc
@@ -1,0 +1,16 @@
+(ns konserve.encryptor-test
+  (:require [clojure.test :refer [deftest]]
+            [konserve.filestore :refer [connect-fs-store delete-store]]
+            [konserve.compliance-test :refer [compliance-test]]
+            [konserve.encryptor :refer [aes-encryptor]]))
+
+(deftest encryptor-test
+  (let [folder "/tmp/konserve-fs-encryptor-test"
+        _      (delete-store folder)
+        store  (connect-fs-store folder
+                                 :encryptor aes-encryptor
+                                 :config {:encryptor {:type :aes
+                                                      :key "s3cr3t"}}
+                                 :opts {:sync? true})]
+    (compliance-test store)
+    (delete-store folder)))


### PR DESCRIPTION
This uses geheimnis to implement AES encryption for both Clojure and ClojureScript. ClojureScript support is tested in geheimnis, but not here yet. I have tested native compilation with Datahike as well and the encryption works from the command line.

@TimoKramer @jsmassa This support means that geheimnis now also is one of our used libraries. I had prepared it 5 years ago, but only now it makes sense to add it as the encryption provides strong access control in the distributed address space.