### PR TITLE
Write-path fixes: skip-exists on overwrite + cache dissoc hook guard

### DIFF
--- a/src/konserve/cache.cljc
+++ b/src/konserve/cache.cljc
@@ -130,25 +130,41 @@
                (go-locked
                 store (first key-vec)
                 (let [cache (:cache store)
-                      [old-val new-val] (<?- (-assoc-in store key-vec (partial meta-update (first key-vec) :edn) val opts))
+                      key (first key-vec)
+                      [old-val new-val] (<?- (-assoc-in store key-vec (partial meta-update key :edn) val opts))
                       had-key? (cache/has? @cache key)]
-                  (swap! cache cache/evict (first key-vec))
+                  (swap! cache cache/evict key)
                   (when had-key?
-                    (swap! cache cache/miss (first key-vec) new-val))
+                    (swap! cache cache/miss key new-val))
                   (invoke-write-hooks! store {:api-op :assoc-in
-                                              :key (first key-vec)
+                                              :key key
                                               :key-vec key-vec
                                               :value val})
                   [old-val new-val])))))
 
 (defn assoc
-  "Associates the key-vec to the value, any missing collections for
- the key-vec (nested maps and vectors) are newly created."
+  "Associates the key to the value. This is a simple top-level overwrite."
   ([store key val]
    (assoc store key val {:sync? false}))
   ([store key val opts]
    (log/trace :konserve/cache-assoc {:key key})
-   (assoc-in store [key] val opts)))
+   (async+sync (:sync? opts)
+               *default-sync-translation*
+               (go-locked
+                store key
+                ;; Mirror konserve.core/assoc — fire :api-op :assoc, not the
+                ;; :assoc-in we'd inherit by delegating to assoc-in — so hook
+                ;; consumers see the same op label as the non-cache API.
+                (let [cache (:cache store)
+                      [old-val new-val] (<?- (-assoc-in store [key] (partial meta-update key :edn) val opts))
+                      had-key? (cache/has? @cache key)]
+                  (swap! cache cache/evict key)
+                  (when had-key?
+                    (swap! cache cache/miss key new-val))
+                  (invoke-write-hooks! store {:api-op :assoc
+                                              :key key
+                                              :value val})
+                  [old-val new-val])))))
 
 (defn dissoc
   "Removes an entry from the store. "

--- a/src/konserve/cache.cljc
+++ b/src/konserve/cache.cljc
@@ -9,7 +9,7 @@
             #?(:clj [clojure.core.cache :as cache]
                :cljs [cljs.cache :as cache])
             [konserve.core #?@(:clj (:refer [go-locked locked])) :as core]
-            [konserve.utils :refer [meta-update #?(:clj async+sync) *default-sync-translation*]
+            [konserve.utils :refer [meta-update invoke-write-hooks! #?(:clj async+sync) *default-sync-translation*]
              #?@(:cljs [:refer-macros [async+sync]])]
             [replikativ.logging :as log]
             [superv.async :refer [go-try- <?-]]
@@ -100,6 +100,11 @@
                   (swap! cache cache/evict key)
                   (when had-key?
                     (swap! cache cache/miss key new-val))
+                  (invoke-write-hooks! store {:api-op :update-in
+                                              :key key
+                                              :key-vec key-vec
+                                              :old-value old-val
+                                              :value new-val})
                   [old-val new-val])))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
@@ -130,6 +135,10 @@
                   (swap! cache cache/evict (first key-vec))
                   (when had-key?
                     (swap! cache cache/miss (first key-vec) new-val))
+                  (invoke-write-hooks! store {:api-op :assoc-in
+                                              :key (first key-vec)
+                                              :key-vec key-vec
+                                              :value val})
                   [old-val new-val])))))
 
 (defn assoc
@@ -151,9 +160,12 @@
                *default-sync-translation*
                (go-locked
                 store key
-                (let [cache (:cache store)]
+                (let [cache (:cache store)
+                      result (<?- (-dissoc store key opts))]
                   (swap! cache cache/evict key)
-                  (<?- (-dissoc store key opts)))))))
+                  (invoke-write-hooks! store {:api-op :dissoc
+                                              :key key})
+                  result)))))
 
 ;; alias core functions without caching for convenience
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}

