### PR TITLE
feat(core): per-write metadata channel (immutable marking / anti-entropy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ public
 
 .idea
 *.iml
+
+# internal design scratch (not part of the published library)
+.internal/

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -342,9 +342,13 @@
 
   Returns a map of keys to results (typically true for each key).
 
-  The optional `meta` MAP (4-arity, before the trailing `opts`) is merged into EACH
-  written value's metadata (built fields win), e.g. `{:immutable? true}` to mark the
-  whole batch (the index-node flush) as content-addressed; forwarded on the write-hook.
+  The optional `meta` (4-arity, before the trailing `opts`) is merged into each written
+  value's metadata (built fields win) and forwarded on the write-hook. It is either:
+    - a MAP — applied to EVERY key in the batch (e.g. `{:immutable? true}` to mark a
+      uniformly content-addressed node flush); or
+    - a FN `(fn [key] -> meta-map|nil)` — resolved PER KEY, so one atomic batch can mark
+      some keys immutable and leave others (e.g. a mutable branch-head pointer written in
+      the same `multi-assoc`) unmarked.
 
   Throws an exception if the store doesn't support multi-key operations."
   ([store kvs]
@@ -360,9 +364,12 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-try-
-                (let [mfn    (if meta
-                               (fn [key type old] (clojure.core/merge meta (meta-update key type old)))
-                               meta-update)
+                (let [mfn    (cond
+                               ;; per-key meta: `(meta key)` (nil ⇒ just the built meta)
+                               (fn? meta) (fn [key type old] (clojure.core/merge (meta key) (meta-update key type old)))
+                               ;; static meta: applied to every key
+                               meta       (fn [key type old] (clojure.core/merge meta (meta-update key type old)))
+                               :else      meta-update)
                       result (try
                                (<?- (-multi-assoc store kvs mfn opts))
                                (catch #?(:clj Exception :cljs js/Error) e
@@ -378,7 +385,9 @@
                                       (throw e))
                                     :cljs (throw e))))]
                   (invoke-write-hooks! store (cond-> {:api-op :multi-assoc :kvs kvs}
-                                               meta (clojure.core/assoc :meta meta)))
+                                               ;; per-key fn forwarded as :meta-fn, static map as :meta
+                                               (fn? meta)                  (clojure.core/assoc :meta-fn meta)
+                                               (and meta (not (fn? meta))) (clojure.core/assoc :meta meta)))
                   result)))))
 
 (defn dissoc

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -329,6 +329,15 @@
                          (throw e))
                        :cljs (throw e))))))))
 
