### PR TITLE
Allow multiple assoc operations in one transaction.

### DIFF
--- a/README.org
+++ b/README.org
@@ -216,12 +216,23 @@ Usage:
 
 #+BEGIN_SRC clojure
   (ns test-db
-    (:require [clojure.core.async :refer [go]]
+    (:require [clojure.core.async :refer [go <!]]
               [konserve.indexeddb :refer [connect-idb-store]]
               [konserve.core :as k]))
 
-  (go (def my-idb-store (<! (connect-idb-store "example-db"))))
+  (go 
+    (def my-idb-store (<! (connect-idb-store "example-db")))
+    
+    ;; Regular operations
+    (<! (k/assoc-in my-idb-store [:user] {:name "Alice" :age 30}))
+    (<! (k/get-in my-idb-store [:user]))
+    
+    ;; Multi-key atomic operations
+    (<! (k/multi-assoc my-idb-store {:user1 {:name "Alice"} 
+                                     :user2 {:name "Bob"}})))
 #+END_SRC
+
+The IndexedDB implementation supports atomic multi-key operations through IndexedDB's native transaction model. This means you can write to multiple keys in a single atomic operation - all changes will either succeed or fail together.
 
 *** External Backends
     :PROPERTIES:

--- a/benchmark/src/benchmark/common.clj
+++ b/benchmark/src/benchmark/common.clj
@@ -25,9 +25,7 @@
           population)
     store))
 
-
 ; time measurements
-
 
 (defmacro timed
   "Evaluates expr. Returns the value of expr and the time in a map."

--- a/benchmark/src/benchmark/measure/create.clj
+++ b/benchmark/src/benchmark/measure/create.clj
@@ -10,9 +10,9 @@
   (setup-store store-type store-size)
   (case store-type
     :memory (if sync? (timed (new-mem-store opts))
-                      (timed (<!! (new-mem-store opts))))
+                (timed (<!! (new-mem-store opts))))
     :file (if sync? (timed (connect-fs-store fs-store-path :opts opts))
-                    (timed (<!! (connect-fs-store fs-store-path :opts opts))))) )
+              (timed (<!! (connect-fs-store fs-store-path :opts opts))))))
 
 (defmethod benchmark :create [_function stores store-sizes iterations]
   (->> (for [store-type stores
@@ -42,10 +42,10 @@
 
 (defn create-empty-time-plot [data]
   (bar {:title      "Median Create Performance of Empty Store"
-         :vals       (filter #(= 0 (:size %)) data)
-         :x          {:key :store :title "Store"}
-         :y          {:key :median :title "Time (in ms)"}
-         :zero-y     true}))
+        :vals       (filter #(= 0 (:size %)) data)
+        :x          {:key :store :title "Store"}
+        :y          {:key :median :title "Time (in ms)"}
+        :zero-y     true}))
 
 (defmethod plots :create [_function data]
   [["create-time" (create-time-plot data)]
@@ -57,6 +57,4 @@
 
   (oz/start-server!)
   (oz/view! (create-time-plot data) :mode :vega)
-  (oz/view! (create-empty-time-plot data) :mode :vega)
-  
-  )
+  (oz/view! (create-empty-time-plot data) :mode :vega))

--- a/benchmark/src/benchmark/measure/get.clj
+++ b/benchmark/src/benchmark/measure/get.clj
@@ -9,12 +9,12 @@
   (let [mid-el (int (/ n 2))
         store (setup-store store-type n)
         times (if sync?
-          [(timed (k/get store 0 nil opts))
-           (timed (k/get store mid-el nil opts))
-           (timed (k/get store (dec n) nil opts))]
-          [(timed (<!! (k/get store 0 nil opts)))
-           (timed (<!! (k/get store mid-el nil opts)))
-           (timed (<!! (k/get store (dec n) nil opts)))])]
+                [(timed (k/get store 0 nil opts))
+                 (timed (k/get store mid-el nil opts))
+                 (timed (k/get store (dec n) nil opts))]
+                [(timed (<!! (k/get store 0 nil opts)))
+                 (timed (<!! (k/get store mid-el nil opts)))
+                 (timed (<!! (k/get store (dec n) nil opts)))])]
     times))
 
 (defmethod benchmark :get [_function stores store-sizes iterations]

--- a/benchmark/src/benchmark/plot.clj
+++ b/benchmark/src/benchmark/plot.clj
@@ -151,7 +151,6 @@
                    :update {:tooltip {:signal tooltip}}
                    :hover  {:strokeOpacity {:value 0.5}}}}]}]}))
 
