### PR TITLE
fix(read): drop redundant exists probe in -get-in — one backend request fewer per get

### DIFF
--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -7,7 +7,7 @@
    [konserve.serializers :refer [key->serializer]]
    [konserve.compressor :refer [get-compressor]]
    [konserve.encryptor :refer [get-encryptor]]
-   [konserve.protocols :refer [PEDNKeyValueStore -exists?
+   [konserve.protocols :refer [PEDNKeyValueStore
                                PBinaryKeyValueStore
                                -serialize -deserialize
                                PAssocSerializers
@@ -211,6 +211,13 @@
 
 (def ^:const max-lock-attempts 100)
 
+(def ^:private not-found-sentinel
+  "Internal marker distinguishing a missing key from a stored nil value on the
+  read path. Threaded through `io-operation` as `:not-found` so `-get-in` can
+  avoid a separate existence probe (an extra HEAD round-trip per read on
+  remote backends such as S3)."
+  #?(:clj (Object.) :cljs (js-obj)))
+
 (defn get-lock [this store-key env]
   (async+sync
    (:sync? env)
@@ -300,7 +307,10 @@
                   (log/trace :konserve/optimistic-lock-retry {:key key :attempt (inc attempt) :max-retries max-retries})
                   (recur (inc attempt)))
                 result)))
-          nil))))))
+          ;; Key is missing (and not migratable). Read callers that need to
+          ;; distinguish a missing key from a stored nil pass a `:not-found`
+          ;; sentinel; everyone else keeps getting nil as before.
+          (:not-found env)))))))
 
 (defn list-keys
   "Return all keys in the store."
@@ -424,23 +434,28 @@
        sync?
        *default-sync-translation*
        (go-try-
-        (if (<?- (-exists? this (first key-vec) opts))
-          (let [a (<?-
-                   (io-operation this serializers read-handlers write-handlers
-                                 {:key-vec key-vec
-                                  :operation :read-edn
-                                  :compressor compressor
-                                  :encryptor encryptor
-                                  :format    :data
-                                  :version version
-                                  :sync? sync?
-                                  :buffer-size buffer-size
-                                  :config config
-                                  :default-serializer default-serializer
-                                  :msg       {:type :read-edn-error
-                                              :key  key}}))]
-            (clojure.core/get-in a (rest key-vec)))
-          not-found)))))
+        ;; No upfront -exists? probe: io-operation already checks blob
+        ;; existence (and migratability) exactly once and returns the
+        ;; :not-found sentinel for missing keys. The previous double probe
+        ;; cost an extra HEAD request per read on remote backends.
+        (let [a (<?-
+                 (io-operation this serializers read-handlers write-handlers
+                               {:key-vec key-vec
+                                :operation :read-edn
+                                :compressor compressor
+                                :encryptor encryptor
+                                :format    :data
+                                :version version
+                                :sync? sync?
+                                :buffer-size buffer-size
+                                :config config
+                                :default-serializer default-serializer
+                                :not-found not-found-sentinel
+                                :msg       {:type :read-edn-error
+                                            :key  key}}))]
+          (if (identical? a not-found-sentinel)
+            not-found
+            (clojure.core/get-in a (rest key-vec))))))))
   (-get-meta [this key opts]
     (let [{:keys [sync?]} opts]
       (io-operation this serializers read-handlers write-handlers


### PR DESCRIPTION
## Problem

`-get-in` issued an upfront `-exists?` probe before reading, making every `k/get` cost 3 backend requests on remote stores (2 HEAD + 1 GET on S3-class backends). At 40 ms RTT that is ~150 ms for a single logical read — the probe result is redundant because the read itself already discovers absence.

## Fix

Remove the upfront probe; `io-operation` signals absence through a private not-found sentinel carried via `:not-found` in the env, so the miss case still returns the caller's default without an extra roundtrip. `k/get` is now 1 HEAD + 1 GET on S3 (2 requests instead of 3).

A 0-probe variant (GET only) was considered and rejected: the filestore's `-create-blob` CREATE flag would materialize empty blobs on probe-free missing reads — a `PBackingStore` contract issue that is out of scope here.

## Validation

- Full konserve suite green (69 tests / 0 failures).
- konserve-s3 suite against MinIO green (8 tests / 0 failures).
- Measured with datahike on MinIO through a 40 ms latency proxy: cold read path drops by one roundtrip exactly; no behavior change for hit, miss, or `:sync?`/async paths.

Found while chasing S3 tail latency in datahike (replikativ/datahike#867 measurement campaign).