--- a/src/konserve/cache.cljc
+++ b/src/konserve/cache.cljc
@@ -163,8 +163,14 @@
                 (let [cache (:cache store)
                       result (<?- (-dissoc store key opts))]
                   (swap! cache cache/evict key)
-                  (invoke-write-hooks! store {:api-op :dissoc
-                                              :key key})
+                  ;; Match konserve.core/dissoc: only fire the hook when a
+                  ;; value was actually removed (-dissoc returns false for an
+                  ;; absent key). Otherwise a no-op delete would emit a
+                  ;; spurious hook and konserve-sync would replicate a phantom
+                  ;; deletion.
+                  (when result
+                    (invoke-write-hooks! store {:api-op :dissoc
+                                                :key key}))
                   result)))))
 
 ;; alias core functions without caching for convenience

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -252,8 +252,19 @@
           store-key     (key->store-key key)
           env           (assoc env :store-key store-key :header-size header-size)
           serializer    (get serializers default-serializer)
-          store-key-exists? (<?- (-blob-exists? backing store-key env))
           migration-key (<?- (-migratable backing key store-key env))
+          ;; A full-overwrite write doesn't need to know whether the blob
+          ;; already exists: it writes regardless, never reads the old value
+          ;; (the old-read below is gated on `(not overwrite?)`), and the
+          ;; migrate branch needs a non-nil migration-key. So when there is no
+          ;; migration to perform we can skip the existence probe entirely —
+          ;; on remote backends that probe is a full round-trip (e.g. an S3
+          ;; HEAD) paid per write for an answer that is then ignored.
+          skip-exists?  (and overwrite?
+                             (or (= :write-edn operation) (= :write-binary operation))
+                             (nil? migration-key))
+          store-key-exists? (when-not skip-exists?
+                              (<?- (-blob-exists? backing store-key env)))
           max-retries (get-in config [:optimistic-locking-retries] 0)]
       (if (and (not store-key-exists?) migration-key)
         (<?- (-migrate backing migration-key key-vec serializer read-handlers write-handlers env))


### PR DESCRIPTION
Write-path correctness/efficiency fixes — skip-exists optimization plus
cache write-hook consistency with `konserve.core`.

## 1. Skip existence probe on full-overwrite writes (`impl/defaults`)

`io-operation` called `-blob-exists?` unconditionally before every op. For
a full-overwrite write (single-key `assoc`, `:overwrite? true`) the result
is never used — the write proceeds regardless, the old-value read is gated
on `(not overwrite?)`, and the migrate branch needs a non-nil
`migration-key`. On remote backings that probe is a full round-trip (S3
`HEAD`, GCS metadata GET, …) paid per write for a discarded answer.

Skip it for `:write-edn`/`:write-binary` + `:overwrite? true` + no
migration. Reads and read-modify-write are unchanged and still probe; the
migrate path is unchanged.

Measured on a Datahike commit (index nodes = single-key `k/assoc`) vs MinIO:

| | round-trips/commit | ms/commit | commits/s | PUT p99 |
|---|---|---|---|---|
| before | 9.2 HEAD + 7.2 PUT + 1 GET | 51.9 | 19.3 | 115 ms |
| after  | 2.0 HEAD + 7.2 PUT + 1 GET | 39.9 | 25.1 | 29 ms |

## 2. Cache write-hook consistency with core (`cache`)

Audited every `konserve.cache` mutation against `konserve.core` after the
"fire write hooks from cache" change. `update-in` was already consistent.
Fixed:

- **dissoc** fired its hook unconditionally; core guards with
  `(when result …)` (`-dissoc` returns false for an absent key). A no-op
  cache delete no longer emits a phantom hook that konserve-sync would
  replicate.
- **assoc** delegated to `assoc-in`, so it reported `:api-op :assoc-in`
  instead of `:assoc`. It now has its own body firing `:assoc`, matching
  core, so hook consumers see the same label via either API.
- **assoc-in** referenced an unbound `key` (→ `clojure.core/key`) in its
  cache-repopulation check, so `had-key?` was always false and the cache
  was evicted but never repopulated. Bound `key = (first key-vec)`,
  matching `update-in`. (Correctness was preserved via reload; this
  restores the caching optimization.)

## Tests

`clojure -M:test` green — 57 tests, 1071 assertions (filestore migration
suite exercises the `migration-key` path; cache tests cover the hooks).