-
 (defn bar [description]
   (let [{:keys [x y vals title]} description]
     {:description

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -3,8 +3,8 @@
   (:require [clojure.core.async :refer [chan put! poll!]]
             [hasch.core :as hasch]
             [konserve.protocols :as protocols :refer [-exists? -get-meta -get-in -assoc-in
-                                        -update-in -dissoc -bget -bassoc
-                                        -keys -multi-assoc]]
+                                                      -update-in -dissoc -bget -bassoc
+                                                      -keys -multi-assoc]]
             [konserve.utils :refer [meta-update multi-key-capable? #?(:clj async+sync) *default-sync-translation*]
              #?@(:cljs [:refer-macros [async+sync]])]
             [konserve.impl.storage-layout :as storage-layout]
@@ -160,11 +160,10 @@
    (trace "assoc on key " key)
    (assoc-in store [key] val opts)))
 
-
 ;; JVM implementation of multi-assoc
 #?(:clj
-(defn multi-assoc
-  "Atomically associates multiple key-value pairs with flat keys.
+   (defn multi-assoc
+     "Atomically associates multiple key-value pairs with flat keys.
    Takes a map of keys to values and stores them in a single atomic transaction.
    All operations must succeed or all must fail (all-or-nothing semantics).
    
@@ -177,38 +176,53 @@
    Returns a map of keys to results (typically true for each key).
    
    Throws an exception if the store doesn't support multi-key operations."
-  ([store kvs]
-   (multi-assoc store kvs {:sync? false}))
-  ([store kvs opts]
-   (trace "multi-assoc operation with " (count kvs) " keys")
-   (when-not (multi-key-capable? store)
-     (throw (ex-info "Store does not support multi-key operations" 
-                    {:store-type (type store)
-                     :reason "Store doesn't implement PMultiKeyEDNValueStore protocol or multi-key support is disabled"})))
-   (async+sync (:sync? opts)
-              *default-sync-translation*
-              (go-try-
-               (try
-                 (<?- (-multi-assoc store kvs meta-update opts))
-                 (catch Exception e
+     ([store kvs]
+      (multi-assoc store kvs {:sync? false}))
+     ([store kvs opts]
+      (trace "multi-assoc operation with " (count kvs) " keys")
+      (when-not (multi-key-capable? store)
+        (throw (ex-info "Store does not support multi-key operations"
+                        {:store-type (type store)
+                         :reason "Store doesn't implement PMultiKeyEDNValueStore protocol or multi-key support is disabled"})))
+      (async+sync (:sync? opts)
+                  *default-sync-translation*
+                  (go-try-
+                   (try
+                     (<?- (-multi-assoc store kvs meta-update opts))
+                     (catch Exception e
                    ;; Backend might throw an exception indicating it doesn't support multi-key operations
                    ;; even though the store implements the protocol
-                   (if (and (instance? clojure.lang.ExceptionInfo e) 
-                            (= :not-supported (:type (ex-data e))))
-                     (throw (ex-info "Backing store does not support multi-key operations" 
-                                    {:store-type (type store)
-                                     :cause e
-                                     :reason (:reason (ex-data e))}))
-                     (throw e)))))))))
+                       (if (and (instance? clojure.lang.ExceptionInfo e)
+                                (= :not-supported (:type (ex-data e))))
+                         (throw (ex-info "Backing store does not support multi-key operations"
+                                         {:store-type (type store)
+                                          :cause e
+                                          :reason (:reason (ex-data e))}))
+                         (throw e)))))))))
 
-;; ClojureScript implementation (not supported yet)
+;; ClojureScript implementation
 #?(:cljs
