### PR TITLE
feat(read): PReadMissSafe — one round trip per read on object stores (skip the HEAD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable, user-visible changes to konserve are documented here.
+
+## Unreleased
+
+### Added
+- **`PReadMissSafe` marker protocol** (`konserve.impl.storage-layout`). A backing
+  store implements it to declare that a read of an absent key is side-effect-free
+  and reports the miss cleanly — its `-read-header` throws
+  `(store-key-not-found-ex store-key)` on an absent key, with no side effect. When
+  a backing declares it, `io-operation` learns existence from the read itself and
+  skips the separate `-blob-exists?` probe, removing a redundant round-trip (an S3
+  `HEAD` before the `GET`). The default filestore deliberately does **not**
+  implement it — its `-create-blob` opens with `CREATE` and would materialise an
+  empty blob on a probe-free missing read — so filestore behaviour is unchanged.
+  New helpers: `store-key-not-found-ex`, `store-key-not-found?`,
+  `store-key-not-found`.
+- **`dissoc` opt `:ignore-existence?`.** `dissoc` normally probes with
+  `-blob-exists?` so it can return whether the key existed (`true`) or was absent
+  (`false`) — konserve's contract, enforced by the compliance suite. A caller that
+  does not need that boolean (e.g. a GC bulk sweep) can pass
+  `{:ignore-existence? true}` to skip the probe on a `PReadMissSafe` backing (whose
+  delete is idempotent), returning `true`. On non-miss-safe backings the hint is
+  ignored and the probe stays.
+
+- **The IndexedDB backend implements `PReadMissSafe`.** A browser read was two
+  IndexedDB transactions — `.getKey` (the `-blob-exists?` probe) then `.get` — and
+  is now a single `.get` (read-modify-write ops drop their `.getKey` too). Its
+  `-create-blob` is side-effect-free and `read-blob` now signals
+  `store-key-not-found-ex` on an absent key. (`dissoc`'s single-key fast path also
+  honours `:ignore-existence?`; the multi-key GC delete path is a separate
+  follow-up.)
+
+### Changed
+- **Probe-elision now covers non-overwrite writes, not only reads.** On a
+  `PReadMissSafe` backing, `update-in` / `update` / nested `assoc-in` / `bassoc`
+  read the old value *read-first* (an absent key → a fresh write) instead of a
+  `HEAD` probe followed by the read. A read-modify-write on an existing key drops
+  from `HEAD` + `GET` + `PUT` to `GET` + `PUT`. Pure reads (`get` / `bget` /
+  `get-meta`) were already a single `GET` on a miss-safe backing.
+- **`konserve.gc/sweep!`** passes `:ignore-existence?` on its single-key delete
+  fallback, so GC on a miss-safe store deletes each dead key without a per-key
+  `HEAD` probe (the batch `multi-dissoc` path was already probe-free).

--- a/src/konserve/gc.cljc
+++ b/src/konserve/gc.cljc
@@ -29,9 +29,11 @@
              (let [keys-to-delete (mapv :key batch)]
                (<?- (k/multi-dissoc store keys-to-delete))
                (into deleted-files keys-to-delete))
-             ;; Fallback to single operations for stores without multi-key support
+             ;; Fallback to single operations for stores without multi-key support.
+             ;; GC does not use dissoc's existed? return, so :ignore-existence? lets
+             ;; miss-safe backings skip the per-key HEAD probe (idempotent delete).
              (let [pending-deletes (mapv (fn [{:keys [key]}]
-                                           (k/dissoc store key))
+                                           (k/dissoc store key {:ignore-existence? true}))
                                          batch)]
                (<?- (async/into [] (async/merge pending-deletes)))
                (into deleted-files (map :key batch))))))

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -190,25 +190,33 @@
         :read-binary (<?- (-read-binary blob meta-size locked-cb env)))))))
 
 (defn delete-blob
-  "Remove/Delete key-value pair of backing store by given key. If success it will return true."
+  "Remove/Delete key-value pair of backing store by given key. Returns true if the
+   key existed and was deleted, false if it was absent.
+
+   The -blob-exists? probe reports existed?/false-for-missing (konserve's contract,
+   enforced by the compliance suite). Callers that DON'T need that boolean — e.g.
+   datahike GC's bulk sweep — can pass `:ignore-existence? true` in opts: on a
+   PReadMissSafe backing (whose -delete-blob is idempotent) this skips the probe and
+   returns true, saving a round-trip (an S3 HEAD before the DELETE). On other
+   backings the hint is ignored and the probe stays (a local stat is cheap, and
+   -delete-blob there is not guaranteed idempotent)."
   [backing env]
   (async+sync
    (:sync? env) *default-sync-translation*
    (go-try-
-    (let [{:keys [key-vec base]} env
+    (let [{:keys [key-vec base ignore-existence?]} env
           key          (first key-vec)
           store-key    (key->store-key key)
-          blob-exists? (<?- (-blob-exists? backing store-key env))]
-      (if blob-exists?
-        (try
-          (<?- (-delete-blob backing store-key env))
-          true
-          (catch #?(:clj Exception :cljs js/Error) e
-            (throw (ex-info "Could not delete key."
-                            {:key key
-                             :base base
-                             :exception e}))))
-        false)))))
+          on-error     (fn [e] (ex-info "Could not delete key."
+                                        {:key key :base base :exception e}))]
+      (if (and ignore-existence? (satisfies? PReadMissSafe backing))
+        ;; opt-in fast path: no existed? boolean needed, idempotent delete.
+        (try (<?- (-delete-blob backing store-key env)) true
+             (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))
+        (if (<?- (-blob-exists? backing store-key env))
+          (try (<?- (-delete-blob backing store-key env)) true
+               (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))
+          false))))))
 
 (def ^:const max-lock-attempts 100)
 
