### PR TITLE
fix: gate utils.cljc defmacros with #?(:clj ...) so cljs can load the ns

### DIFF
--- a/src/konserve/utils.cljc
+++ b/src/konserve/utils.cljc
@@ -58,23 +58,24 @@
                                                                                :error e})
                  :cljs (js/console.warn "Write hook error:" hook-id (pr-str e))))))))))
 
-(defmacro async+sync
-  [sync? async->sync async-code]
-  (let [async->sync (if (symbol? async->sync)
-                      (or (resolve async->sync)
-                          (when-let [_ns (or (get-in &env [:ns :use-macros async->sync])
-                                             (get-in &env [:ns :uses async->sync]))]
-                            (resolve (symbol (str _ns) (str async->sync)))))
-                      async->sync)]
-    (assert (some? async->sync))
-    `(if ~sync?
-       ~(clojure.walk/postwalk (fn [n]
-                                 (if-not (meta n)
-                                   (async->sync n n) ;; primitives have no metadata
-                                   (with-meta (async->sync n n)
-                                     (update (meta n) :tag (fn [t] (async->sync t t))))))
-                               async-code)
-       ~async-code)))
+#?(:clj
+   (defmacro async+sync
+     [sync? async->sync async-code]
+     (let [async->sync (if (symbol? async->sync)
+                         (or (resolve async->sync)
+                             (when-let [_ns (or (get-in &env [:ns :use-macros async->sync])
+                                                (get-in &env [:ns :uses async->sync]))]
+                               (resolve (symbol (str _ns) (str async->sync)))))
+                         async->sync)]
+       (assert (some? async->sync))
+       `(if ~sync?
+          ~(clojure.walk/postwalk (fn [n]
+                                    (if-not (meta n)
+                                      (async->sync n n) ;; primitives have no metadata
+                                      (with-meta (async->sync n n)
+                                        (update (meta n) :tag (fn [t] (async->sync t t))))))
+                                  async-code)
+          ~async-code))))
 
 (def ^:dynamic *default-sync-translation*
   '{go-try try
@@ -85,7 +86,8 @@
     go-locked locked
     maybe-go-locked maybe-locked})
 
-(defmacro with-promise [sym & body]
-  `(let [~sym (cljs.core.async/promise-chan)]
-     ~@body
-     ~sym))
+#?(:clj
+   (defmacro with-promise [sym & body]
+     `(let [~sym (cljs.core.async/promise-chan)]
+        ~@body
+        ~sym)))


### PR DESCRIPTION
## Summary

- Wrap `async+sync` and `with-promise` in `src/konserve/utils.cljc` with `#?(:clj ...)` so the cljs analyzer skips the macro bodies entirely.
- Fixes the `"Argument to resolve must be a quoted symbol"` failure seen by cljs consumers (e.g. cljdoc) when `konserve.utils` is loaded transitively from a `.cljs` namespace.

## Why

When a `.cljc` file has bare `defmacro` forms, the cljs analyzer still walks the macro bodies on compile. `async+sync` calls `(resolve async->sync)`, which cljs expands as `cljs.core/resolve` — a macro that asserts its argument is a quoted-symbol literal. The bare symbol binding fails that assertion and the namespace can't be compiled. Macros only ever run on the JVM, so gating the forms with `:clj` is the standard fix; cljs picks them up through `:require-macros` / macro inference from the Clojure side.

Fixes #140

## Test plan

- [x] `clojure -M:test` passes on the branch
- [x] cljs build path still compiles (e.g. `npx shadow-cljs release node-tests && node out/node-tests.js`)
- [ ] Re-run the failing cljdoc analysis for a downstream cljs consumer (e.g. datahike) to confirm the original error no longer fires