+(defn uniform-meta
+  "Build a per-key meta map applying the same `meta` to every key — a convenience
+   for `multi-assoc`'s per-key `meta` when a whole batch shares one annotation:
+   `(multi-assoc store nodes (uniform-meta nodes {:immutable? true}) opts)`.
+   `kvs` may be the kv-map itself or a seq of keys."
+  [kvs meta]
+  (let [ks (if (map? kvs) (clojure.core/keys kvs) kvs)]
+    (zipmap ks (clojure.core/repeat meta))))
+
 (defn multi-assoc
   "Atomically associates multiple key-value pairs with flat keys.
   Takes a map of keys to values and stores them in a single atomic transaction.
@@ -342,13 +351,13 @@
 
   Returns a map of keys to results (typically true for each key).
 
-  The optional `meta` (4-arity, before the trailing `opts`) is merged into each written
-  value's metadata (built fields win) and forwarded on the write-hook. It is either:
-    - a MAP — applied to EVERY key in the batch (e.g. `{:immutable? true}` to mark a
-      uniformly content-addressed node flush); or
-    - a FN `(fn [key] -> meta-map|nil)` — resolved PER KEY, so one atomic batch can mark
-      some keys immutable and leave others (e.g. a mutable branch-head pointer written in
-      the same `multi-assoc`) unmarked.
+  The optional `meta` (4-arity, before the trailing `opts`) is a PER-KEY map
+  `{key -> meta-map}`, pure data so the whole map is forwarded verbatim on the write-hook
+  (a consumer like konserve-sync can relay/serialize it). Each written value's metadata is
+  merged with `(get meta key)` (built `{:key :type :last-write}` fields win). Keys absent
+  from `meta` get no extra metadata, so one atomic batch can mark some keys immutable
+  (content-addressed nodes) and leave others (a mutable branch-head pointer) unmarked. Use
+  `uniform-meta` for the all-keys-same case.
 
   Throws an exception if the store doesn't support multi-key operations."
   ([store kvs]
@@ -364,12 +373,10 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-try-
-                (let [mfn    (cond
-                               ;; per-key meta: `(meta key)` (nil ⇒ just the built meta)
-                               (fn? meta) (fn [key type old] (clojure.core/merge (meta key) (meta-update key type old)))
-                               ;; static meta: applied to every key
-                               meta       (fn [key type old] (clojure.core/merge meta (meta-update key type old)))
-                               :else      meta-update)
+                (let [mfn    (if meta
+                               ;; per-key meta map: `(get meta key)` (nil ⇒ just the built meta)
+                               (fn [key type old] (clojure.core/merge (clojure.core/get meta key) (meta-update key type old)))
+                               meta-update)
                       result (try
                                (<?- (-multi-assoc store kvs mfn opts))
                                (catch #?(:clj Exception :cljs js/Error) e
@@ -385,9 +392,8 @@
                                       (throw e))
                                     :cljs (throw e))))]
                   (invoke-write-hooks! store (cond-> {:api-op :multi-assoc :kvs kvs}
-                                               ;; per-key fn forwarded as :meta-fn, static map as :meta
-                                               (fn? meta)                  (clojure.core/assoc :meta-fn meta)
-                                               (and meta (not (fn? meta))) (clojure.core/assoc :meta meta)))
+                                               ;; per-key meta map forwarded verbatim (pure data)
+                                               meta (clojure.core/assoc :meta meta)))
                   result)))))
 
 (defn dissoc

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -192,16 +192,24 @@
 (defn update-in
   "Updates a position described by key-vec by applying up-fn and storing
   the result atomically. Returns a vector [old new] of the previous
-  value and the result of applying up-fn (the newly stored value)."
+  value and the result of applying up-fn (the newly stored value).
+
+  The optional `meta-up-fn` (5-arity, before the trailing `opts`) is
+  `(fn [built-meta] -> meta)`, transforming the value's default metadata — the general
+  metadata form (cf. `assoc`'s `meta` map). `opts` stays last."
   ([store key-vec up-fn]
-   (update-in store key-vec up-fn {:sync? false}))
+   (update-in store key-vec up-fn nil {:sync? false}))
   ([store key-vec up-fn opts]
+   (update-in store key-vec up-fn nil opts))
+  ([store key-vec up-fn meta-up-fn opts]
    (log/trace :konserve/update-in {:key-vec key-vec})
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
                 store (first key-vec)
-                (let [[old-val new-val :as result] (<?- (-update-in store key-vec (partial meta-update (first key-vec) :edn) up-fn opts))]
+                (let [base (partial meta-update (first key-vec) :edn)
+                      mfn  (if meta-up-fn (fn [old] (meta-up-fn (base old))) base)
+                      [old-val new-val :as result] (<?- (-update-in store key-vec mfn up-fn opts))]
                   (invoke-write-hooks! store {:api-op :update-in
                                               :key (first key-vec)
                                               :key-vec key-vec
@@ -215,23 +223,35 @@
   the result atomically. Returns a vector [old new] of the previous
   value and the result of applying up-fn (the newly stored value)."
   ([store key fn]
-   (update store key fn {:sync? false}))
+   (update store key fn nil {:sync? false}))
   ([store key fn opts]
+   (update store key fn nil opts))
+  ([store key fn meta-up-fn opts]
    (log/trace :konserve/update {:key key})
-   (update-in store [key] fn opts)))
+   (update-in store [key] fn meta-up-fn opts)))
 
 (defn assoc-in
   "Associates the key-vec to the value, any missing collections for
-  the key-vec (nested maps and vectors) are newly created."
+  the key-vec (nested maps and vectors) are newly created.
+
+  The optional `meta-up-fn` (5-arity, before the trailing `opts`) is
+  `(fn [built-meta] -> meta)` — it TRANSFORMS the value's default metadata (the built
+  `{:key :type :last-write}`). This is the general form of `assoc`'s `meta` map (a map
+  is just the merge-transform), exposed here because nested writes may derive metadata
+  from the built fields. `opts` stays last and purely runtime."
   ([store key-vec val]
-   (assoc-in store key-vec val {:sync? false}))
+   (assoc-in store key-vec val nil {:sync? false}))
   ([store key-vec val opts]
+   (assoc-in store key-vec val nil opts))
+  ([store key-vec val meta-up-fn opts]
    (log/trace :konserve/assoc-in {:key-vec key-vec})
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
                 store (first key-vec)
-                (let [result (<?- (-assoc-in store key-vec (partial meta-update (first key-vec) :edn) val opts))]
+                (let [base   (partial meta-update (first key-vec) :edn)
+                      mfn    (if meta-up-fn (fn [old] (meta-up-fn (base old))) base)
+                      result (<?- (-assoc-in store key-vec mfn val opts))]
                   (invoke-write-hooks! store {:api-op :assoc-in
                                               :key (first key-vec)
                                               :key-vec key-vec
@@ -240,19 +260,30 @@
 
 (defn assoc
   "Associates the key to the value. This is a simple top-level overwrite
-   and does not require locking for MVCC stores. For nested paths, use assoc-in."
+   and does not require locking for MVCC stores. For nested paths, use assoc-in.
+
+   The optional `meta` MAP (5-arity, before the trailing `opts`) is merged into the
+   value's stored metadata — the built `{:key :type :last-write}` fields win on
+   conflict, so `meta` is additive. Use `{:immutable? true}` to mark a content-
+   addressed (write-once) value: it is recorded durably AND forwarded on the write-
+   hook event, so a consumer (konserve-sync) can skip re-storing a value it already
+   has. `opts` stays last and purely runtime."
   ([store key val]
-   (assoc store key val {:sync? false}))
+   (assoc store key val nil {:sync? false}))
   ([store key val opts]
+   (assoc store key val nil opts))
+  ([store key val meta opts]
    (log/trace :konserve/assoc {:key key})
    (async+sync (:sync? opts)
                *default-sync-translation*
                (maybe-go-locked
                 store key
-                (let [result (<?- (-assoc-in store [key] (partial meta-update key :edn) val opts))]
-                  (invoke-write-hooks! store {:api-op :assoc
-                                              :key key
-                                              :value val})
+                (let [mfn    (if meta
+                               (fn [old] (clojure.core/merge meta (meta-update key :edn old)))
+                               (partial meta-update key :edn))
+                      result (<?- (-assoc-in store [key] mfn val opts))]
+                  (invoke-write-hooks! store (cond-> {:api-op :assoc :key key :value val}
+                                               meta (clojure.core/assoc :meta meta)))
                   result)))))
 
 (defn multi-get
@@ -311,10 +342,16 @@
 
   Returns a map of keys to results (typically true for each key).
 
+  The optional `meta` MAP (4-arity, before the trailing `opts`) is merged into EACH
+  written value's metadata (built fields win), e.g. `{:immutable? true}` to mark the
+  whole batch (the index-node flush) as content-addressed; forwarded on the write-hook.
+
   Throws an exception if the store doesn't support multi-key operations."
   ([store kvs]
-   (multi-assoc store kvs {:sync? false}))
+   (multi-assoc store kvs nil {:sync? false}))
   ([store kvs opts]
+   (multi-assoc store kvs nil opts))
+  ([store kvs meta opts]
    (log/trace :konserve/multi-assoc {:key-count (count kvs)})
    (when-not (multi-key-capable? store)
      (throw (#?(:clj ex-info :cljs js/Error.) "Store does not support multi-key operations"
@@ -323,8 +360,11 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-try-
-                (let [result (try
-                               (<?- (-multi-assoc store kvs meta-update opts))
+                (let [mfn    (if meta
+                               (fn [key type old] (clojure.core/merge meta (meta-update key type old)))
+                               meta-update)
+                      result (try
+                               (<?- (-multi-assoc store kvs mfn opts))
                                (catch #?(:clj Exception :cljs js/Error) e
                                  ;; Backend might throw an exception indicating it doesn't support multi-key operations
                                  ;; even though the store implements the protocol
@@ -337,8 +377,8 @@
                                                        :reason (:reason (ex-data e))}))
                                       (throw e))
                                     :cljs (throw e))))]
-                  (invoke-write-hooks! store {:api-op :multi-assoc
-                                              :kvs kvs})
+                  (invoke-write-hooks! store (cond-> {:api-op :multi-assoc :kvs kvs}
+                                               meta (clojure.core/assoc :meta meta)))
                   result)))))
 
 (defn dissoc

--- a/test/konserve/value_metadata_test.cljc
+++ b/test/konserve/value_metadata_test.cljc
@@ -1,0 +1,71 @@
+(ns konserve.value-metadata-test
+  "The per-write metadata channel: a static `meta` map on `assoc`/`multi-assoc`
+   (merged into the stored metadata + forwarded on the write-hook), and a general
+   `meta-up-fn` transform on `assoc-in`/`update-in`. Backward-compatible (3/4 arities
+   unchanged); `opts` stays last."
+  (:require [clojure.test :refer [deftest is testing]]
+            [konserve.core :as k]))
+
+(defn- mem []
+  (let [cfg {:backend :memory :id (random-uuid)}]
+    (k/create-store cfg {:sync? true})
+    (k/connect-store cfg {:sync? true})))
+
+(deftest assoc-meta-map
+  (testing "assoc 5-arity merges meta into stored metadata + forwards it on the hook"
+    (let [store  (mem)
+          events (atom [])]
+      (k/add-write-hook! store :t (fn [e] (swap! events conj e)))
+      ;; mutable (4-arity) — no meta, no :immutable?, hook has no :meta
+      (k/assoc store :k1 1 {:sync? true})
+      (is (nil? (:immutable? (k/get-meta store :k1 nil {:sync? true}))))
+      (is (nil? (:meta (last @events))) "mutable write's hook event has no :meta")
+      ;; immutable (5-arity, meta before opts)
+      (k/assoc store :k2 2 {:immutable? true} {:sync? true})
+      (let [m (k/get-meta store :k2 nil {:sync? true})]
+        (is (true? (:immutable? m)) "meta recorded durably")
+        (is (= :edn (:type m)) "built fields (:type) preserved — they win on conflict")
+        (is (some? (:last-write m)) "built :last-write preserved"))
+      (is (= {:immutable? true} (:meta (last @events))) "hook forwards :meta")
+      (is (= 2 (k/get store :k2 nil {:sync? true})) "value stored correctly"))))
+
+(deftest multi-assoc-meta-map
+  (testing "multi-assoc 4-arity applies meta to EVERY value in the batch"
+    (let [store  (mem)
+          events (atom [])]
+      (k/add-write-hook! store :t (fn [e] (swap! events conj e)))
+      (k/multi-assoc store {:a 1 :b 2} {:immutable? true} {:sync? true})
+      (is (true? (:immutable? (k/get-meta store :a nil {:sync? true}))))
+      (is (true? (:immutable? (k/get-meta store :b nil {:sync? true}))))
+      (is (= {:immutable? true} (:meta (last @events))) "batch hook forwards :meta"))))
+
+(deftest assoc-in-meta-up-fn
+  (testing "assoc-in 5-arity: meta-up-fn TRANSFORMS the built metadata (the general form)"
+    (let [store (mem)]
+      (k/assoc-in store [:x] 1
+                  (fn [m] (clojure.core/assoc m :immutable? true :tag :node))
+                  {:sync? true})
+      (let [m (k/get-meta store :x nil {:sync? true})]
+        (is (true? (:immutable? m)))
+        (is (= :node (:tag m)) "arbitrary metadata via the transform")
+        (is (= :edn (:type m)) "default metadata still built (transform composes on top)")))))
+
+(deftest update-in-meta-up-fn
+  (testing "update-in 5-arity meta-up-fn transforms metadata while updating the value"
+    (let [store (mem)]
+      (k/assoc store :c 1 {:sync? true})
+      (k/update-in store [:c] inc (fn [m] (clojure.core/assoc m :immutable? true)) {:sync? true})
+      (is (= 2 (k/get store :c nil {:sync? true})))
+      (is (true? (:immutable? (k/get-meta store :c nil {:sync? true})))))))
+
+(deftest backward-compat
+  (testing "existing 3/4 arities are byte-for-byte unchanged (no meta, no :meta on hook)"
+    (let [store  (mem)
+          events (atom [])]
+      (k/add-write-hook! store :t (fn [e] (swap! events conj e)))
+      (k/assoc store :a 1 {:sync? true})         ; 4-arity opts
+      (k/assoc-in store [:b] 2 {:sync? true})     ; 4-arity opts
+      (k/update store :a inc {:sync? true})       ; 4-arity opts
+      (is (= 2 (k/get store :a nil {:sync? true})))
+      (is (= 2 (k/get store :b nil {:sync? true})))
+      (is (every? #(nil? (:meta %)) @events) "no :meta on any hook event"))))

--- a/test/konserve/value_metadata_test.cljc
+++ b/test/konserve/value_metadata_test.cljc
@@ -39,6 +39,23 @@
       (is (true? (:immutable? (k/get-meta store :b nil {:sync? true}))))
       (is (= {:immutable? true} (:meta (last @events))) "batch hook forwards :meta"))))
 
+(deftest multi-assoc-meta-per-key-fn
+  (testing "multi-assoc 4-arity accepts a per-key meta FN — mark some keys, not others
+            (one atomic batch with immutable nodes + a mutable pointer)"
+    (let [store  (mem)
+          events (atom [])]
+      (k/add-write-hook! store :t (fn [e] (swap! events conj e)))
+      (k/multi-assoc store {:node1 1 :node2 2 :branch 3}
+                     (fn [k] (when (not= k :branch) {:immutable? true}))   ; per-key
+                     {:sync? true})
+      (is (true? (:immutable? (k/get-meta store :node1 nil {:sync? true}))) ":node1 immutable")
+      (is (true? (:immutable? (k/get-meta store :node2 nil {:sync? true}))) ":node2 immutable")
+      (is (nil?  (:immutable? (k/get-meta store :branch nil {:sync? true}))) ":branch left mutable")
+      (let [mf (:meta-fn (last @events))]
+        (is (fn? mf) "hook event carries a per-key :meta-fn (not :meta)")
+        (is (= {:immutable? true} (mf :node1)))
+        (is (nil? (mf :branch)))))))
+
 (deftest assoc-in-meta-up-fn
   (testing "assoc-in 5-arity: meta-up-fn TRANSFORMS the built metadata (the general form)"
     (let [store (mem)]

--- a/test/konserve/value_metadata_test.cljc
+++ b/test/konserve/value_metadata_test.cljc
@@ -29,32 +29,34 @@
       (is (= {:immutable? true} (:meta (last @events))) "hook forwards :meta")
       (is (= 2 (k/get store :k2 nil {:sync? true})) "value stored correctly"))))
 
-(deftest multi-assoc-meta-map
-  (testing "multi-assoc 4-arity applies meta to EVERY value in the batch"
+(deftest multi-assoc-uniform-meta
+  (testing "multi-assoc 4-arity with a per-key map covering every key (via uniform-meta)"
     (let [store  (mem)
-          events (atom [])]
+          events (atom [])
+          kvs    {:a 1 :b 2}]
       (k/add-write-hook! store :t (fn [e] (swap! events conj e)))
-      (k/multi-assoc store {:a 1 :b 2} {:immutable? true} {:sync? true})
+      (k/multi-assoc store kvs (k/uniform-meta kvs {:immutable? true}) {:sync? true})
       (is (true? (:immutable? (k/get-meta store :a nil {:sync? true}))))
       (is (true? (:immutable? (k/get-meta store :b nil {:sync? true}))))
-      (is (= {:immutable? true} (:meta (last @events))) "batch hook forwards :meta"))))
+      (is (= {:a {:immutable? true} :b {:immutable? true}} (:meta (last @events)))
+          "batch hook forwards the per-key :meta map as pure data"))))
 
-(deftest multi-assoc-meta-per-key-fn
-  (testing "multi-assoc 4-arity accepts a per-key meta FN — mark some keys, not others
+(deftest multi-assoc-meta-per-key
+  (testing "multi-assoc 4-arity takes a per-key meta MAP — mark some keys, not others
             (one atomic batch with immutable nodes + a mutable pointer)"
     (let [store  (mem)
           events (atom [])]
       (k/add-write-hook! store :t (fn [e] (swap! events conj e)))
       (k/multi-assoc store {:node1 1 :node2 2 :branch 3}
-                     (fn [k] (when (not= k :branch) {:immutable? true}))   ; per-key
+                     {:node1 {:immutable? true} :node2 {:immutable? true}}  ; :branch absent
                      {:sync? true})
       (is (true? (:immutable? (k/get-meta store :node1 nil {:sync? true}))) ":node1 immutable")
       (is (true? (:immutable? (k/get-meta store :node2 nil {:sync? true}))) ":node2 immutable")
       (is (nil?  (:immutable? (k/get-meta store :branch nil {:sync? true}))) ":branch left mutable")
-      (let [mf (:meta-fn (last @events))]
-        (is (fn? mf) "hook event carries a per-key :meta-fn (not :meta)")
-        (is (= {:immutable? true} (mf :node1)))
-        (is (nil? (mf :branch)))))))
+      (let [m (:meta (last @events))]
+        (is (map? m) "hook event carries a pure-data per-key :meta map (no closures)")
+        (is (= {:immutable? true} (get m :node1)))
+        (is (nil? (get m :branch)))))))
 
 (deftest assoc-in-meta-up-fn
   (testing "assoc-in 5-arity: meta-up-fn TRANSFORMS the built metadata (the general form)"


### PR DESCRIPTION
## What

Lets a write attach metadata to a value, keeping `opts` purely ephemeral and the
hot blind-overwrite path read-free. This is the substrate for echo-free bidirectional
sync (konserve-sync can skip re-storing an immutable value it already has) and the
shared correctness primitive for MST/prolly anti-entropy (content nodes are write-once).

## API

A 5-arity with `meta` positioned **before** the trailing `opts`, disambiguated by
**arity count** (no 4-arity-with-meta, so the existing 4-arity stays `opts`):

- **`assoc` / `multi-assoc`** (top-level overwrites): a static `meta` **map**, merged
  into the value's stored metadata (built `{:key :type :last-write}` fields win → meta
  is additive), and forwarded on the write-hook event as `:meta`.
  ```clojure
  (k/assoc store cid db {:immutable? true} {:sync? true})   ; content-addressed → immutable
  (k/assoc store :db db {:sync? true})                      ; 4-arity, mutable, unchanged
  ```
- **`assoc-in` / `update-in` / `update`** (nested/transforming): a general
  **`meta-up-fn`** `(fn [built-meta] -> meta)` — the transform of which the map is the
  merge special case.

## Compatibility

- 3/4-arities are byte-for-byte unchanged.
- **Backends untouched** (defaults / lmdb / s3): the protocol already threads a
  `meta-up-fn`; `core` just builds a richer one. lmdb doesn't fire its own hooks.
- `bassoc` left as-is for now (binary, not a content-node path).

## Tests

`konserve.value-metadata-test` covers all five fns + hook forwarding + backward-compat
(18 assertions). No regression: memory / store / storage-layout / filestore suites
green (48 tests / 813 assertions).