### PR TITLE
fix(cljs): header meta-size as 4-byte big-endian int (JVM↔cljs cross-host)

### DIFF
--- a/src/konserve/impl/storage_layout.cljc
+++ b/src/konserve/impl/storage_layout.cljc
@@ -37,7 +37,13 @@
            return-buffer    (js/Uint8Array. header-size)] ;;possibly sparse?
        (dotimes [i (alength env-array)]
          (aset return-buffer i (aget env-array i)))
-       (aset return-buffer 4 meta)
+       ;; Meta-size is a 4-byte big-endian int at bytes 4-7 (matches the JVM `.putInt`
+       ;; and the header doc "5-8th Byte = Meta-Size"). Writing it as a single byte (the
+       ;; previous cljs code) capped meta at 255 and broke JVM<->cljs cross-host reads.
+       (aset return-buffer 4 (bit-and (unsigned-bit-shift-right meta 24) 0xff))
+       (aset return-buffer 5 (bit-and (unsigned-bit-shift-right meta 16) 0xff))
+       (aset return-buffer 6 (bit-and (unsigned-bit-shift-right meta 8) 0xff))
+       (aset return-buffer 7 (bit-and meta 0xff))
        return-buffer)))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
@@ -115,7 +121,12 @@
            serializer-id (aget header-bytes 1)
            compressor-id (aget header-bytes 2)
            encryptor-id (aget header-bytes 3)
-           meta-size (aget header-bytes 4)
+           ;; Meta-size is a 4-byte big-endian int at bytes 4-7 (matches the JVM `.getInt`).
+           ;; `*`/`+` instead of bit-ops to avoid JS 32-bit-signed overflow for large sizes.
+           meta-size (+ (* (aget header-bytes 4) 16777216)
+                        (* (aget header-bytes 5) 65536)
+                        (* (aget header-bytes 6) 256)
+                        (aget header-bytes 7))
            serializer (serializers (byte->key serializer-id))
            compressor (byte->compressor compressor-id)
            encryptor (byte->encryptor encryptor-id)]

--- a/src/konserve/impl/storage_layout.cljc
+++ b/src/konserve/impl/storage_layout.cljc
@@ -121,12 +121,17 @@
            serializer-id (aget header-bytes 1)
            compressor-id (aget header-bytes 2)
            encryptor-id (aget header-bytes 3)
-           ;; Meta-size is a 4-byte big-endian int at bytes 4-7 (matches the JVM `.getInt`).
-           ;; `*`/`+` instead of bit-ops to avoid JS 32-bit-signed overflow for large sizes.
-           meta-size (+ (* (aget header-bytes 4) 16777216)
-                        (* (aget header-bytes 5) 65536)
-                        (* (aget header-bytes 6) 256)
-                        (aget header-bytes 7))
+           ;; Meta-size is a 4-byte big-endian int at bytes 4-7 (matches the JVM `.getInt`;
+           ;; `*`/`+` instead of bit-ops to avoid JS 32-bit-signed overflow for large sizes).
+           ;; Back-compat: a legacy cljs writer stored meta-size as a SINGLE byte at offset 4
+           ;; (bytes 5-7 = 0), capped at 255. Read those transparently so existing cljs stores
+           ;; still load: a nonzero byte 4 with all lower bytes zero can only be the legacy
+           ;; single-byte size (a real 4-byte meta-size >= 16 MB is never a metadata blob).
+           b4 (aget header-bytes 4) b5 (aget header-bytes 5)
+           b6 (aget header-bytes 6) b7 (aget header-bytes 7)
+           meta-size (if (and (not= b4 0) (== b5 0) (== b6 0) (== b7 0))
+                       b4
+                       (+ (* b4 16777216) (* b5 65536) (* b6 256) b7))
            serializer (serializers (byte->key serializer-id))
            compressor (byte->compressor compressor-id)
            encryptor (byte->encryptor encryptor-id)]

--- a/test/konserve/storage_layout_test.cljc
+++ b/test/konserve/storage_layout_test.cljc
@@ -1,0 +1,44 @@
+(ns konserve.storage-layout-test
+  "Guards the blob-header byte layout (konserve.impl.storage-layout). The meta-size is a
+  4-byte big-endian int at bytes 4-7 on BOTH the JVM (.putInt/.getInt) and cljs. A previous
+  cljs regression wrote/read it as a single byte at offset 4: same-host cljs was self-
+  consistent (so a round-trip test passed) but JVM<->cljs cross-host exchange broke (cljs
+  read meta-size 0 for any JVM blob with meta-size < 16MB). These tests pin the exact bytes
+  (cross-host) AND round-trip sizes > 255 (which the single-byte format truncated)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [konserve.impl.storage-layout :as sl]
+            [konserve.serializers :as ser]
+            [konserve.compressor :refer [null-compressor]]
+            [konserve.encryptor :refer [null-encryptor]]))
+
+(defn- header-bytes [meta-size]
+  (mapv #(bit-and % 0xff)
+        (vec (sl/create-header sl/default-version
+                               (ser/fressian-serializer)
+                               null-compressor null-encryptor
+                               meta-size))))
+
+(defn- roundtrip-meta-size [meta-size]
+  (let [header (sl/create-header sl/default-version (ser/fressian-serializer)
+                                 null-compressor null-encryptor meta-size)
+        ;; parse-header takes the store's serializers map (key -> instance)
+        [_version _ser _comp _enc parsed-meta-size _hsize]
+        (sl/parse-header header ser/key->serializer)]
+    parsed-meta-size))
+
+(deftest header-meta-size-byte-layout
+  (testing "meta-size occupies bytes 4-7 as a big-endian int (canonical JVM/doc layout)"
+    ;; 300 = 0x0000012C  -> bytes 4..7 = [0 0 1 44]
+    (let [b (header-bytes 300)]
+      (is (= 20 (count b)) "header is 20 bytes")
+      (is (= [0 0 1 44] (subvec b 4 8)) "meta-size 300 big-endian at bytes 4-7"))
+    ;; 70000 = 0x00011170 -> bytes 4..7 = [0 1 17 112]
+    (is (= [0 1 17 112] (subvec (header-bytes 70000) 4 8)))
+    ;; a value with a non-zero high byte (offset 4) the old single-byte format dropped
+    ;; 16777216 = 0x01000000 -> [1 0 0 0]
+    (is (= [1 0 0 0] (subvec (header-bytes 16777216) 4 8)))))
+
+(deftest header-meta-size-roundtrip
+  (testing "create-header -> parse-header round-trips meta-size, including > 255"
+    (doseq [ms [0 1 44 200 255 256 300 1000 70000 1000000 16777216 16777217]]
+      (is (= ms (roundtrip-meta-size ms)) (str "meta-size " ms)))))