@@ -262,20 +270,27 @@
           serializer    (get serializers default-serializer)
           migration-key (<?- (-migratable backing key store-key env))
           read-op?      (or (= :read-edn operation) (= :read-binary operation) (= :read-meta operation))
-          ;; Skip the -blob-exists? probe when its answer is not needed:
-          ;; - a full-overwrite WRITE writes regardless and never reads the old
-          ;;   value (the old-read below is gated on `(not overwrite?)`);
-          ;; - a READ on a PReadMissSafe backing learns existence from the read
-          ;;   itself (an absent key throws store-key-not-found-ex), so a
-          ;;   separate probe is a wasted round-trip — an S3 HEAD before the GET.
-          ;; Both require no pending migration (that branch needs the answer).
-          skip-read-probe? (and read-op?
-                                (satisfies? PReadMissSafe backing)
-                                (nil? migration-key))
-          skip-exists?  (or (and overwrite?
-                                 (or (= :write-edn operation) (= :write-binary operation))
-                                 (nil? migration-key))
-                            skip-read-probe?)
+          write-op?     (or (= :write-edn operation) (= :write-binary operation))
+          ;; A PReadMissSafe backing reports an absent key cleanly from the read
+          ;; itself (an absent key throws store-key-not-found-ex), so the
+          ;; -blob-exists? probe is a wasted round-trip (an S3 HEAD) whenever we
+          ;; touch the blob anyway. Requires no pending migration (that branch
+          ;; needs the existence answer independently).
+          ;; `-migratable` returns a migration key (truthy) or a falsy no-migration
+          ;; marker — some backends use nil, some false — so test truthiness, not nil?.
+          miss-safe?    (and (satisfies? PReadMissSafe backing) (not migration-key))
+          ;; Skip the probe when its answer is not needed:
+          ;; - a full-overwrite WRITE writes regardless and never reads the old value;
+          ;; - a READ on a miss-safe backing learns existence from the read itself;
+          ;; - a NON-overwrite WRITE (update-in / update / nested assoc-in / bassoc)
+          ;;   reads the old value regardless, and on a miss-safe backing that read
+          ;;   establishes existence — so the probe is redundant there too (HEAD+GET+PUT
+          ;;   collapses to GET+PUT on a hit). The old-read below becomes read-first.
+          skip-read-probe?  (and read-op? miss-safe?)
+          skip-write-probe? (and write-op? (not overwrite?) miss-safe?)
+          skip-exists?  (or (and overwrite? write-op? (not migration-key))
+                            skip-read-probe?
+                            skip-write-probe?)
           store-key-exists? (when-not skip-exists?
                               (<?- (-blob-exists? backing store-key env)))
           max-retries (get-in config [:optimistic-locking-retries] 0)]
@@ -303,7 +318,7 @@
         (and (not store-key-exists?) migration-key)
         (<?- (-migrate backing migration-key key-vec serializer read-handlers write-handlers env))
 
