### PR TITLE
feat(tiered): :frontend-only write policy (read-through cache over a read-only backend)

### DIFF
--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -19,7 +19,13 @@
 ;; TODO match metadata timestamps between frontend and backend
 
 ;; Write policies
-(def write-policies #{:write-through :write-behind :write-around})
+(def write-policies #{:write-through :write-behind :write-around :frontend-only})
+;; :frontend-only — a read-through CACHE over a read-only backend. Writes (and
+;; deletes) go to the FRONTEND only; the backend is never mutated by this peer.
+;; Combine with read-policy :frontend-first so reads still fall through to the
+;; backend on a miss. `-keys` reports the frontend, so this store enumerates and
+;; syncs as its local cache (e.g. a konserve-sync subscriber warming an LMDB
+;; frontend over a shared, writer-owned S3 backend it must not write to).
 
 ;; Read policies
 (def read-policies #{:frontend-first :frontend-only})
@@ -232,7 +238,11 @@
                            (<?- (-dissoc frontend-store (first key-vec) opts))
                            (catch #?(:clj Exception :cljs js/Error) e
                              (log/warn :konserve/tiered-frontend-invalidation-failed {:key (first key-vec) :error e}))))
-                     result)))))
+                     result)
+
+                   :frontend-only
+                   ;; Cache mode: write to the frontend only; never touch the backend.
+                   (<?- (-update-in frontend-store key-vec meta-up-fn up-fn opts))))))
 
   (-assoc-in [_this key-vec meta-up-fn val opts]
     (log/trace :konserve/tiered-assoc-in {:key-vec key-vec})
@@ -263,18 +273,24 @@
                            (<?- (-dissoc frontend-store (first key-vec) opts))
                            (catch #?(:clj Exception :cljs js/Error) e
                              (log/warn :konserve/tiered-frontend-invalidation-failed {:key (first key-vec) :error e}))))
-                     result)))))
+                     result)
+
+                   :frontend-only
+                   (<?- (-assoc-in frontend-store key-vec meta-up-fn val opts))))))
 
   (-dissoc [_this key opts]
     (log/trace :konserve/tiered-dissoc {:key key})
     (async+sync (:sync? opts)
                 *default-sync-translation*
                 (go-try-
-                 ;; Always remove from both stores
-                 (let [backend-result (-dissoc backend-store key opts)
-                       frontend-result (-dissoc frontend-store key opts)]
-                   (<?- frontend-result)
-                   (<?- backend-result)))))
+                 (if (= write-policy :frontend-only)
+                   ;; Cache mode: delete from the frontend only; never touch the backend.
+                   (<?- (-dissoc frontend-store key opts))
+                   ;; Otherwise remove from both stores
+                   (let [backend-result (-dissoc backend-store key opts)
+                         frontend-result (-dissoc frontend-store key opts)]
+                     (<?- frontend-result)
+                     (<?- backend-result))))))
 
   PBinaryKeyValueStore
   (-bget [_this key locked-cb opts]
@@ -320,7 +336,10 @@
                            (<?- (-dissoc frontend-store key opts))
                            (catch #?(:clj Exception :cljs js/Error) e
                              (log/warn :konserve/tiered-frontend-invalidation-failed {:key key :error e}))))
-                     result)))))
+                     result)
+
+                   :frontend-only
+                   (<?- (-bassoc frontend-store key meta-up-fn val opts))))))
 
   PAssocSerializers
   (-assoc-serializers [this serializers]
@@ -330,12 +349,13 @@
 
   PKeyIterable
   (-keys [_this opts]
-    (log/trace :konserve/tiered-keys {:read-policy read-policy})
-    ;; Respect read-policy: frontend-only returns frontend keys only
-    ;; This is critical for performance when frontend has subset of backend keys
-    (case read-policy
-      :frontend-only (-keys frontend-store opts)
-      :frontend-first (-keys backend-store opts)))
+    (log/trace :konserve/tiered-keys {:read-policy read-policy :write-policy write-policy})
+    ;; A :frontend-only WRITE store (cache mode) enumerates/syncs as its local cache,
+    ;; so `-keys` reports the frontend even though reads fall through to the backend.
+    ;; Otherwise respect read-policy (frontend-only reads => frontend keys).
+    (if (or (= write-policy :frontend-only) (= read-policy :frontend-only))
+      (-keys frontend-store opts)
+      (-keys backend-store opts)))
 
   PMultiKeySupport
   (-supports-multi-key? [_this]
@@ -380,7 +400,10 @@
                              (<?- (-dissoc frontend-store k opts)))
                            (catch #?(:clj Exception :cljs js/Error) e
                              (log/warn :konserve/tiered-frontend-invalidation-failed {:kvs-keys (clojure.core/keys kvs) :error e}))))
-                     result)))))
+                     result)
+
+                   :frontend-only
+                   (<?- (-multi-assoc frontend-store kvs meta-up-fn opts))))))
 
   (-multi-dissoc [_this keys-to-remove opts]
     (log/trace :konserve/tiered-multi-dissoc {:key-count (count keys-to-remove)})
@@ -392,12 +415,15 @@
     (async+sync (:sync? opts)
                 *default-sync-translation*
                 (go-try-
-                 (let [backend-result (<?- (-multi-dissoc backend-store keys-to-remove opts))]
-                   (try
-                     (<?- (-multi-dissoc frontend-store keys-to-remove opts))
-                     (catch #?(:clj Exception :cljs js/Error) e
-                       (log/warn :konserve/tiered-frontend-multi-dissoc-failed {:keys keys-to-remove :error e})))
-                   backend-result))))
+                 (if (= write-policy :frontend-only)
+                   ;; Cache mode: delete from the frontend only; never touch the backend.
+                   (<?- (-multi-dissoc frontend-store keys-to-remove opts))
+                   (let [backend-result (<?- (-multi-dissoc backend-store keys-to-remove opts))]
+                     (try
+                       (<?- (-multi-dissoc frontend-store keys-to-remove opts))
+                       (catch #?(:clj Exception :cljs js/Error) e
+                         (log/warn :konserve/tiered-frontend-multi-dissoc-failed {:keys keys-to-remove :error e})))
+                     backend-result)))))
 
   (-multi-get [_this keys opts]
     (log/trace :konserve/tiered-multi-get {:key-count (count keys)})

--- a/test/konserve/memory_test.cljc
+++ b/test/konserve/memory_test.cljc
@@ -61,6 +61,17 @@
                 (<! (tiered-tests/test-write-policies-async frontend backend))
                 (done))))))
 
