### PR TITLE
fix(core): reclaim per-key locks to bound :locks registry growth

### DIFF
--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -73,22 +73,101 @@
   [store]
   (-lock-free? store))
 
-(defn get-lock [{:keys [locks] :as store} key]
+;; --- In-process per-key lock registry ----------------------------------------
+;; SOLID via Clojure protocols + records: callers (get-lock / release-lock and the
+;; locked / go-locked macros) depend on the PLockRegistry abstraction (DIP), not on
+;; the concrete map; the locking strategy is a substitutable record (LSP) and new
+;; strategies are added without touching callers (OCP).
+
+(defprotocol PLockRegistry
+  "Per-key in-process lock lifecycle. A lock is a core.async channel used as a
+   binary semaphore (holds one :unlocked token while free)."
+  (-acquire-lock [this key]
+    "Register intent on `key` and return its unlocked semaphore channel.")
+  (-release-lock [this key]
+    "Release `key`; reclaim the registry entry once no holder remains. Returns nil."))
+
+;; Pure registry calculations — no I/O, trivially unit-testable ----------------
+
+(defn- unlocked-chan
+  "A fresh channel preloaded with one :unlocked semaphore token."
+  []
+  (let [c (chan)]
+    (put! c :unlocked)
+    c))
+
+(defn- fresh-lock
+  "A new refcounted registry entry: an unlocked lock held by one acquirer."
+  []
+  {:ch (unlocked-chan) :n 1})
+
+(defn- acquire-entry
+  "Bump the refcount of `key`'s lock in registry map `m`, inserting `entry` when
+   absent. Pure."
+  [m key entry]
+  (if-let [e (clojure.core/get m key)]
+    (clojure.core/assoc m key (clojure.core/update e :n inc))
+    (clojure.core/assoc m key entry)))
+
+(defn- release-entry
+  "Drop one refcount for `key` in registry map `m`, removing the entry when the
+   last holder releases. Pure."
+  [m key]
+  (if-let [e (clojure.core/get m key)]
+    (if (<= (:n e) 1)
+      (clojure.core/dissoc m key)
+      (clojure.core/assoc m key (clojure.core/update e :n dec)))
+    m))
+
+;; Locking strategies — substitutable PLockRegistry records --------------------
+
+(defrecord RefcountedLockRegistry [locks]
+  ;; `locks`: atom of {key -> {:ch chan :n refcount}}. The refcount is bumped on
+  ;; acquire (before the caller parks) and dropped on release, so the entry
+  ;; survives every concurrent waiter and is reclaimed only at zero — bounding the
+  ;; registry instead of leaking one channel per distinct key for the store's life.
+  PLockRegistry
+  (-acquire-lock [_ key]
+    (:ch (clojure.core/get (swap! locks acquire-entry key (fresh-lock)) key)))
+  (-release-lock [_ key]
+    (swap! locks release-entry key)
+    nil))
+
+(defrecord LockFreeRegistry []
+  ;; MVCC backends (LMDB, …) serialize internally, so locks need not be tracked:
+  ;; hand out a throwaway unlocked channel and register nothing.
+  PLockRegistry
+  (-acquire-lock [_ _key] (unlocked-chan))
+  (-release-lock [_ _key] nil))
+
+(def ^:private lock-free-registry
+  "Stateless singleton shared by every lock-free store."
+  (->LockFreeRegistry))
+
+(defn- store-lock-registry
+  "Select `store`'s lock strategy (DIP: returns a PLockRegistry)."
+  [store]
   (if (lock-free? store)
-    ;; For lock-free stores, create a fresh unlocked channel
-    ;; This is used by operations that still need locking (assoc-in, update-in)
-    (let [c (chan)]
-      (put! c :unlocked)
-      c)
-    ;; Normal case: get or create persistent lock
-    (or (clojure.core/get @locks key)
-        (let [c (chan)]
-          (put! c :unlocked)
-          (clojure.core/get (swap! locks (fn [old]
-                                           (log/trace :konserve/creating-lock {:key key})
-                                           (if (old key) old
-                                               (clojure.core/assoc old key c))))
-                            key)))))
+    lock-free-registry
+    (->RefcountedLockRegistry (:locks store))))
+
+;; Public API — single level of abstraction, delegate to the strategy ----------
+
+(defn get-lock
+  "Acquire `store`/`key`'s in-process lock channel, registering intent. MUST be
+   paired with `release-lock` so the entry is reclaimed when the last holder
+   releases — otherwise the registry grows one channel per distinct key for the
+   store's lifetime (unbounded heap retention). Lock-free stores get a throwaway
+   channel."
+  [store key]
+  (-acquire-lock (store-lock-registry store) key))
+
+(defn release-lock
+  "Release `store`/`key`'s in-process lock; reclaim the registry entry when no
+   holder remains. No-op for lock-free stores / unregistered keys. Paired with
+   `get-lock`."
+  [store key]
+  (-release-lock (store-lock-registry store) key))
 
 (defn wait [lock]
   #?(:clj (while (not (poll! lock))
@@ -98,25 +177,31 @@
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defmacro locked [store key & code]
-  `(let [l# (get-lock ~store ~key)]
+  `(let [s# ~store
+         k# ~key
+         l# (get-lock s# k#)]
      (try
        (wait l#)
-       (log/trace :konserve/acquired-spin-lock {:key ~key})
+       (log/trace :konserve/acquired-spin-lock {:key k#})
        ~@code
        (finally
-         (log/trace :konserve/releasing-spin-lock {:key ~key})
-         (put! l# :unlocked)))))
+         (log/trace :konserve/releasing-spin-lock {:key k#})
+         (put! l# :unlocked)
+         (release-lock s# k#)))))
 
 (defmacro go-locked [store key & code]
   `(go-try-
-    (let [l# (get-lock ~store ~key)]
+    (let [s# ~store
+          k# ~key
+          l# (get-lock s# k#)]
       (try
         (<?- l#)
-        (log/trace :konserve/acquired-go-lock {:key ~key})
+        (log/trace :konserve/acquired-go-lock {:key k#})
         ~@code
         (finally
-          (log/trace :konserve/releasing-go-lock {:key ~key})
-          (put! l# :unlocked))))))
+          (log/trace :konserve/releasing-go-lock {:key k#})
+          (put! l# :unlocked)
+          (release-lock s# k#))))))
 
 ;; Optional locking macros - skip locking for lock-free stores (MVCC backends)
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}

--- a/test/konserve/lock_test.clj
+++ b/test/konserve/lock_test.clj
@@ -1,0 +1,67 @@
+(ns konserve.lock-test
+  "Regression tests for konserve.core in-process per-key lock lifecycle.
+
+   Before the refcount fix, `konserve.core/get-lock` assoc'd a persistent lock
+   channel per key into the store's `:locks` atom and NEVER removed it, so
+   `:locks` grew one core.async ManyToManyChannel per DISTINCT key for the whole
+   lifetime of the store (unbounded heap retention — acutely visible with
+   datahike's content-addressed key space, which produced ~82k retained
+   channels on a single long-lived store)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.core.async :refer [<!! <! timeout]]
+            [konserve.core :refer [go-locked get-lock release-lock]]
+            [konserve.memory :refer [new-mem-store]]))
+
+(deftest locks-reclaimed-after-use
+  (testing "go-locked reclaims its :locks entry instead of leaking it"
+    (let [store (<!! (new-mem-store))
+          locks (:locks store)]
+      (is (zero? (count @locks)) "baseline: empty lock registry")
+
+      (testing "single op reclaims its lock entry"
+        (<!! (go-locked store :k :work))
+        (is (zero? (count @locks))))
+
+      (testing "repeated ops on ONE key do not accumulate"
+        (dotimes [_ 100] (<!! (go-locked store :k :work)))
+        (is (zero? (count @locks))))
+
+      (testing "many DISTINCT keys do not accumulate (the heap-leak shape)"
+        (dotimes [i 500] (<!! (go-locked store (str "key-" i) :work)))
+        (is (zero? (count @locks)))))))
+
+(deftest get-release-lock-refcount
+  (testing "explicit get-lock/release-lock bracket reclaims only at refcount 0"
+    (let [store (<!! (new-mem-store))
+          locks (:locks store)]
+      (get-lock store :k)
+      (get-lock store :k)                       ;; two concurrent holders of :k
+      (is (= 1 (count @locks)))
+      (is (= 2 (:n (get @locks :k))))
+      (release-lock store :k)
+      (is (= 1 (count @locks)) "entry survives while one holder remains")
+      (is (= 1 (:n (get @locks :k))))
+      (release-lock store :k)
+      (is (zero? (count @locks)) "entry reclaimed when the last holder releases")
+      (release-lock store :k)                   ;; over-release is a safe no-op
+      (is (zero? (count @locks))))))
+
+(deftest mutual-exclusion-preserved-under-contention
+  (testing "refcounted lock still serializes concurrent ops on the same key"
+    (let [store   (<!! (new-mem-store))
+          locks   (:locks store)
+          counter (atom 0)
+          n       200
+          ;; Each op does a non-atomic read-modify-write while holding the lock,
+          ;; PARKING (<! timeout) inside the critical section to widen the race
+          ;; window. If a premature dissoc let two ops hold :shared at once,
+          ;; updates would be lost and the final count would be < n.
+          ops (mapv (fn [_]
+                      (go-locked store :shared
+                                 (let [v @counter]
+                                   (<! (timeout 0))
+                                   (reset! counter (inc v)))))
+                    (range n))]
+      (doseq [op ops] (<!! op))
+      (is (= n @counter) "no lost updates: mutual exclusion held under contention")
+      (is (zero? (count @locks)) "all locks reclaimed after contention"))))


### PR DESCRIPTION
## Problem

`konserve.core/get-lock` registers a per-key lock by `assoc`-ing a fresh
core.async channel into the store's `:locks` atom **and never removes it**:

```clojure
(or (clojure.core/get @locks key)
    (let [c (chan)]
      (put! c :unlocked)
      (clojure.core/get (swap! locks (fn [old]
                                       (if (old key) old
                                           (clojure.core/assoc old key c))))
                        key)))
```

So `:locks` grows **one `ManyToManyChannel` per distinct key** for the entire
lifetime of the store. For a store with a bounded, reused key set this is
invisible; for a store whose key space is effectively unbounded it is a slow,
unbounded heap leak.

I hit this with a long-lived [datahike](https://github.com/replikativ/datahike)
store: its content-addressed key space means almost every write touches a *new*
key, so the lock registry never stops growing. A live heap walk attributed
**~82,000 retained channels** to a single `DefaultStore`'s `:locks` map — none
of them reclaimable, because nothing ever dissociates a key.

## Root cause

Locks were treated as *permanent per-key singletons* when they only need to live
as long as there is an in-flight holder/waiter on that key. Mutual exclusion
requires a shared channel **only while operations overlap**; once the last
holder releases, the entry is dead weight.

## Fix

Refcount each per-key lock and reclaim it at zero:

- `get-lock` bumps the key's refcount (inserting a fresh unlocked channel when
  absent) and returns its channel.
- A new, paired `release-lock` drops the refcount and dissociates the entry when
  the last holder leaves.
- `locked` / `go-locked` call `release-lock` in their `finally`, right after
  handing the `:unlocked` token back.

Because the refcount is incremented inside the same `swap!` that hands out the
channel (before the caller parks), every concurrent waiter is counted and they
all share the **same** channel — mutual exclusion is unchanged. The entry is
removed only when no holder remains, so the registry is bounded by *concurrent*
key usage instead of *cumulative distinct keys*.

### Design (SOLID via protocols + records)

The selection of locking behavior is now a `PLockRegistry` abstraction with two
substitutable strategies, so callers depend on the protocol rather than on the
concrete map:

- `RefcountedLockRegistry` — default stores; the refcounted `:locks` atom.
- `LockFreeRegistry` — MVCC backends (`lock-free?` true); hands out a throwaway
  unlocked channel and registers nothing, exactly as before.

The registry-mutation helpers (`acquire-entry` / `release-entry`) are pure
functions, unit-tested directly.

### Compatibility

- `get-lock`'s signature and return contract are unchanged.
- `release-lock` is **additive**. Any external caller that uses `get-lock`
  without the macros keeps working (it simply won't reclaim, i.e. the old
  behavior). All in-tree callers go through `locked` / `go-locked` /
  `maybe-locked` / `maybe-go-locked`, which now pair correctly.
- Lock-free stores are behaviorally identical to before.

## Tests

New `konserve.lock-test`:

- `locks-reclaimed-after-use` — single op, 100 repeats on one key, and 500
  distinct keys all leave `:locks` empty (the leak shape).
- `get-release-lock-refcount` — two holders → entry survives one release,
  reclaimed on the second; over-release is a safe no-op.
- `mutual-exclusion-preserved-under-contention` — 200 concurrent `go-locked`
  ops on one key, each doing a non-atomic read-modify-write while **parked**
  (`<! (timeout 0)`) inside the critical section. A premature reclaim would lose
  updates; the final count must equal 200.

Full JVM suite green with the change: **68 tests / 1124 assertions, 0 failures,
0 errors** (`clojure -M:test`).

## Note (pre-existing, not introduced here)

A single key with **>1024 simultaneously parked waiters** will hit core.async's
1024-pending-operations-per-channel assertion. This is unchanged by this PR —
the original code also shares one channel per key — but worth stating since the
contention test exercises the parked-waiter path.

## Alternatives considered

If the protocol/record split is more abstraction than you'd like for this
module, the same refcount fix collapses cleanly into the two existing functions
plus the `finally` release. Happy to trim it down to whatever shape you prefer.