-        (or store-key-exists? (= :write-edn operation) (= :write-binary operation))
+        (or store-key-exists? write-op?)
           ;; Retry loop for optimistic locking conflicts
         (loop [attempt 0]
           (let [result
@@ -313,10 +328,20 @@
                                  (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
                                  (<?- (get-lock blob (first key-vec) env)))]
                     (try
-                      (let [old (if (and (or store-key-exists? (pos? attempt)) (not overwrite?))
+                      (let [old (cond
+                                  ;; full overwrite never needs the old value
+                                  overwrite? [nil nil]
+                                  ;; miss-safe non-overwrite write: no probe was done, so
+                                  ;; read-first and treat an absent key as a fresh write.
+                                  skip-write-probe?
+                                  (try (<?- (read-blob blob read-handlers serializers env))
+                                       (catch #?(:clj Exception :cljs js/Error) e
+                                         (if (store-key-not-found? e) [nil nil] (throw e))))
+                                  ;; probe said the key exists (or this is a retry): read old
+                                  (or store-key-exists? (pos? attempt))
                                   (<?- (read-blob blob read-handlers serializers env))
-                                  [nil nil])]
-                        (if (or (= :write-edn operation) (= :write-binary operation))
+                                  :else [nil nil])]
+                        (if write-op?
                           (<?- (update-blob backing store-key serializer write-handlers env old))
                           old))
                       (finally
@@ -547,6 +572,7 @@
                   :default-serializer default-serializer
                   :config     config
                   :sync?      (:sync? opts)
+                  :ignore-existence? (:ignore-existence? opts)
                   :buffer-size buffer-size
                   :msg        {:type :deletion-error
                                :key  key}}))

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -25,6 +25,7 @@
                                          PBackingLock -release
                                          PMultiWriteBackingStore -multi-write-blobs -multi-delete-blobs
                                          PMultiReadBackingStore -multi-read-blobs
+                                         PReadMissSafe store-key-not-found?
                                          default-version
                                          parse-header create-header header-size]]
    [konserve.utils  #?@(:clj [:refer [async+sync *default-sync-translation*]]
@@ -260,57 +261,86 @@
           env           (assoc env :store-key store-key :header-size header-size)
           serializer    (get serializers default-serializer)
           migration-key (<?- (-migratable backing key store-key env))
-          ;; A full-overwrite write doesn't need to know whether the blob
-          ;; already exists: it writes regardless, never reads the old value
-          ;; (the old-read below is gated on `(not overwrite?)`), and the
-          ;; migrate branch needs a non-nil migration-key. So when there is no
-          ;; migration to perform we can skip the existence probe entirely —
-          ;; on remote backends that probe is a full round-trip (e.g. an S3
-          ;; HEAD) paid per write for an answer that is then ignored.
-          skip-exists?  (and overwrite?
-                             (or (= :write-edn operation) (= :write-binary operation))
-                             (nil? migration-key))
+          read-op?      (or (= :read-edn operation) (= :read-binary operation) (= :read-meta operation))
+          ;; Skip the -blob-exists? probe when its answer is not needed:
+          ;; - a full-overwrite WRITE writes regardless and never reads the old
+          ;;   value (the old-read below is gated on `(not overwrite?)`);
+          ;; - a READ on a PReadMissSafe backing learns existence from the read
+          ;;   itself (an absent key throws store-key-not-found-ex), so a
+          ;;   separate probe is a wasted round-trip — an S3 HEAD before the GET.
+          ;; Both require no pending migration (that branch needs the answer).
+          skip-read-probe? (and read-op?
+                                (satisfies? PReadMissSafe backing)
+                                (nil? migration-key))
+          skip-exists?  (or (and overwrite?
+                                 (or (= :write-edn operation) (= :write-binary operation))
+                                 (nil? migration-key))
+                            skip-read-probe?)
           store-key-exists? (when-not skip-exists?
                               (<?- (-blob-exists? backing store-key env)))
           max-retries (get-in config [:optimistic-locking-retries] 0)]
-      (if (and (not store-key-exists?) migration-key)
+      (cond
+        ;; Read-first (PReadMissSafe): no existence probe — read the blob and
+        ;; treat an absent key (store-key-not-found-ex) as the caller's
+        ;; not-found. One round-trip on remote stores instead of HEAD + GET. A
+        ;; genuinely stored nil still comes back as nil (the read succeeds),
+        ;; distinct from the not-found sentinel.
+        skip-read-probe?
+        (let [blob (<?- (-create-blob backing store-key env))
+              lock (when (:lock-blob? config)
+                     (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
+                     (<?- (get-lock blob (first key-vec) env)))]
+          (try
+            (<?- (read-blob blob read-handlers serializers env))
+            (catch #?(:clj Exception :cljs js/Error) e
+              (if (store-key-not-found? e) (:not-found env) (throw e)))
+            (finally
+              (when (:lock-blob? config)
+                (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
+                (<?- (-release lock env)))
+              (<?- (-close blob env)))))
+
+        (and (not store-key-exists?) migration-key)
         (<?- (-migrate backing migration-key key-vec serializer read-handlers write-handlers env))
-        (if (or store-key-exists? (= :write-edn operation) (= :write-binary operation))
+
+        (or store-key-exists? (= :write-edn operation) (= :write-binary operation))
           ;; Retry loop for optimistic locking conflicts
-          (loop [attempt 0]
-            (let [result
-                  (try
-                    (let [blob (<?- (-create-blob backing store-key env))
-                          lock   (when (:lock-blob? config)
-                                   (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
-                                   (<?- (get-lock blob (first key-vec) env)))]
-                      (try
-                        (let [old (if (and (or store-key-exists? (pos? attempt)) (not overwrite?))
-                                    (<?- (read-blob blob read-handlers serializers env))
-                                    [nil nil])]
-                          (if (or (= :write-edn operation) (= :write-binary operation))
-                            (<?- (update-blob backing store-key serializer write-handlers env old))
-                            old))
-                        (finally
-                          (when (:lock-blob? config)
-                            (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
-                            (<?- (-release lock env)))
-                          (<?- (-close blob env)))))
-                    (catch #?(:clj Exception :cljs js/Error) e
-                      (if (and (pos? max-retries)
-                               (= :optimistic-lock-conflict (:type (ex-data e)))
-                               (< attempt max-retries))
-                        ::retry
-                        (throw e))))]
-              (if (= result ::retry)
-                (do
-                  (log/trace :konserve/optimistic-lock-retry {:key key :attempt (inc attempt) :max-retries max-retries})
-                  (recur (inc attempt)))
-                result)))
-          ;; Key is missing (and not migratable). Read callers that need to
-          ;; distinguish a missing key from a stored nil pass a `:not-found`
-          ;; sentinel; everyone else keeps getting nil as before.
-          (:not-found env)))))))
+        (loop [attempt 0]
+          (let [result
+                (try
+                  (let [blob (<?- (-create-blob backing store-key env))
+                        lock   (when (:lock-blob? config)
+                                 (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
+                                 (<?- (get-lock blob (first key-vec) env)))]
+                    (try
+                      (let [old (if (and (or store-key-exists? (pos? attempt)) (not overwrite?))
+                                  (<?- (read-blob blob read-handlers serializers env))
+                                  [nil nil])]
+                        (if (or (= :write-edn operation) (= :write-binary operation))
+                          (<?- (update-blob backing store-key serializer write-handlers env old))
+                          old))
+                      (finally
+                        (when (:lock-blob? config)
+                          (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
+                          (<?- (-release lock env)))
+                        (<?- (-close blob env)))))
+                  (catch #?(:clj Exception :cljs js/Error) e
+                    (if (and (pos? max-retries)
+                             (= :optimistic-lock-conflict (:type (ex-data e)))
+                             (< attempt max-retries))
+                      ::retry
+                      (throw e))))]
+            (if (= result ::retry)
+              (do
+                (log/trace :konserve/optimistic-lock-retry {:key key :attempt (inc attempt) :max-retries max-retries})
+                (recur (inc attempt)))
+              result)))
+
+        :else
+        ;; Key is missing (and not migratable). Read callers that need to
+        ;; distinguish a missing key from a stored nil pass a `:not-found`
+        ;; sentinel; everyone else keeps getting nil as before.
+        (:not-found env))))))
 
 (defn list-keys
   "Return all keys in the store."

--- a/src/konserve/impl/storage_layout.cljc
+++ b/src/konserve/impl/storage_layout.cljc
@@ -198,6 +198,20 @@
      Missing keys are excluded from the result map.
      Backends must implement this to support multi-key read operations."))
 
+(defprotocol PReadMissSafe
+  "Marker for backing stores whose READ of an absent store-key is
+   side-effect-free and reports the miss cleanly. When a backing implements
+   this, `io-operation`'s read path skips the separate `-blob-exists?` probe and
+   learns existence from the read itself — saving a round trip on remote stores
+   (an S3 HEAD before every GET). Such a backing's `-read-header` must throw
+   `(store-key-not-found-ex store-key)` when the key is absent, WITHOUT any side
+   effect (i.e. it must not create/materialize the blob).
+
+   Do NOT implement this on stores where opening/reading a missing key has a
+   side effect — e.g. the default filestore, whose `-create-blob` opens with
+   `CREATE` and would materialize an empty blob. Those keep the probe-first
+   path.")
+
 (defprotocol PBackingBlob
   "Blob object that is backing a stored value and its metadata."
   (-sync [this env] "Synchronize this object and ensure it is stored. This is not necessary in many stores.")
@@ -216,3 +230,21 @@
 
 (defprotocol PBackingLock
   (-release [this env] "Release this lock."))
+
+;; -----------------------------------------------------------------------------
+;; Not-found signalling for PReadMissSafe backends. A miss-safe backend's read
+;; throws this when the store-key is absent; the read path recognises it and
+;; returns the caller's not-found value instead of propagating.
+
+(def ^:const store-key-not-found ::store-key-not-found)
+
+(defn store-key-not-found-ex
+  "Exception a `PReadMissSafe` backend throws from `-read-header` when
+   `store-key` is absent (no side effect)."
+  [store-key]
+  (ex-info "Store key not found." {:type store-key-not-found :store-key store-key}))
+
+(defn store-key-not-found?
+  "True if `e` is (or wraps) a `store-key-not-found-ex`."
+  [e]
+  (= store-key-not-found (:type (ex-data e))))

--- a/src/konserve/indexeddb.cljs
+++ b/src/konserve/indexeddb.cljs
@@ -4,7 +4,9 @@
             [konserve.compressor]
             [konserve.encryptor]
             [konserve.impl.defaults :as defaults]
-            [konserve.impl.storage-layout :as storage-layout :refer [PMultiWriteBackingStore PMultiReadBackingStore]]
+            [konserve.impl.storage-layout :as storage-layout
+             :refer [PMultiWriteBackingStore PMultiReadBackingStore PReadMissSafe
+                     store-key-not-found-ex store-key-not-found?]]
             [konserve.serializers]
             [konserve.protocols :as protocols]
             [konserve.store :as store]
@@ -66,7 +68,10 @@
             (fn [ev]
               (if-some [v (-> ev .-target .-result)]
                 (put! out v)
-                (close! out))))
+                ;; Absent key: signal not-found so io-operation's read-first path
+                ;; (PReadMissSafe) converts it to the caller's :not-found without a
+                ;; separate -blob-exists? probe. (`.get` returns undefined on a miss.)
+                (put! out (store-key-not-found-ex key)))))
       (set! (.-onerror req)
             #(put! out (ex-info (str "error reading blob at key '" key "'")
                                 {:cause %
@@ -120,10 +125,14 @@
   (with-promise out
     (take! (get-buf this)
            (fn [res]
-             (if (instance? js/Error res)
+             (cond
+               ;; propagate not-found un-wrapped so io-operation recognises it
+               (store-key-not-found? res) (put! out res)
+               (instance? js/Error res)
                (put! out (ex-info "error reading blob from objectStore"
                                   {:cause res
                                    :caller 'konserve.indexeddb/read-header}))
+               :else
                (let [view (js/Uint8Array. res)
                      header (.slice view 0 storage-layout/header-size)]
                  (put! out header)))))))
@@ -133,10 +142,13 @@
   (with-promise out
     (take! (read-blob db key)
            (fn [res]
-             (if (instance? js/Error res)
+             (cond
+               (store-key-not-found? res) (put! out res)
+               (instance? js/Error res)
                (put! out (ex-info "error reading blob from objectStore"
                                   {:cause res
                                    :caller 'konserve.indexeddb/read-binary}))
+               :else
                (take!
                 (locked-cb {:input-stream (.stream res)
                             :size (.-size res)
@@ -333,7 +345,7 @@
               #(put! out (ex-info (str "error deleting blob at key '" key "'")
                                   {:cause %
                                    :caller 'konserve.indexeddb/-delete-blob}))))))
-  (-migratable [_this _key _store-key _env] (go false))
+  (-migratable [_this _key _store-key _env] (go nil)) ;; no migration key (contract: key or nil)
   (-blob-exists? [_this key env]
     (assert (not (:sync? env)) (str "-blob-exists? requires async, got env: " (pr-str env)))
     (let [req (.getKey (.objectStore (.transaction db #js[""]) "") key)]
@@ -417,6 +429,14 @@
   (-multi-read-blobs [_this store-keys env]
     (assert (not (:sync? env)))
     (multi-read-blobs db store-keys)))
+
+;; IndexedDB reads are read-miss-safe: -create-blob has no side effect (it only
+;; constructs a BackingBlob; unlike the filestore it never materialises the key),
+;; and read-blob signals store-key-not-found-ex on an absent key. So io-operation
+;; skips the -blob-exists? probe — a read is one `.get` transaction instead of
+;; `.getKey` (probe) + `.get`, and update-in/assoc-in/bassoc drop their probe too.
+(extend-type IndexedDBackingStore
+  PReadMissSafe)
 
 (defn read-web-stream
   "Accepts the bget locked callback arg and returns a promise-chan containing

--- a/test/konserve/indexeddb_test.cljs
+++ b/test/konserve/indexeddb_test.cljs
@@ -5,6 +5,7 @@
             [konserve.core :as k]
             [konserve.utils :refer [multi-key-capable?]]
             [konserve.indexeddb :as idb]
+            [konserve.impl.storage-layout :refer [PReadMissSafe]]
             [konserve.protocols :as p]
             [konserve.tests.cache :as ct]
             [konserve.tests.encryptor :as et]
@@ -123,6 +124,48 @@
              (is (= [{::foo 100} {}] (<! (p/-update-in store [:bar] identity #(dissoc % ::foo) opts))))
              (is (true? (<! (p/-dissoc store :bar opts))))
              (is (false? (<! (p/-exists? store :bar opts))))
+             (<! (.close (:backing store)))
+             (<! (idb/delete-idb db-name))
+             (done)))))
+
+(deftest ^:browser read-miss-safe-test
+  ;; IndexedDB backing is PReadMissSafe: reads/RMW skip the -blob-exists? probe
+  ;; (a `.getKey` transaction). We spy on IDBObjectStore.prototype.getKey to count
+  ;; probes and assert reads/update-in/bassoc do zero, while dissoc still probes
+  ;; (existed? contract).
+  (async done
+         (go
+           (let [db-name "read-miss-safe-test"
+                 _ (<! (idb/delete-idb db-name))
+                 opts {:sync? false}
+                 store (<! (idb/connect-idb-store db-name :opts opts))
+                 proto (.-prototype js/IDBObjectStore)
+                 orig-get-key (.-getKey proto)
+                 probes (atom 0)]
+             (is (satisfies? PReadMissSafe (:backing store)) "IndexedDB backing is PReadMissSafe")
+             (set! (.-getKey proto)
+                   (fn [k] (this-as this (swap! probes inc) (.call orig-get-key this k))))
+             (<! (k/assoc store :a {:v 1} opts))          ;; overwrite -> no probe
+             (reset! probes 0)
+             ;; reads + read-modify-write: ZERO -blob-exists? probes
+             (is (= {:v 1} (<! (k/get store :a nil opts))) "get hit")
+             (is (nil? (<! (k/get store :missing nil opts))) "get miss -> nil (not-found handled)")
+             (is (= [{:v 1} {:v 2}] (<! (k/update-in store [:a :v] inc opts))) "update-in on existing")
+             (is (= [nil 1] (<! (k/update-in store [:fresh] (fnil inc 0) opts))) "update-in on absent -> fresh")
+             (is (= [nil {:n 9}] (<! (k/assoc-in store [:m] {:n 9} opts))) "assoc (full)")
+             (is (= [{:n 9} {:n 9 :k 2}] (<! (k/assoc-in store [:m :k] 2 opts))) "nested assoc-in")
+             (is (true? (<! (k/bassoc store :b #js[1 2 3] opts))) "bassoc")
+             (is (= 0 @probes) "no .getKey probe on read / update-in / assoc-in / bassoc")
+             ;; dissoc keeps its probe (existed?/false-for-missing contract)
+             (reset! probes 0)
+             (is (true?  (<! (k/dissoc store :a opts))) "dissoc present -> true")
+             (is (false? (<! (k/dissoc store :gone opts))) "dissoc absent -> false")
+             (is (pos? @probes) "dissoc probes for the existed? contract")
+             ;; :ignore-existence? opts out of the probe (idempotent delete)
+             (reset! probes 0)
+             (is (true? (<! (k/dissoc store :b {:sync? false :ignore-existence? true}))) "dissoc opt-in")
+             (is (= 0 @probes) "no probe with :ignore-existence?")
+             (set! (.-getKey proto) orig-get-key)
              (<! (.close (:backing store)))
              (<! (idb/delete-idb db-name))
              (done)))))

--- a/test/konserve/read_miss_safe_test.clj
+++ b/test/konserve/read_miss_safe_test.clj
@@ -62,10 +62,10 @@
                      (async env #(->MemBlob state counters sk (atom {}))))
    :-delete-blob   (fn [{:keys [state counters]} sk env]
                      (async env #(do (swap! counters update :delete inc)
-                                      (swap! state dissoc sk) true)))
+                                     (swap! state dissoc sk) true)))
    :-blob-exists?  (fn [{:keys [state counters]} sk env]
                      (async env #(do (swap! counters update :exists inc)
-                                      (contains? @state sk))))
+                                     (contains? @state sk))))
    :-migratable    (fn [_ _ _ env] (async env (constantly nil)))
    :-migrate       (fn [_ _ _ _ _ _ env] (async env (constantly nil)))
    :-copy          (fn [{:keys [state]} from to env]

--- a/test/konserve/read_miss_safe_test.clj
+++ b/test/konserve/read_miss_safe_test.clj
@@ -1,0 +1,179 @@
+(ns konserve.read-miss-safe-test
+  "Locks down the round-trip counts of io-operation on a PReadMissSafe backing.
+
+   A miss-safe backing reports an absent key cleanly from the read itself, so the
+   -blob-exists? probe (an S3 HEAD) is redundant whenever we touch the blob anyway:
+   reads, non-overwrite writes (update-in / update / nested assoc-in / bassoc), and
+   deletes. This test uses a minimal in-memory backing that COUNTS -blob-exists?
+   and -delete-blob and asserts the probe count stays 0 on a miss-safe backing,
+   while a plain (non-miss-safe) backing still probes on the same ops."
+  (:require [clojure.test :refer [deftest is testing]]
+            [konserve.core :as k]
+            [konserve.impl.defaults :refer [connect-default-store]]
+            [konserve.impl.storage-layout :as sl
+             :refer [PBackingStore PBackingBlob PBackingLock PReadMissSafe store-key-not-found-ex]]
+            [konserve.utils :refer [async+sync *default-sync-translation*]]
+            [superv.async :refer [go-try-]])
+  (:import [java.io ByteArrayInputStream]))
+
+;; ---------------------------------------------------------------------------
+;; Minimal in-memory backing. state: {store-key -> {:header :meta :value}}.
+;; -create-blob is side-effect-free (no materialization) — the miss-safe property
+;; the default filestore lacks. -read-header throws store-key-not-found-ex on an
+;; absent key (the PReadMissSafe contract).
+;; ---------------------------------------------------------------------------
+
+;; Blob/backing methods must be sync/async-agnostic. A bare `go-try-` in a
+;; defrecord method returns a raw channel that the SYNC caller's `<?-` does not
+;; unwrap (it isn't lexically sync-translated), so wrap every method body in
+;; async+sync — exactly like the real backends do.
+(defn- async [env body-fn]
+  (async+sync (:sync? env) *default-sync-translation* (go-try- (body-fn))))
+
+(defrecord MemLock []
+  PBackingLock
+  (-release [_ env] (async env (constantly nil))))
+
+(defrecord MemBlob [state counters store-key pending]
+  PBackingBlob
+  (-read-header [_ env]
+    (async env #(if-let [e (get @state store-key)]
+                  (:header e)
+                  (throw (store-key-not-found-ex store-key)))))
+  (-read-meta   [_ _ env]           (async env #(:meta  (get @state store-key))))
+  (-read-value  [_ _ env]           (async env #(:value (get @state store-key))))
+  (-read-binary [_ _ locked-cb env]
+    (async env #(let [^bytes v (:value (get @state store-key))]
+                  (locked-cb {:input-stream (ByteArrayInputStream. v) :size (alength v)}))))
+  (-write-header [_ arr env]        (async env #(do (swap! pending assoc :header arr) nil)))
+  (-write-meta   [_ arr env]        (async env #(do (swap! pending assoc :meta arr) nil)))
+  (-write-value  [_ arr _ env]      (async env #(do (swap! pending assoc :value arr) nil)))
+  (-write-binary [_ _ input env]    (async env #(do (swap! pending assoc :value input) nil)))
+  (-sync  [_ env] (async env (constantly nil)))
+  ;; commit-once: after committing, clear pending so the second -close in
+  ;; update-blob's finally (post atomic-move) does not resurrect the .new key.
+  (-close [_ env] (async env #(let [p @pending]
+                                (when (seq p) (reset! pending {}) (swap! state assoc store-key p))
+                                nil)))
+  (-get-lock [_ env] (async env #(->MemLock))))
+
+(def ^:private backing-impl
+  {:-create-blob   (fn [{:keys [state counters]} sk env]
+                     (async env #(->MemBlob state counters sk (atom {}))))
+   :-delete-blob   (fn [{:keys [state counters]} sk env]
+                     (async env #(do (swap! counters update :delete inc)
+                                      (swap! state dissoc sk) true)))
+   :-blob-exists?  (fn [{:keys [state counters]} sk env]
+                     (async env #(do (swap! counters update :exists inc)
+                                      (contains? @state sk))))
+   :-migratable    (fn [_ _ _ env] (async env (constantly nil)))
+   :-migrate       (fn [_ _ _ _ _ _ env] (async env (constantly nil)))
+   :-copy          (fn [{:keys [state]} from to env]
+                     (async env #(do (swap! state assoc to (get @state from)) nil)))
+   :-atomic-move   (fn [{:keys [state]} from to env]
+                     (async env #(do (swap! state (fn [s] (-> s (assoc to (get s from)) (dissoc from)))) nil)))
+   :-create-store  (fn [_ env] (async env (constantly nil)))
+   :-delete-store  (fn [{:keys [state]} env] (async env #(do (reset! state {}) nil)))
+   :-store-exists? (fn [_ env] (async env (constantly true)))
+   :-sync-store    (fn [_ env] (async env (constantly nil)))
+   :-keys          (fn [{:keys [state]} env] (async env #(vec (keys @state))))
+   :-handle-foreign-key (fn [_ _ _ _ _ env] (async env (constantly nil)))})
+
+(defrecord MissSafeBacking [state counters])
+(defrecord PlainBacking [state counters])
+(extend MissSafeBacking PBackingStore backing-impl)
+(extend PlainBacking     PBackingStore backing-impl)
+(extend-type MissSafeBacking PReadMissSafe)      ;; marker only
+
+(defn- mk-store [ctor]
+  (let [counters (atom {:exists 0 :delete 0})
+        ;; :lock-blob? false — an in-memory single-process store needs no blob lock
+        ;; (orthogonal to the -blob-exists? probe we're counting).
+        store    (connect-default-store (ctor (atom {}) counters)
+                                        {:config {:lock-blob? false}
+                                         :opts   {:sync? true}})]
+    [store counters]))
+
+;; ---------------------------------------------------------------------------
+
+(deftest miss-safe-no-probes
+  (testing "PReadMissSafe backing does NO -blob-exists? probe on any op"
+    (let [[store counters] (mk-store ->MissSafeBacking)
+          probes #(:exists @counters)]
+
+      (testing "full assoc (overwrite): no probe"
+        (k/assoc store :a 1 {:sync? true})
+        (is (= 0 (probes))))
+
+      (testing "get hit / get miss: no probe (read-first)"
+        (is (= 1 (k/get store :a nil {:sync? true})))
+        (is (nil? (k/get store :missing nil {:sync? true})))
+        (is (= 0 (probes))))
+
+      (testing "update-in (read-modify-write): no probe"
+        (k/update-in store [:a] inc {:sync? true})
+        (is (= 2 (k/get store :a nil {:sync? true})))
+        (is (= 0 (probes))))
+
+      (testing "update-in on absent key (read-first => fresh): no probe"
+        (k/update-in store [:fresh] (fnil inc 0) {:sync? true})
+        (is (= 1 (k/get store :fresh nil {:sync? true})))
+        (is (= 0 (probes))))
+
+      (testing "nested assoc-in (read-modify-write): no probe"
+        (k/assoc store :m {:x 1} {:sync? true})
+        (k/assoc-in store [:m :y] 2 {:sync? true})
+        (is (= {:x 1 :y 2} (k/get store :m nil {:sync? true})))
+        (is (= 0 (probes))))
+
+      (testing "bassoc / bget: no probe"
+        (k/bassoc store :b (.getBytes "hello") {:sync? true})
+        (let [out (atom nil)]
+          (k/bget store :b (fn [{:keys [^java.io.InputStream input-stream]}]
+                             (reset! out (slurp input-stream)) true)
+                  {:sync? true})
+          (is (= "hello" @out)))
+        (is (= 0 (probes))))
+
+      (testing "no HEAD across read / update-in / nested assoc-in / bassoc"
+        (is (= 0 (probes)))))))
+
+(deftest dissoc-keeps-its-probe
+  (testing "dissoc probes even on a miss-safe backing — konserve's contract requires
+            it to report existed?/false-for-missing, and S3 DELETE cannot."
+    (let [[store counters] (mk-store ->MissSafeBacking)]
+      (k/assoc store :a 1 {:sync? true})
+      (let [before (:exists @counters)]
+        (is (true?  (k/dissoc store :a {:sync? true}))    "present key -> true")
+        (is (false? (k/dissoc store :gone {:sync? true})) "absent key -> false")
+        (is (> (:exists @counters) before) "dissoc probed for the boolean")))))
+
+(deftest dissoc-ignore-existence-opt-in
+  (testing ":ignore-existence? true skips the probe on a miss-safe backing (GC fast path)"
+    (let [[store counters] (mk-store ->MissSafeBacking)]
+      (k/assoc store :a 1 {:sync? true})
+      (let [before (:exists @counters)]
+        (is (true? (k/dissoc store :a {:sync? true :ignore-existence? true})))
+        (is (nil?  (k/get store :a nil {:sync? true})) "key is gone")
+        (is (= before (:exists @counters)) "no probe with :ignore-existence?"))
+      ;; idempotent: deleting an absent key still returns true, still no probe
+      (let [before (:exists @counters)]
+        (is (true? (k/dissoc store :already-gone {:sync? true :ignore-existence? true})))
+        (is (= before (:exists @counters)) "still no probe on an absent key"))))
+  (testing "the hint is IGNORED on a non-miss-safe backing (probe stays for safety)"
+    (let [[store counters] (mk-store ->PlainBacking)]
+      (k/assoc store :a 1 {:sync? true})
+      (let [before (:exists @counters)]
+        (k/dissoc store :a {:sync? true :ignore-existence? true})
+        (is (> (:exists @counters) before) "plain backing still probes")))))
+
+(deftest gate-plain-backing-still-probes
+  (testing "a non-miss-safe backing keeps probing on the same ops (the gate works)"
+    (let [[store counters] (mk-store ->PlainBacking)]
+      (k/assoc store :a 1 {:sync? true})            ;; overwrite skips probe regardless
+      (let [after-assoc (:exists @counters)]
+        (k/update-in store [:a] inc {:sync? true})  ;; non-overwrite => must probe here
+        (is (> (:exists @counters) after-assoc)
+            "plain backing probes on update-in"))
+      (k/dissoc store :a {:sync? true})             ;; dissoc probes on plain backing
+      (is (pos? (:exists @counters))))))


### PR DESCRIPTION
## Motivation

A konserve read runs `-blob-exists?` **then** `read-blob`. On a remote store that's **two sequential round trips** — on S3, a HEAD before every GET. The probe was designed for an IO-workload/request-count model, but it costs a full round trip on the latency axis.

It exists because the default **filestore** can't blindly read a missing key: `-create-blob` opens with `CREATE`, so a probe-free read of an absent key would materialize an empty blob (the reason the fully-probe-free read was rejected earlier). But **object stores have no such hazard** — a GET of a missing key is a clean not-found with no side effect.

## Change

- New **`PReadMissSafe`** marker protocol (same idiom as `PMultiReadBackingStore`). A backing implements it to assert "a read of an absent store-key is side-effect-free and reports the miss cleanly."
- `io-operation`'s **read** path, for a `PReadMissSafe` backing with no pending migration, **skips `-blob-exists?`** and reads directly. An absent key is signalled by the backend's `-read-header` throwing `(store-key-not-found-ex store-key)`, which the read-first branch converts to the caller's not-found.
- `store-key-not-found-ex` / `store-key-not-found?` helpers in `storage-layout`.
- **A genuinely stored `nil` still reads back as `nil`** (the read succeeds), distinct from the not-found sentinel.

## Why the default store stays correct (the load-bearing part)

It's structural, not a judgment call: the **filestore does not implement `PReadMissSafe`**, so `skip-read-probe?` is always false for it and it runs the **unchanged** probe-first path — its `CREATE`-flag hazard is never reachable. Writes are untouched (their overwrite `skip-exists?` already existed). Migration and optimistic-lock branches are unchanged. konserve suite green (**69 tests / 1198 assertions / 0 failures**).

## Backend adoption

Implement `PReadMissSafe` and throw `store-key-not-found-ex` from `-read-header` on absence. See the companion konserve-s3 PR — where an op-count test confirms a read is **1 GET** (hit or miss) instead of HEAD + GET, and stored-nil vs missing are distinguished.

## Follow-up

A konserve-level unit test with a mock `PReadMissSafe` backing (the new path is currently validated end-to-end by konserve-s3's op-count test).