-(defn multi-assoc
-  "Not yet supported in ClojureScript."
-  ([store kvs]
-   (multi-assoc store kvs {:sync? false}))
-  ([store kvs opts]
-   (throw (js/Error. "multi-assoc is not supported in ClojureScript yet")))))
+   (defn multi-assoc
+     "Atomically associates multiple key-value pairs with flat keys.
+   Takes a map of keys to values and stores them in a single atomic transaction.
+   All operations must succeed or all must fail (all-or-nothing semantics).
+   
+   Example:
+   ```
+   (multi-assoc store {:user1 {:name \"Alice\"}
+                       :user2 {:name \"Bob\"}})
+   ```
+   
+   Returns a map of keys to results (typically true for each key).
+   
+   Throws an error if the store doesn't support multi-key operations."
+     ([store kvs]
+      (multi-assoc store kvs {:sync? false}))
+     ([store kvs opts]
+      (trace "multi-assoc operation with " (count kvs) " keys")
+      (when-not (multi-key-capable? store)
+        (throw (js/Error. "Store does not support multi-key operations")))
+      (-multi-assoc store kvs meta-update opts))))
 
 (defn dissoc
   "Removes an entry from the store. "

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -19,6 +19,7 @@
                                          -read-header -read-meta -read-value -read-binary
                                          -write-header -write-meta -write-value -write-binary
                                          PBackingLock -release
+                                         PMultiWriteBackingStore -multi-write-blobs
                                          default-version
                                          parse-header create-header header-size]]
    [konserve.utils  #?@(:clj [:refer [async+sync *default-sync-translation*]]
@@ -302,6 +303,66 @@
               (recur (into keys additional-keys) store-keys)))
           keys))))))
 