+(deftest tiered-store-memory-frontend-only-test
+  #?(:clj
+     (let [{:keys [frontend backend]} (create-tiered-mem-stores)]
+       (<!! (tiered-tests/test-frontend-only-async frontend backend)))
+     :cljs
+     (async done
+            (go
+              (let [{:keys [frontend backend]} (<! (create-tiered-mem-stores))]
+                (<! (tiered-tests/test-frontend-only-async frontend backend))
+                (done))))))
+
 (deftest tiered-store-memory-read-policies-test
   #?(:clj
      (let [{:keys [frontend backend]} (create-tiered-mem-stores)]

--- a/test/konserve/tests/tiered.cljc
+++ b/test/konserve/tests/tiered.cljc
@@ -62,6 +62,36 @@
         (is (= {:value 44} (<?- (k/get-in backend-store [:test-key]))))
         (is (= {:value 44} (<?- (k/get-in store [:test-key]))))))))
 
+(defn test-frontend-only-async
+  "Cache mode: :frontend-only writes + :frontend-first reads. Writes/deletes land in
+   the frontend only (backend is read-only truth), reads fall through on a miss, and
+   -keys reports the frontend."
+  [frontend-store backend-store]
+  (go
+    (testing "Frontend-only (cache) write policy"
+      (let [store (<?- (tiered/connect-tiered-store frontend-store backend-store
+                                                    :write-policy :frontend-only
+                                                    :read-policy :frontend-first))]
+        ;; writes land in the frontend ONLY — the backend is never touched
+        (<?- (k/assoc-in store [:cached] {:v 1}))
+        (is (= {:v 1} (<?- (k/get-in frontend-store [:cached]))) "write went to frontend")
+        (is (nil? (<?- (k/get-in backend-store [:cached]))) "backend NOT written")
+        (is (= {:v 1} (<?- (k/get-in store [:cached]))) "reads from frontend")
+        ;; a key that exists only in the backend (and hasn't been read/cached yet)
+        (<?- (k/assoc-in backend-store [:only-backend] {:v 2}))
+        ;; -keys reports the FRONTEND (the local cache), not the read-only backend
+        (let [ks (set (map :key (<?- (k/keys store))))]
+          (is (contains? ks :cached) "keys includes the cached key")
+          (is (not (contains? ks :only-backend)) "keys excludes the not-yet-cached backend key"))
+        ;; reading it falls through (frontend-first) and warms the frontend cache
+        (is (= {:v 2} (<?- (k/get-in store [:only-backend]))) "cold read falls through to backend")
+        (is (= {:v 2} (<?- (k/get-in frontend-store [:only-backend]))) "read-through warmed the frontend")
+        ;; dissoc removes from the frontend ONLY — a backend copy is untouched
+        (<?- (k/assoc-in backend-store [:cached] {:v 99}))
+        (<?- (k/dissoc store :cached))
+        (is (nil? (<?- (k/get-in frontend-store [:cached]))) "dissoc removed from frontend")
+        (is (= {:v 99} (<?- (k/get-in backend-store [:cached]))) "backend copy untouched by dissoc")))))
+
 (defn test-read-policies-async [frontend-store backend-store]
   (go
     (testing "Frontend-first policy"


### PR DESCRIPTION
Adds a fourth `konserve.tiered` write policy: **`:frontend-only`** — a read-through cache over a **read-only** backend.

## Behaviour (cache mode)
With `:write-policy :frontend-only` (pair it with `:read-policy :frontend-first`):
- **writes** (`-assoc-in`, `-update-in`, `-bassoc`, `-multi-assoc`) go to the **frontend only** — the backend is never mutated by this peer;
- **deletes** (`-dissoc`, `-multi-dissoc`) also hit the frontend only;
- **reads** still fall through to the backend on a frontend miss, and the read-through **warms** the frontend (existing behaviour);
- **`-keys`** reports the **frontend**, so the store enumerates and *syncs* as its local cache rather than mirroring the shared backend.

## Why
A konserve-sync subscriber that warms a **local LMDB frontend over a shared, writer-owned S3 backend it must not write to** — e.g. a Datahike streaming read replica in a db-per-tenant SaaS. The existing policies didn't fit:
- `write-through`/`write-behind` write the backend (wasteful + wrong — readers shouldn't touch shared truth, and it no-ops on content-addressed keys),
- `write-around` inverts the caching, and
- with any of them `-keys` reflected the shared backend, so konserve-sync's handshake saw "nothing missing" and never filled the frontend.

`:frontend-only` gives: **auto-warm the local cache, fall back to S3 on a miss, never write S3.**

## Test
`konserve.tests.tiered/test-frontend-only-async` (wired into `memory_test`) covers: frontend-only writes with the backend untouched, read-through fallthrough + warm, frontend-scoped `-keys`, and frontend-only `dissoc` leaving a backend copy intact. Full memory suite: **74 tests / 1232 assertions, 0 failures**; format clean.