### PR TITLE
test(lock): randomized concurrency stress for per-key lock reclaim

### DIFF
--- a/test/konserve/lock_test.clj
+++ b/test/konserve/lock_test.clj
@@ -8,8 +8,8 @@
    datahike's content-addressed key space, which produced ~82k retained
    channels on a single long-lived store)."
   (:require [clojure.test :refer [deftest is testing]]
-            [clojure.core.async :refer [<!! <! timeout]]
-            [konserve.core :refer [go-locked get-lock release-lock]]
+            [clojure.core.async :refer [<!! <! go timeout alts!!]]
+            [konserve.core :refer [go-locked get-lock release-lock locked]]
             [konserve.memory :refer [new-mem-store]]))
 
 (deftest locks-reclaimed-after-use
@@ -65,3 +65,107 @@
       (doseq [op ops] (<!! op))
       (is (= n @counter) "no lost updates: mutual exclusion held under contention")
       (is (zero? (count @locks)) "all locks reclaimed after contention"))))
+
+;; -----------------------------------------------------------------------------
+;; Randomized concurrency stress.
+;;
+;; The reclaim mechanism is konserve's per-key isolation (the "I" in ACID, given a
+;; single-writer runtime). A regression could surface three ways, and this test is
+;; built to make each one observable:
+;;
+;;   1. Lost mutual exclusion — a reclaimed entry hands a fresh channel to a 2nd
+;;      writer while the key is still held → two writers in one CS at once.
+;;   2. Premature reclaim / lost wakeup — a channel a waiter is parked on gets
+;;      discarded → that waiter never wakes → deadlock.
+;;   3. The original leak — the registry never shrinks.
+;;
+;; Oracles (each DETERMINISTIC for a correct impl under ANY interleaving, so a
+;; correct impl never flakes; a broken one fails with high probability):
+;;   - per-key MAX OCCUPANCY must be 1            — direct witness of (1)
+;;   - a NON-ATOMIC per-key counter must equal    — any single lost update fails;
+;;     the op count                                 a sensitive amplifier of (1)
+;;   - every op must finish within a wall budget  — catches (2) instead of hanging
+;;   - :locks must be empty at quiescence         — catches (3) and over-reclaim
+;;
+;; Fault-detection is maximized by: short critical sections that PARK mid-way to
+;; widen the interleaving window; staggered arrivals (seeded jitter) so a key
+;; oscillates idle↔busy across the n=0 reclaim boundary; contention regimes from
+;; one hot key to a spray of single-use keys; and BOTH acquire paths (async
+;; `go-locked` parking + sync `locked` spinning) on the same keys.
+
+(defn- stress-round
+  "Run one randomized round against a fresh `store`. Returns a result map of the
+   four oracles. `sync-every` n>0 routes every n-th op through the sync `locked`
+   path (real thread, spin-acquire); 0 = all async."
+  [store {:keys [keys-n per-key sync-every round-timeout-ms seed]}]
+  (let [locks    (:locks store)
+        rng      (java.util.Random. (long seed))
+        jit      (fn [] (.nextInt rng 2))                 ; 0..1 ms, seeded
+        occ      (atom {})                                ; key -> # in CS now
+        max-occ  (atom 0)
+        counter  (atom {})                                ; key -> non-atomic count
+        enter    (fn [k] (swap! max-occ max (get (swap! occ update k (fnil inc 0)) k)))
+        leave    (fn [k] (swap! occ update k (fnil dec 0)))
+        ks       (mapv #(str "k-" %) (range keys-n))
+        idx      (atom -1)
+        results  (vec
+                  (for [k ks _ (range per-key)]
+                    (let [i     (swap! idx inc)
+                          sync? (and (pos? (long (or sync-every 0)))
+                                     (zero? (mod i (long sync-every))))
+                          pre   (jit)]                     ; arrival stagger (seeded)
+                      (if sync?
+                        {:future
+                         (future
+                           (Thread/sleep (long pre))
+                           (locked store k
+                                   (enter k)
+                                   (let [v (get @counter k 0)] ; non-atomic RMW:
+                                     (Thread/sleep (long (jit)))
+                                     (swap! counter assoc k (inc v))) ; ...stale write
+                                   (leave k)))}
+                        {:chan
+                         (go
+                           (<! (timeout pre))             ; stagger OUTSIDE the lock
+                           (<! (go-locked store k
+                                          (enter k)
+                                          (let [v (get @counter k 0)]
+                                            (<! (timeout (jit)))
+                                            (swap! counter assoc k (inc v)))
+                                          (leave k))))}))))
+        chans    (keep :chan results)
+        futs     (keep :future results)
+        ;; shared wall budget so a deadlock FAILS the round instead of hanging
+        deadline (timeout round-timeout-ms)
+        ok-chans (every? (fn [c] (let [[_ port] (alts!! [c deadline])] (= port c))) chans)
+        end      (+ (System/currentTimeMillis) round-timeout-ms)
+        ok-futs  (every? (fn [f] (not= ::timeout
+                                       (deref f (max 0 (- end (System/currentTimeMillis)))
+                                              ::timeout)))
+                         futs)]
+    {:max-occ      @max-occ
+     :counts-ok    (= (zipmap ks (repeat per-key)) @counter)
+     :no-deadlock  (and ok-chans ok-futs)
+     :leaked       (count @locks)
+     :occ-residual (reduce + 0 (vals @occ))}))
+
+(deftest lock-stress
+  (testing "randomized stress: isolation holds, locks reclaim, no deadlock"
+    (let [regimes [{:label "hot key (async)"          :keys-n 1   :per-key 300 :sync-every 0}
+                   {:label "few keys oscillating"     :keys-n 6   :per-key 80  :sync-every 4}
+                   {:label "many keys churn boundary" :keys-n 150 :per-key 3   :sync-every 5}
+                   {:label "spray (leak shape)"       :keys-n 400 :per-key 1   :sync-every 0}
+                   {:label "mixed sync+async"         :keys-n 3   :per-key 60  :sync-every 2}]
+          rounds  3]
+      (doseq [[ri regime] (map-indexed vector regimes)
+              r           (range rounds)]
+        (let [store (<!! (new-mem-store))
+              res   (stress-round store (assoc regime
+                                               :round-timeout-ms 20000
+                                               :seed (+ (* 100 (inc ri)) r)))
+              tag   (str (:label regime) " / round " r " -> " res)]
+          (is (= 1 (:max-occ res))        (str "two writers entered one key's CS: " tag))
+          (is (:counts-ok res)            (str "lost update — mutual exclusion broke: " tag))
+          (is (:no-deadlock res)          (str "deadlock / lost wakeup: " tag))
+          (is (zero? (:leaked res))       (str "registry not reclaimed: " tag))
+          (is (zero? (:occ-residual res)) (str "occupancy residual: " tag)))))))


### PR DESCRIPTION
Follow-up to #145. Adds a randomized concurrency stress test that guards the refcounted per-key lock reclaim against regressions.

## Why

The reclaim merged in #145 is konserve's in-process **isolation** mechanism — the "I" in ACID, given a single-writer runtime. A future change to it could break correctness three ways, and a stress test only earns its keep if it can actually *catch* them:

1. **Lost mutual exclusion** — a reclaimed entry hands a fresh channel to a second writer while the key is still held → two writers in one critical section.
2. **Premature reclaim / lost wakeup** — a channel a waiter is parked on gets discarded → that waiter never wakes → deadlock.
3. **The original leak** — the registry never shrinks.

## What it does

`konserve.lock-test/lock-stress` runs five contention regimes for several randomized rounds:

| regime | shape | stresses |
|---|---|---|
| hot key (async) | 1 key, 300 ops | many waiters sharing one entry |
| few keys oscillating | 6 × 80, ¼ sync | entries crossing n=0 ↔ n>0 |
| many keys churn boundary | 150 × 3, ⅕ sync | maximal create→reclaim→recreate churn |
| spray (leak shape) | 400 × 1 | the original heap-leak pattern |
| mixed sync+async | 3 × 60, ½ sync | `locked` (spin) + `go-locked` (park) on the same keys |

Each round asserts four oracles, all **deterministic for a correct implementation under any interleaving** — so a correct impl never flakes, while a broken one fails with high probability:

- per-key **max occupancy must be 1** — direct witness of failure (1)
- a **non-atomic per-key counter must equal the op count** — any single lost update fails; amplifies (1)
- every op **finishes within a wall budget** — catches (2) instead of hanging the suite
- **`:locks` empty at quiescence** — catches (3) and over-reclaim

Detection is maximized by short critical sections that park mid-way (widening the interleaving window), seeded staggered arrivals (so keys oscillate across the reclaim boundary), and exercising both the async parking path and the sync spinning path on the same keys.

## Verified sensitive

To confirm it isn't a test that only ever passes, I sabotaged `release-entry` to dissoc unconditionally (reclaim while holders remain). The test caught it immediately, across rounds and regimes:

```
two writers entered one key's CS: hot key (async) -> {:max-occ 3, :counts-ok false, ...}
lost update — mutual exclusion broke: few keys oscillating -> {:max-occ 9, :counts-ok false, ...}
```

i.e. it directly observed multiple writers in one key's critical section, via both the occupancy gauge and the lost-update counter. Sabotage reverted before this PR.

## Tests

Purely additive (only the two `require` lines change). Full JVM suite green: **69 tests / 1199 assertions, 0 failures, 0 errors** (`clojure -M:test`).