--- a/test/konserve/storage_layout_test.cljc
+++ b/test/konserve/storage_layout_test.cljc
@@ -40,5 +40,20 @@
 
 (deftest header-meta-size-roundtrip
   (testing "create-header -> parse-header round-trips meta-size, including > 255"
-    (doseq [ms [0 1 44 200 255 256 300 1000 70000 1000000 16777216 16777217]]
+    ;; Note: cljs reserves the pattern [b4≠0, b5=b6=b7=0] (exact multiples of 16MB) for
+    ;; legacy single-byte detection, so those sizes don't round-trip — but a metadata blob
+    ;; is never 16MB, so this only excludes unrealistic sizes.
+    (doseq [ms [0 1 44 200 255 256 300 1000 70000 1000000 16777215 16777217 16777300]]
       (is (= ms (roundtrip-meta-size ms)) (str "meta-size " ms)))))
+
+#?(:cljs
+   (deftest header-legacy-cljs-single-byte-read
+     (testing "parse-header still reads a LEGACY cljs single-byte meta-size (byte 4, bytes 5-7 = 0)"
+       ;; Simulate a header written by the old cljs writer: canonical bytes 0-3, then the
+       ;; meta-size as a single byte at offset 4, bytes 5-19 left zero (Uint8Array zero-init).
+       (doseq [ms [1 44 200 255]]
+         (let [legacy (js/Uint8Array. (sl/create-header sl/default-version (ser/fressian-serializer)
+                                                        null-compressor null-encryptor 0))]
+           (aset legacy 4 ms) (aset legacy 5 0) (aset legacy 6 0) (aset legacy 7 0)
+           (let [[_ _ _ _ parsed _] (sl/parse-header legacy ser/key->serializer)]
+             (is (= ms parsed) (str "legacy single-byte meta-size " ms))))))))


### PR DESCRIPTION
## Problem

The cljs `create-header`/`parse-header` (in `konserve.impl.storage-layout`) write/read the blob-header **meta-size** as a **single byte** at offset 4, whereas the JVM uses a **4-byte big-endian int** (`.putInt`/`.getInt` at offset 4) — matching the documented header layout (`"5-8th Byte = Meta-Size"`).

Same-host cljs was self-consistent, so this went unnoticed (and a plain round-trip test would not catch it — each host is self-consistent on its *own* layout). But it breaks **all JVM ↔ cljs cross-host exchange**:

- **JVM → cljs**: a JVM-written blob with meta-size < 16 MB has its high byte (offset 4) = 0, so cljs reads `meta-size = 0` and returns the **metadata segment as the value** (or computes a negative value-size and throws `RangeError: Buffer.alloc … out of range`).
- It also capped cljs meta-size at 255 bytes even same-host.

Discovered while getting a ClojureScript frontend to read a JVM-written datahike/konserve store (a kabel-style JVM→cljs blob exchange).

## Fix

- cljs `create-header` now writes the meta-size as a 4-byte big-endian int at bytes 4–7 (matching the JVM `.putInt`).
- cljs `parse-header` reads the canonical 4-byte big-endian, **and** transparently still reads the **legacy single-byte** layout (byte 4, bytes 5–7 = 0) — so **existing cljs-only stores keep loading, no migration required**. Disambiguation is unambiguous in practice: a nonzero byte 4 with all lower bytes zero can only be the legacy single-byte size (a real 4-byte meta-size ≥ 16 MB is never a metadata blob). Reads use `*`/`+` rather than bit-ops to avoid JS 32-bit-signed overflow.

## Backward compatibility

- **Old cljs store → new cljs reader**: ✅ (legacy single-byte auto-detected).
- **New cljs writer ↔ JVM**: ✅ (both canonical 4-byte big-endian).
- The only sizes that can't round-trip on cljs are exact multiples of 16 MB with zero low bytes (reserved for legacy detection) — never a real metadata blob.

## Test

Adds `test/konserve/storage_layout_test.cljc`: pins the **exact byte layout** (meta-size big-endian at bytes 4–7, identical on JVM and cljs), round-trips sizes > 255 that the single-byte format truncated, and verifies the cljs reader still decodes a simulated legacy single-byte header. Passes on JVM (`clojure -X:test`) and cljs (`shadow-cljs release node-tests`).