+(defn prepare-multi-assoc
+  "Prepares multiple key-value pairs for writing to the backing store.
+   Handles serialization, metadata updates, and key translation."
+  [backing serializers read-handlers write-handlers
+   {:keys [kvs meta-up-fn default-serializer compressor encryptor version config] :as env}]
+  (async+sync
+   (:sync? env) *default-sync-translation*
+   (go-try-
+    (let [serializer (get serializers default-serializer)
+          to-array #?(:cljs
+                      (fn [value]
+                        (-serialize ((encryptor  (:encryptor config)) (compressor serializer)) nil write-handlers value))
+                      :clj
+                      (fn [value]
+                        (let [bos (ByteArrayOutputStream.)]
+                          (try (-serialize ((encryptor (:encryptor config)) (compressor serializer))
+                                         bos write-handlers value)
+                               (.toByteArray bos)
+                               (finally
+                                 (.close bos))))))
+          
+          ;; Process each key-value pair
+          results (loop [pairs []
+                         pending-entries (seq kvs)]
+                    (if-let [[key val] (first pending-entries)]
+                      (let [store-key (key->store-key key)
+
+                            ;; no reading, we will just reset it with fresh metadata here
+                            old-meta nil 
+                            
+                            ;; Prepare serialized data
+                            meta (meta-up-fn key :edn old-meta)
+                            meta-arr (to-array meta)
+                            meta-size (count meta-arr)
+                            value-arr (to-array val)
+                            header (create-header version
+                                                 serializer compressor encryptor meta-size)
+                            
+                            ;; Create serialized data structure
+                            data {:store-key store-key
+                                 :header header
+                                 :meta-arr meta-arr
+                                 :value-arr value-arr
+                                 :meta-size meta-size
+                                 :key key}]
+                        
+                        (recur (conj pairs data) (rest pending-entries)))
+                      pairs))
+          
+          ;; Map to format expected by backing store
+          store-key-values (map (fn [{:keys [store-key header meta-arr value-arr]}]
+                                 [store-key {:header header
+                                            :meta meta-arr
+                                            :value value-arr}])
+                               results)]
+      
+      ;; Return the prepared data for backend
+      {:store-key-values store-key-values
+       :processed-pairs results}))))
+
 (defrecord DefaultStore [version backing serializers default-serializer compressor encryptor
                          read-handlers write-handlers buffer-size locks config]
   PEDNKeyValueStore
@@ -445,7 +506,48 @@
                   :config config
                   :sync? sync?
                   :buffer-size buffer-size
-                  :msg {:type :read-all-keys-error}}))))
+                  :msg {:type :read-all-keys-error}})))
+                  
+  konserve.protocols/PMultiKeySupport
+  (-supports-multi-key? [_]
+    (satisfies? PMultiWriteBackingStore backing))
+  
+  konserve.protocols/PMultiKeyEDNValueStore
+  (-multi-assoc [this kvs meta-up-fn opts]
+    (let [{:keys [sync?]} opts]
+      ;; First check if the backing store supports multi-writes
+      (when-not (satisfies? PMultiWriteBackingStore backing)
+        (throw (ex-info "Backing store does not support multi-key operations" 
+                        {:store-type (type backing)
+                         :type :not-supported})))
+      
+      (let [env (merge opts 
+                      {:kvs kvs
+                       :meta-up-fn meta-up-fn
+                       :compressor compressor
+                       :encryptor encryptor
+                       :version version
+                       :default-serializer default-serializer
+                       :config config
+                       :buffer-size buffer-size
+                       :sync? sync?
+                       :operation :write-edn
+                       :msg {:type :multi-write-edn-error}})]
+        
+        (async+sync
+         sync? *default-sync-translation*
+         (go-try-
+          ;; 1. Prepare the data for multi-key storage
+          (let [prepared-data (<?- (prepare-multi-assoc backing serializers read-handlers write-handlers env))
+                {:keys [store-key-values processed-pairs]} prepared-data
+                
+                ;; 2. Use the backing store's multi-write capability
+                multi-result (<?- (-multi-write-blobs backing store-key-values env))]
+            
+            ;; 3. Map the results back to original keys
+            (into {} (map (fn [{:keys [key store-key]}]
+                           [key (get multi-result store-key true)])
+                         processed-pairs)))))))))
 
 (defn connect-default-store
   "Create general store in given base of backing store."

--- a/src/konserve/impl/storage_layout.cljc
+++ b/src/konserve/impl/storage_layout.cljc
@@ -161,7 +161,7 @@
 
 (defprotocol PMultiWriteBackingStore
   "Protocol for backing stores that support atomic multi-key writes."
-  (-multi-write-blobs [this store-key-values env] 
+  (-multi-write-blobs [this store-key-values env]
     "Write multiple blobs atomically in a single operation.
      store-key-values is a sequence of [store-key serialized-data] pairs.
      serialized-data is a map containing :header, :meta-arr, and :value-arr.

--- a/src/konserve/impl/storage_layout.cljc
+++ b/src/konserve/impl/storage_layout.cljc
@@ -159,6 +159,15 @@
   (-keys [this env] "List all the keys representing blobs in the store.")
   (-handle-foreign-key [this migration-key serializer read-handlers write-handlers env] "Handle keys not recognized by the current konserve version."))
 
+(defprotocol PMultiWriteBackingStore
+  "Protocol for backing stores that support atomic multi-key writes."
+  (-multi-write-blobs [this store-key-values env] 
+    "Write multiple blobs atomically in a single operation.
+     store-key-values is a sequence of [store-key serialized-data] pairs.
+     serialized-data is a map containing :header, :meta-arr, and :value-arr.
+     Returns a map of store-keys to success values (typically true).
+     Backends must implement this to support multi-key operations."))
+
 (defprotocol PBackingBlob
   "Blob object that is backing a stored value and its metadata."
   (-sync [this env] "Synchronize this object and ensure it is stored. This is not necessary in many stores.")

--- a/src/konserve/memory.cljc
+++ b/src/konserve/memory.cljc
@@ -89,10 +89,10 @@
                   {go do
                    <! do}
                   (go (set (map first (vals @state)))))))
-                  
+
   PMultiKeySupport
   (-supports-multi-key? [_] true)
-  
+
   PMultiKeyEDNValueStore
   (-multi-assoc [_ kvs meta-up-fn opts]
     (let [{:keys [sync?]} opts]

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -13,7 +13,7 @@
 
 (defprotocol PMultiKeySupport
   "Protocol for checking if a store supports atomic multi-key operations."
-  (-supports-multi-key? [this] 
+  (-supports-multi-key? [this]
     "Returns true if the store supports atomic multi-key operations."))
 
 (defprotocol PMultiKeyEDNValueStore
@@ -44,6 +44,6 @@
 ;; Default implementations for Object
 
 #?(:clj
-(extend-protocol PMultiKeySupport
-  Object
-  (-supports-multi-key? [_] false)))
+   (extend-protocol PMultiKeySupport
+     Object
+     (-supports-multi-key? [_] false)))

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -11,6 +11,20 @@
   (-assoc-in [this key-vec meta-up-fn val opts])
   (-dissoc [this key opts]))
 
+(defprotocol PMultiKeySupport
+  "Protocol for checking if a store supports atomic multi-key operations."
+  (-supports-multi-key? [this] 
+    "Returns true if the store supports atomic multi-key operations."))
+
+(defprotocol PMultiKeyEDNValueStore
+  "Allows to atomically update multiple key-value pairs with all-or-nothing semantics.
+   This is an optional protocol that backends can implement to provide transactional operations."
+  (-multi-assoc [this kvs meta-up-fn opts]
+    "Atomically associates multiple key-value pairs with flat keys.
+     Takes a map of keys to values and stores them in a single atomic transaction.
+     All operations must succeed or all must fail (all-or-nothing semantics).
+     Returns a map of keys to results (typically true for each key)."))
+
 (defprotocol PBinaryKeyValueStore
   "Allows binary data byte array storage."
   (-bget [this key locked-cb opts] "Calls locked-cb with a platform specific binary representation inside the lock, e.g. wrapped InputStream on the JVM and Blob in JavaScript. You need to properly close/dispose the object when you are done!")
@@ -26,3 +40,10 @@
   (-serialize [this output-stream write-handlers val]
     "For the JVM we use streams, while for JavaScript we return the value for now.")
   (-deserialize [this read-handlers input-stream]))
+
+;; Default implementations for Object
+
+#?(:clj
+(extend-protocol PMultiKeySupport
+  Object
+  (-supports-multi-key? [_] false)))

--- a/src/konserve/utils.cljc
+++ b/src/konserve/utils.cljc
@@ -1,5 +1,6 @@
 (ns konserve.utils
-  (:require [clojure.walk]))
+  (:require [clojure.walk]
+            [konserve.protocols :as protocols]))
 
 (defn invert-map [m]
   (->> (map (fn [[k v]] [v k]) m)
@@ -14,12 +15,36 @@
   {:key 'The stored key'
    :type 'The type of the stored value binary or edn'
    :last-write Date timestamp in milliseconds.}
-  Returns the meta value of the stored key-value tupel. Returns metadata if the key
+  Returns the meta value of the stored key-value tuple. Returns metadata if the key
   value not exist, if it does it will update the last-write to date now. "
   [key type old]
   (if (empty? old)
     {:key key :type type :last-write (now)}
     (clojure.core/assoc old :last-write (now))))
+
+;; Using a dynamic var for testing
+(def ^:dynamic *multi-key-support-enabled* true)
+
+;; Platform-specific implementation for multi-key capability checking
+#?(:clj
+(defn multi-key-capable?
+  "Checks whether the store supports multi-key operations.
+   A store supports multi-key operations if:
+   1. Multi-key support is enabled
+   2. AND it implements PMultiKeyEDNValueStore
+   3. AND it reports support for multi-key operations via PMultiKeySupport
+   This function is used by the high-level API to determine if a store supports multi-key operations."
+  [store]
+  (and *multi-key-support-enabled*
+       (satisfies? protocols/PMultiKeyEDNValueStore store)
+       (protocols/-supports-multi-key? store))))
+
+;; ClojureScript version always returns false for now
+#?(:cljs
+(defn multi-key-capable?
+  "Checks whether the store supports multi-key operations (currently always returns false in ClojureScript)"
+  [store]
+  false))
 
 (defmacro async+sync
   [sync? async->sync async-code]

--- a/src/konserve/utils.cljc
+++ b/src/konserve/utils.cljc
@@ -22,29 +22,13 @@
     {:key key :type type :last-write (now)}
     (clojure.core/assoc old :last-write (now))))
 
-;; Using a dynamic var for testing
-(def ^:dynamic *multi-key-support-enabled* true)
-
-;; Platform-specific implementation for multi-key capability checking
-#?(:clj
 (defn multi-key-capable?
   "Checks whether the store supports multi-key operations.
-   A store supports multi-key operations if:
-   1. Multi-key support is enabled
-   2. AND it implements PMultiKeyEDNValueStore
-   3. AND it reports support for multi-key operations via PMultiKeySupport
+
    This function is used by the high-level API to determine if a store supports multi-key operations."
   [store]
-  (and *multi-key-support-enabled*
-       (satisfies? protocols/PMultiKeyEDNValueStore store)
-       (protocols/-supports-multi-key? store))))
-
-;; ClojureScript version always returns false for now
-#?(:cljs
-(defn multi-key-capable?
-  "Checks whether the store supports multi-key operations (currently always returns false in ClojureScript)"
-  [store]
-  false))
+  (and (satisfies? protocols/PMultiKeyEDNValueStore store)
+       (protocols/-supports-multi-key? store)))
 
 (defmacro async+sync
   [sync? async->sync async-code]


### PR DESCRIPTION
Fixes #125 

This offloads transactions over multiple keys to the underlying store when it supports it. In the future similar extensions for multi-key reads and deletions might be sensible. This is going to probably at least half datahike's write latency on supporting backends. JDBC and dynamodb already have support and will be released after this PR is merged.