### PR TITLE
feat(encryptor): :aes-gcm authenticated encryption; seal/unseal for raw bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,13 @@ All notable, user-visible changes to konserve are documented here.
   separate change; `:raw?` survives it unchanged.
 
 ### Fixed
+- **The IndexedDB store ignored `:config` entirely.** `connect-idb-store` dropped the
+  caller's `:config` (`(dissoc params :config)`) and always used its own hardcoded
+  map, so `{:encryptor {...}}` and `{:compressor {...}}` were silently discarded —
+  a browser store asked for encryption got none. It now merges the caller's config
+  over the defaults, as both filestores already did. This means the existing
+  IndexedDB `:aes` encryptor test had been passing vacuously against an unencrypted
+  store; it now exercises the cipher for real.
 - **`:lz4` combined with an encryptor was unreadable.** Writes nested the encryptor
   outside the compressor (compress, then encrypt) while reads nested them the other
   way round, so a read tried to LZ4-decompress the ciphertext. The `PEncryptor`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,7 @@ All notable, user-visible changes to konserve are documented here.
   since binary bytes pass through unencrypted (below). It keeps its meaning if
   binary later becomes encrypted by default.
 
-- `konserve.compliance-test/compliance-test` takes an options map:
-  `(compliance-test store {:binary? false})` skips the binary (`bassoc`/`bget`)
-  section for stores that cannot hold binary values.
+- **`konserve.core/encrypted?`** — whether a store encrypts the values it writes.
 
 - **`PReadMissSafe` marker protocol** (`konserve.impl.storage-layout`). A backing
   store implements it to declare that a read of an absent key is side-effect-free

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable, user-visible changes to konserve are documented here.
 ## Unreleased
 
 ### Added
+- **`:aes-gcm` encryptor** — AES-256-GCM authenticated encryption (header byte 2),
+  via geheimnis v2. Unlike the old `:aes`, it *detects* tampering: a flipped,
+  truncated or relocated blob fails its authentication tag and raises instead of
+  being deserialized into a value. Each written blob gets a fresh CSPRNG salt from
+  which a per-blob key is derived (HKDF-SHA-256), so no key ever encrypts more than
+  one message and GCM's nonce-reuse failure mode cannot arise. The associated data
+  binds each ciphertext to its layout version, store-key and slot (`:meta` /
+  `:value`), so a blob cannot be moved to another key or slot and still verify. The
+  format is byte-identical on JVM and ClojureScript.
+
+  ```clojure
+  {:encryptor {:type :aes-gcm :key (konserve.encryptor/generate-key)}}
+  ```
+
+  The key must be 256 bits — 32 raw bytes or a 64-character hex string. konserve
+  does not stretch passphrases; a guessable one would be brute-forced offline
+  against the stored blobs.
+
+  On ClojureScript `:aes-gcm` requires the asynchronous API: Web Crypto exposes no
+  synchronous cipher, so `{:sync? true}` is rejected. The JVM supports both.
+
+- **`konserve.protocols/PEncryptor`** — encryption is now its own protocol
+  (`-encrypt` / `-decrypt` over whole byte arrays) rather than a `PStoreSerializer`
+  decorator. An AEAD cipher has to verify its tag over the complete ciphertext
+  before any plaintext may reach the deserializer, so there was nothing to stream.
+  Custom encryptors implement `PEncryptor`; the ops return a channel, or the byte
+  array directly when `(:sync? env)`.
+
+- **`konserve.core/seal` and `unseal`** — encrypt raw bytes under the store's own
+  key, bound to a konserve key. konserve does not encrypt binary values (see below),
+  so if you want a `bassoc`'d payload encrypted, this is how to do it without
+  managing a second key. The ciphertext is bound to the key and layout version, so
+  bytes sealed under one key do not unseal under another, and (with `:aes-gcm`)
+  tampering is rejected rather than returned as garbage.
+
+  ```clojure
+  (k/bassoc store :thumb (<? (k/seal store :thumb raw-bytes)) {:raw? true})
+  (k/bget store :thumb
+          (fn [{is :input-stream}] (go (<? (k/unseal store :thumb (slurp-bytes is)))))
+          {:raw? true})
+  ```
+
+- **`:raw?` opt on `bassoc` / `bget`** — the explicit opt-out for binary values on
+  an encrypted store: "I own this format and its confidentiality." Required there,
+  since binary bytes pass through unencrypted (below). It keeps its meaning if
+  binary later becomes encrypted by default.
+
+- `konserve.compliance-test/compliance-test` takes an options map:
+  `(compliance-test store {:binary? false})` skips the binary (`bassoc`/`bget`)
+  section for stores that cannot hold binary values.
+
 - **`PReadMissSafe` marker protocol** (`konserve.impl.storage-layout`). A backing
   store implements it to declare that a read of an absent key is side-effect-free
   and reports the miss cleanly — its `-read-header` throws
@@ -42,3 +93,28 @@ All notable, user-visible changes to konserve are documented here.
 - **`konserve.gc/sweep!`** passes `:ignore-existence?` on its single-key delete
   fallback, so GC on a miss-safe store deletes each dead key without a per-key
   `HEAD` probe (the batch `multi-dissoc` path was already probe-free).
+- **Binary values on an encrypted store now require an explicit choice.**
+  `bassoc`/`bget` pass your bytes to storage untouched — the format is yours, and
+  konserve has never encrypted them. On a store with an encryptor configured that
+  used to happen silently, which is not something a user of an encrypted store would
+  expect. Both now raise unless you say which you meant: `seal`/`unseal` the payload
+  under the store's key, or pass `{:raw? true}` to own it yourself. Encrypting binary
+  by default needs chunked AEAD framing to keep `bassoc` streaming, which is a
+  separate change; `:raw?` survives it unchanged.
+
+### Fixed
+- **`:lz4` combined with an encryptor was unreadable.** Writes nested the encryptor
+  outside the compressor (compress, then encrypt) while reads nested them the other
+  way round, so a read tried to LZ4-decompress the ciphertext. The `PEncryptor`
+  split makes the order explicit and symmetric. Only stores using both features were
+  affected; the default compressor is the null one.
+
+### Deprecated
+- **The `:aes` encryptor** (unauthenticated AES-256-CBC, geheimnis v1). It cannot
+  detect tampering, and its per-blob salt comes from `Math.random` on ClojureScript
+  rather than a CSPRNG. Existing blobs remain readable and writable — the on-disk
+  format is unchanged, pinned by a golden vector in the test suite — but new stores
+  should use `:aes-gcm`. Note also that its JVM and JS salt encodings disagree, so a
+  blob written on one platform fails to decrypt on the other roughly one time in
+  five; this is preserved rather than fixed, since fixing it would break the stores
+  it currently works for.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable, user-visible changes to konserve are documented here.
 ## Unreleased
 
 ### Added
+- **Authenticated encryption with `:aes-gcm`.** AES-256-GCM encrypts complete
+  serialized metadata and value segments, with fresh per-segment salt and
+  associated data binding ciphertext to its layout version, key and slot.
+  `konserve.core/seal` / `unseal` provide the same protection for
+  materialized binary payloads; streaming binary remains explicitly raw.
+- **`konserve.protocols/PEncryptor`.** Encryption is separated from streaming
+  serialization so authentication completes before plaintext is decoded.
 - **Metrics, without wrapping a store.** `konserve.metrics` reports every
   operation to a process-wide registry of sinks — `(add-sink! id f)` /
   `(remove-sink! id)`, each a `(fn [event])` — at three levels: `:api` (what
@@ -19,6 +26,8 @@ All notable, user-visible changes to konserve are documented here.
   site.
 
 ### Fixed
+- **IndexedDB now honors caller encoding configuration.** Its connect helper no
+  longer discards the nested encryptor/compressor configuration.
 - **Connecting to an existing IndexedDB store opens it again.** The previous
   fix (connect no longer writes) skipped `-create-store` for a store that
   already exists — and for the IndexedDB backing, `-create-store` *is* the open:

--- a/README.org
+++ b/README.org
@@ -473,13 +473,16 @@ Compression and encryption are supported by the default store implementation
 used by all current backends except lmdb and memory.
 
 #+BEGIN_SRC clojure
-  ;; Store configuration with compression and encryption
+  ;; A 256 bit key, as 32 raw bytes or a 64 character hex string. Keep it outside
+  ;; the store you are encrypting. (konserve.encryptor/generate-key) makes one.
+  (def secret (konserve.encryptor/generate-key))
+
   (def config {:backend :file
                :id #uuid "550e8400-e29b-41d4-a716-44665544000c"
                :path "/tmp/secure-store"
-               :config {:encryptor {:type :aes
-                                   :key "s3cr3t"}
-                       :compressor {:type :lz4}}})
+               :config {:encryptor {:type :aes-gcm
+                                    :key secret}
+                        :compressor {:type :lz4}}})
 
   (def store (k/create-store config {:sync? true}))
 #+END_SRC
@@ -487,10 +490,40 @@ used by all current backends except lmdb and memory.
 *Compression:*
 - LZ4 compression (JVM only)
 
-*Encryption:*
-- AES/CBC/PKCS{5/7}Padding with 256 bit
-- Different salt for each written value
-- Same cold storage format for JVM and JS (cross-runtime compatible)
+*Encryption:* =:aes-gcm=
+- AES-256-GCM, authenticated: a tampered, truncated or relocated blob is rejected
+  on read rather than deserialized. Values written under a different key, or moved
+  to another key's blob, fail to authenticate.
+- A fresh CSPRNG salt per written value derives a per-blob key (HKDF-SHA-256), so
+  no key ever encrypts more than one message.
+- Identical cold storage format on JVM and JS (cross-runtime compatible).
+- On ClojureScript this requires the asynchronous API — Web Crypto has no
+  synchronous cipher, so ={:sync? true}= is rejected.
+
+Binary values are *not* encrypted: =bassoc= / =bget= hand your bytes to storage
+untouched, so the format stays yours. On a store with an encryptor configured you
+therefore have to say which you meant — =seal= the payload under the store's own key,
+or declare ={:raw? true}= and own its confidentiality yourself:
+
+#+BEGIN_SRC clojure
+  ;; encrypted under the store's key, and bound to :thumb — it will not unseal
+  ;; under another key, and tampering is rejected
+  (k/bassoc store :thumb (<? (k/seal store :thumb raw-bytes)) {:raw? true})
+  (k/bget store :thumb
+          (fn [{is :input-stream}]
+            (go (<? (k/unseal store :thumb (slurp-bytes is)))))
+          {:raw? true})
+
+  ;; or: I already encrypted these bytes myself, hands off
+  (k/bassoc store :blob my-ciphertext {:raw? true})
+#+END_SRC
+
+*Encryption:* =:aes= — *deprecated*
+- Unauthenticated AES-256-CBC. It cannot detect tampering, and on ClojureScript its
+  per-blob salt comes from =Math.random= rather than a CSPRNG. Blobs written with it
+  stay readable, but do not choose it for new stores.
+- Its JVM and JS salt encodings disagree, so a blob written on one platform fails to
+  decrypt on the other roughly one time in five. =:aes-gcm= has no such problem.
 
 *** Serialization Formats
 

--- a/README.org
+++ b/README.org
@@ -522,9 +522,12 @@ used by all current backends except lmdb and memory.
   (def config {:backend :file
                :id #uuid "550e8400-e29b-41d4-a716-44665544000c"
                :path "/tmp/secure-store"
-               :config {:encryptor {:type :aes
-                                   :key "s3cr3t"}
-                       :compressor {:type :lz4}}})
+               :config
+               {:encoding
+                {:encryptor {:type :aes-gcm
+                             ;; 32 random bytes, shown as 64 hex characters
+                             :key (konserve.encryptor/generate-key)}
+                 :compressor {:type :lz4}}}})
 
   (def store (k/create-store config {:sync? true}))
 #+END_SRC
@@ -546,9 +549,20 @@ frame header carries **no content size**. A one-shot decompressor fails on
 these frames; use a streaming one. See =interop/read_konserve_blob.py=.
 
 *Encryption:*
-- AES/CBC/PKCS{5/7}Padding with 256 bit
-- Different salt for each written value
-- Same cold storage format for JVM and JS (cross-runtime compatible)
+- =:aes-gcm= — AES-256-GCM authenticated encryption. Each metadata/value
+  segment has a fresh salt and per-segment key; associated data binds it to
+  the layout version, store key, and segment. Tampering, truncation, and moving
+  ciphertext between keys or segments are therefore rejected. Encryptor byte 2.
+- =:aes= — legacy, unauthenticated AES-CBC. Encryptor byte 1. It remains
+  readable for existing stores but must not be selected for new ones.
+- =:aes-gcm= uses the asynchronous API in ClojureScript because Web Crypto has
+  no synchronous cipher. Its bytes are interoperable between JVM and JS.
+
+Binary values remain streaming and are not automatically encrypted. On an
+encrypted store, =bassoc= and =bget= therefore require ={:raw? true}= so
+plaintext cannot be stored accidentally. Use =konserve.core/seal= and =unseal=
+to authenticate and encrypt a materialized binary value under the store's key
+before storing it as raw bytes.
 
 *** Serialization Formats
 
@@ -579,7 +593,7 @@ value:
   byte 0     storage layout version (1)
   byte 1     serializer id      (3 = BoringSerializer)
   byte 2     compressor id      (0 none, 1 lz4, 2 zstd)
-  byte 3     encryptor id       (0 none, 1 aes)
+  byte 3     encryptor id       (0 none, 1 legacy aes, 2 aes-gcm)
   bytes 4-7  metadata length, big-endian
   bytes 8-19 spare, zero
 #+END_SRC

--- a/README.org
+++ b/README.org
@@ -555,6 +555,13 @@ these frames; use a streaming one. See =interop/read_konserve_blob.py=.
   ciphertext between keys or segments are therefore rejected. Encryptor byte 2.
 - =:aes= — legacy, unauthenticated AES-CBC. Encryptor byte 1. It remains
   readable for existing stores but must not be selected for new ones.
+- For control-plane records that must never accept plaintext or legacy CBC,
+  set =:require-authenticated? true= inside the =:encryptor= map alongside
+  =:type :aes-gcm= and =:key=. This rejects weaker header-selected formats
+  before deserialization. The default still permits compatibility reads of
+  older records. Unknown encryptor types now fail instead of selecting none.
+  This policy does not prevent rollback of an older authentic record; keep an
+  independent revision floor where rollback resistance is required.
 - =:aes-gcm= uses the asynchronous API in ClojureScript because Web Crypto has
   no synchronous cipher. Its bytes are interoperable between JVM and JS.
 

--- a/deps.edn
+++ b/deps.edn
@@ -3,9 +3,9 @@
         org.clojure/data.fressian {:mvn/version "1.0.0"} ;; for filestore
         mvxcvi/clj-cbor {:mvn/version "1.1.1"}
         org.replikativ/incognito {:mvn/version "0.3.69"}
-        org.replikativ/hasch {:mvn/version "0.3.96"}
+        org.replikativ/hasch {:mvn/version "0.4.100"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
-        org.replikativ/geheimnis {:mvn/version "0.1.25"}
+        org.replikativ/geheimnis {:mvn/version "0.2.36"}
         org.lz4/lz4-java {:mvn/version "1.8.0"}
         org.replikativ/logging {:mvn/version "0.1.3"}
         ;; cljs

--- a/deps.edn
+++ b/deps.edn
@@ -9,9 +9,13 @@
         ;; compiled into datahike's `dthk` native image, where a reflective call
         ;; works only if it was registered at build time.
         org.replikativ/incognito {:mvn/version "0.3.71"}
-        org.replikativ/hasch {:mvn/version "0.3.96"}
+        org.replikativ/hasch {:mvn/version "0.4.100"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
-        org.replikativ/geheimnis {:mvn/version "0.1.25"}
+        ;; Temporary review pin for geheimnis#10. Replace with its released
+        ;; Maven coordinate before publishing Konserve.
+        org.replikativ/geheimnis
+        {:git/url "https://github.com/replikativ/geheimnis"
+         :git/sha "ed95baf100456ea09c3d6ae4dd089049363785d2"}
         org.lz4/lz4-java {:mvn/version "1.8.0"}
         org.replikativ/logging {:mvn/version "0.1.3"}
         ;; cljs

--- a/deps.edn
+++ b/deps.edn
@@ -11,11 +11,8 @@
         org.replikativ/incognito {:mvn/version "0.3.71"}
         org.replikativ/hasch {:mvn/version "0.4.100"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
-        ;; Temporary review pin for geheimnis#10. Replace with its released
-        ;; Maven coordinate before publishing Konserve.
-        org.replikativ/geheimnis
-        {:git/url "https://github.com/replikativ/geheimnis"
-         :git/sha "ed95baf100456ea09c3d6ae4dd089049363785d2"}
+        ;; Includes the synchronous JVM AEAD APIs used by :aes-gcm.
+        org.replikativ/geheimnis {:mvn/version "0.2.39"}
         org.lz4/lz4-java {:mvn/version "1.8.0"}
         org.replikativ/logging {:mvn/version "0.1.3"}
         ;; cljs

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -11,212 +11,205 @@
           (instance? Throwable thing)))
 
 #?(:clj
-   (defn compliance-test
-     "Exercise the full store API against `store`.
+   (defn compliance-test [store]
+     (doseq [opts [{:sync? false} {:sync? true}]
+             ;; binary values are never encrypted — they pass through to storage as
+             ;; given — so an encrypted store requires the caller to say so
+             :let [<!! (if (:sync? opts) identity <!!)
+                   bin-opts (cond-> opts (k/encrypted? store) (clojure.core/assoc :raw? true))]]
 
-     `:binary?` (default true) covers bassoc/bget. Pass false for stores that
-     cannot hold binary values — notably encrypted ones, where binary would bypass
-     the cipher and is refused."
-     ([store] (compliance-test store {}))
-     ([store {:keys [binary?] :or {binary? true}}]
-      (doseq [opts [{:sync? false} {:sync? true}]
-              :let [<!! (if (:sync? opts) identity <!!)]]
+       (testing "Testing the append store functionality."
+         (<!! (k/append store :foolog {:bar 42} opts))
+         (<!! (k/append store :foolog {:bar 43} opts))
+         (is (= (<!! (k/log store :foolog opts))
+                '({:bar 42}
+                  {:bar 43})))
+         (is (= (<!! (k/reduce-log store
+                                   :foolog
+                                   (fn [acc elem]
+                                     (conj acc elem))
+                                   []
+                                   opts))
+                [{:bar 42} {:bar 43}]))
+         (let [{:keys [key type last-write]} (<!! (k/get-meta store :foolog nil opts))]
+           (are [x y] (= x y)
+             :foolog        key
+             :append-log    type
+             java.util.Date (clojure.core/type last-write))))
 
-        (testing "Testing the append store functionality."
-          (<!! (k/append store :foolog {:bar 42} opts))
-          (<!! (k/append store :foolog {:bar 43} opts))
-          (is (= (<!! (k/log store :foolog opts))
-                 '({:bar 42}
-                   {:bar 43})))
-          (is (= (<!! (k/reduce-log store
-                                    :foolog
-                                    (fn [acc elem]
-                                      (conj acc elem))
-                                    []
-                                    opts))
-                 [{:bar 42} {:bar 43}]))
-          (let [{:keys [key type last-write]} (<!! (k/get-meta store :foolog nil opts))]
-            (are [x y] (= x y)
-              :foolog        key
-              :append-log    type
-              java.util.Date (clojure.core/type last-write))))
+       (testing "Test the core API."
+         (is (= nil (<!! (k/get store :foo nil opts))))
+         (is (false? (<!! (k/exists? store :foo opts))))
+         (<!! (k/assoc store :foo :bar opts))
+         (is (<!! (k/exists? store :foo opts)))
+         (is (= :bar (<!! (k/get store :foo nil opts))))
+         (<!! (k/assoc-in store [:foo] :bar2 opts))
+         (is (= :bar2 (<!! (k/get store :foo nil opts))))
+         (is (= :default (<!! (k/get-in store [:fuu] :default opts))))
+         (is (= :bar2 (<!! (k/get store :foo nil opts))))
+         (is (= :default (<!! (k/get-in store [:fuu] :default opts))))
+         (<!! (k/update-in store [:foo] name opts))
+         (is (= "bar2" (<!! (k/get store :foo nil opts))))
+         (<!! (k/assoc-in store [:baz] {:bar 42} opts))
+         (<!! (k/assoc-in store [:baz :barf] 43 opts))
+         (is (= 42 (<!! (k/get-in store [:baz :bar] nil opts))))
+         (<!! (k/update-in store [:baz :bar] inc opts))
+         (is (= 43 (<!! (k/get-in store [:baz :bar] nil opts))))
+         (<!! (k/update-in store [:baz :bar] (fn [x] (+ x 2 3)) opts))
+         (is (= 48 (<!! (k/get-in store [:baz :bar] nil opts))))
+         (is (= true (<!! (k/dissoc store :foo opts))))
+         (is (= false (<!! (k/dissoc store :not-there opts))))
+         (is (= nil (<!! (k/get-in store [:foo] nil opts))))
+         (<!! (k/bassoc store :binbar (byte-array (range 10)) bin-opts))
+         (<!! (k/bget store :binbar (fn [{:keys [input-stream]}]
+                                      (go
+                                        (is (= (map byte (slurp input-stream))
+                                               (range 10)))
+                                        true))
+                      bin-opts))
+         (let  [list-keys (<!! (k/keys store opts))]
+           (are [x y] (= x y)
+             #{{:key :baz
+                :type :edn}
+               {:key :binbar
+                :type :binary}
+               {:key :foolog
+                :type :append-log}}
+             (->> list-keys (map #(clojure.core/dissoc % :last-write)) set)
+             true
+             (every?
+              (fn [{:keys [:last-write]}]
+                (= (type (java.util.Date.)) (type last-write)))
+              list-keys)))
 
-        (testing "Test the core API."
-          (is (= nil (<!! (k/get store :foo nil opts))))
-          (is (false? (<!! (k/exists? store :foo opts))))
-          (<!! (k/assoc store :foo :bar opts))
-          (is (<!! (k/exists? store :foo opts)))
-          (is (= :bar (<!! (k/get store :foo nil opts))))
-          (<!! (k/assoc-in store [:foo] :bar2 opts))
-          (is (= :bar2 (<!! (k/get store :foo nil opts))))
-          (is (= :default (<!! (k/get-in store [:fuu] :default opts))))
-          (is (= :bar2 (<!! (k/get store :foo nil opts))))
-          (is (= :default (<!! (k/get-in store [:fuu] :default opts))))
-          (<!! (k/update-in store [:foo] name opts))
-          (is (= "bar2" (<!! (k/get store :foo nil opts))))
-          (<!! (k/assoc-in store [:baz] {:bar 42} opts))
-          (<!! (k/assoc-in store [:baz :barf] 43 opts))
-          (is (= 42 (<!! (k/get-in store [:baz :bar] nil opts))))
-          (<!! (k/update-in store [:baz :bar] inc opts))
-          (is (= 43 (<!! (k/get-in store [:baz :bar] nil opts))))
-          (<!! (k/update-in store [:baz :bar] (fn [x] (+ x 2 3)) opts))
-          (is (= 48 (<!! (k/get-in store [:baz :bar] nil opts))))
-          (is (= true (<!! (k/dissoc store :foo opts))))
-          (is (= false (<!! (k/dissoc store :not-there opts))))
-          (is (= nil (<!! (k/get-in store [:foo] nil opts))))
-          (when binary?
-            (<!! (k/bassoc store :binbar (byte-array (range 10)) opts))
-            (<!! (k/bget store :binbar (fn [{:keys [input-stream]}]
-                                         (go
-                                           (is (= (map byte (slurp input-stream))
-                                                  (range 10)))
-                                           true))
-                         opts)))
-          (let  [list-keys (<!! (k/keys store opts))]
-            (are [x y] (= x y)
-              (cond-> #{{:key :baz
-                         :type :edn}
-                        {:key :foolog
-                         :type :append-log}}
-                binary? (conj {:key :binbar
-                               :type :binary}))
-              (->> list-keys (map #(clojure.core/dissoc % :last-write)) set)
-              true
-              (every?
-               (fn [{:keys [:last-write]}]
-                 (= (type (java.util.Date.)) (type last-write)))
-               list-keys)))
-
-          (doseq [to-delete (cond-> [:baz :foolog] binary? (conj :binbar))]
-            (<!! (k/dissoc store to-delete opts)))
+         (doseq [to-delete [:baz :binbar :foolog]]
+           (<!! (k/dissoc store to-delete opts)))
 
         ;; TODO fix by adding spec to core and cache namespace
-          #_(let [params (clojure.core/keys store)
-                  corruptor (fn [s k]
-                              (if (= (type (k s)) clojure.lang.Atom)
-                                (clojure.core/assoc-in s [k] (atom {}))
-                                (clojure.core/assoc-in s [k] (UnknownType.))))
-                  corrupt (reduce corruptor store params)]
-              (is (exception? (<!! (get corrupt :bad))))
-              (is (exception? (<!! (get-meta corrupt :bad))))
-              (is (exception? (<!! (assoc corrupt :bad 10))))
-              (is (exception? (<!! (dissoc corrupt :bad))))
-              (is (exception? (<!! (assoc-in corrupt [:bad :robot] 10))))
-              (is (exception? (<!! (update-in corrupt [:bad :robot] inc))))
-              (is (exception? (<!! (exists? corrupt :bad))))
-              (is (exception? (<!! (keys corrupt))))
-              (is (exception? (<!! (bget corrupt :bad (fn [_] nil)))))
-              (is (exception? (<!! (bassoc corrupt :binbar (byte-array (range 10))))))))
+         #_(let [params (clojure.core/keys store)
+                 corruptor (fn [s k]
+                             (if (= (type (k s)) clojure.lang.Atom)
+                               (clojure.core/assoc-in s [k] (atom {}))
+                               (clojure.core/assoc-in s [k] (UnknownType.))))
+                 corrupt (reduce corruptor store params)]
+             (is (exception? (<!! (get corrupt :bad))))
+             (is (exception? (<!! (get-meta corrupt :bad))))
+             (is (exception? (<!! (assoc corrupt :bad 10))))
+             (is (exception? (<!! (dissoc corrupt :bad))))
+             (is (exception? (<!! (assoc-in corrupt [:bad :robot] 10))))
+             (is (exception? (<!! (update-in corrupt [:bad :robot] inc))))
+             (is (exception? (<!! (exists? corrupt :bad))))
+             (is (exception? (<!! (keys corrupt))))
+             (is (exception? (<!! (bget corrupt :bad (fn [_] nil)))))
+             (is (exception? (<!! (bassoc corrupt :binbar (byte-array (range 10))))))))
 
        ;; Optional test for multi-key operations - runs if store supports it
-        (when (utils/multi-key-capable? store)
-          (testing "Testing multi-key operations"
+       (when (utils/multi-key-capable? store)
+         (testing "Testing multi-key operations"
              ;; Test multi-assoc with flat keys
-            (let [result (<!! (k/multi-assoc store {:multi1 42 :multi2 "value"} opts))]
-              (is (= result {:multi1 true :multi2 true}))
-              (is (= 42 (<!! (k/get store :multi1 nil opts))))
-              (is (= "value" (<!! (k/get store :multi2 nil opts)))))
+           (let [result (<!! (k/multi-assoc store {:multi1 42 :multi2 "value"} opts))]
+             (is (= result {:multi1 true :multi2 true}))
+             (is (= 42 (<!! (k/get store :multi1 nil opts))))
+             (is (= "value" (<!! (k/get store :multi2 nil opts)))))
 
              ;; Test multi-dissoc with existing keys
-            (let [result (<!! (k/multi-dissoc store [:multi1 :multi2] opts))]
-              (is (= result {:multi1 true :multi2 true}))
-              (is (= nil (<!! (k/get store :multi1 nil opts))))
-              (is (= nil (<!! (k/get store :multi2 nil opts)))))
+           (let [result (<!! (k/multi-dissoc store [:multi1 :multi2] opts))]
+             (is (= result {:multi1 true :multi2 true}))
+             (is (= nil (<!! (k/get store :multi1 nil opts))))
+             (is (= nil (<!! (k/get store :multi2 nil opts)))))
 
              ;; Test multi-dissoc with non-existing keys
-            (let [result (<!! (k/multi-dissoc store [:nonexistent1 :nonexistent2] opts))]
-              (is (= result {:nonexistent1 false :nonexistent2 false})))
+           (let [result (<!! (k/multi-dissoc store [:nonexistent1 :nonexistent2] opts))]
+             (is (= result {:nonexistent1 false :nonexistent2 false})))
 
              ;; Test multi-dissoc with mix of existing and non-existing keys
-            (<!! (k/multi-assoc store {:multi3 "test3" :multi4 "test4"} opts))
-            (let [result (<!! (k/multi-dissoc store [:multi3 :multi4 :nonexistent3] opts))]
-              (is (= result {:multi3 true :multi4 true :nonexistent3 false}))
-              (is (= nil (<!! (k/get store :multi3 nil opts))))
-              (is (= nil (<!! (k/get store :multi4 nil opts)))))
+           (<!! (k/multi-assoc store {:multi3 "test3" :multi4 "test4"} opts))
+           (let [result (<!! (k/multi-dissoc store [:multi3 :multi4 :nonexistent3] opts))]
+             (is (= result {:multi3 true :multi4 true :nonexistent3 false}))
+             (is (= nil (<!! (k/get store :multi3 nil opts))))
+             (is (= nil (<!! (k/get store :multi4 nil opts)))))
 
              ;; Test multi-get with existing keys
-            (<!! (k/multi-assoc store {:multi5 "value5" :multi6 {:nested "data"} :multi7 123} opts))
-            (let [result (<!! (k/multi-get store [:multi5 :multi6 :multi7] opts))]
-              (is (= result {:multi5 "value5" :multi6 {:nested "data"} :multi7 123})))
+           (<!! (k/multi-assoc store {:multi5 "value5" :multi6 {:nested "data"} :multi7 123} opts))
+           (let [result (<!! (k/multi-get store [:multi5 :multi6 :multi7] opts))]
+             (is (= result {:multi5 "value5" :multi6 {:nested "data"} :multi7 123})))
 
              ;; Test multi-get with some missing keys (sparse map behavior)
-            (let [result (<!! (k/multi-get store [:multi5 :nonexistent :multi7] opts))]
+           (let [result (<!! (k/multi-get store [:multi5 :nonexistent :multi7] opts))]
              ;; Should only contain found keys
-              (is (= result {:multi5 "value5" :multi7 123}))
+             (is (= result {:multi5 "value5" :multi7 123}))
              ;; Verify missing key is not in result
-              (is (not (contains? result :nonexistent))))
+             (is (not (contains? result :nonexistent))))
 
              ;; Test multi-get with all missing keys
-            (let [result (<!! (k/multi-get store [:missing1 :missing2 :missing3] opts))]
+           (let [result (<!! (k/multi-get store [:missing1 :missing2 :missing3] opts))]
              ;; Should return empty map
-              (is (= result {})))
+             (is (= result {})))
 
              ;; Test multi-get with empty key list
-            (let [result (<!! (k/multi-get store [] opts))]
+           (let [result (<!! (k/multi-get store [] opts))]
              ;; Should return empty map
-              (is (= result {})))
+             (is (= result {})))
 
              ;; Clean up multi-get test keys
-            (<!! (k/multi-dissoc store [:multi5 :multi6 :multi7] opts))))
+           (<!! (k/multi-dissoc store [:multi5 :multi6 :multi7] opts))))
 
       ;; Optional test for write hooks - runs if store supports it
-        (when (utils/write-hooks-capable? store)
-          (testing "Testing write hooks"
-            (let [hook-events (atom [])]
+       (when (utils/write-hooks-capable? store)
+         (testing "Testing write hooks"
+           (let [hook-events (atom [])]
             ;; Register a hook that captures events
-              (k/add-write-hook! store ::test-hook
-                                 (fn [event]
-                                   (swap! hook-events conj event)))
+             (k/add-write-hook! store ::test-hook
+                                (fn [event]
+                                  (swap! hook-events conj event)))
 
             ;; Test assoc-in triggers hook
-              (<!! (k/assoc-in store [:hook-test] {:value 42} opts))
-              (is (= 1 (count @hook-events)))
-              (is (= :assoc-in (:api-op (first @hook-events))))
-              (is (= :hook-test (:key (first @hook-events))))
-              (is (= {:value 42} (:value (first @hook-events))))
-              (is (= [:hook-test] (:key-vec (first @hook-events))))
+             (<!! (k/assoc-in store [:hook-test] {:value 42} opts))
+             (is (= 1 (count @hook-events)))
+             (is (= :assoc-in (:api-op (first @hook-events))))
+             (is (= :hook-test (:key (first @hook-events))))
+             (is (= {:value 42} (:value (first @hook-events))))
+             (is (= [:hook-test] (:key-vec (first @hook-events))))
 
             ;; Test update-in triggers hook
-              (<!! (k/update-in store [:hook-test :value] inc opts))
-              (is (= 2 (count @hook-events)))
-              (is (= :update-in (:api-op (second @hook-events))))
-              (is (= :hook-test (:key (second @hook-events))))
-              (is (= [:hook-test :value] (:key-vec (second @hook-events))))
+             (<!! (k/update-in store [:hook-test :value] inc opts))
+             (is (= 2 (count @hook-events)))
+             (is (= :update-in (:api-op (second @hook-events))))
+             (is (= :hook-test (:key (second @hook-events))))
+             (is (= [:hook-test :value] (:key-vec (second @hook-events))))
 
             ;; Test dissoc triggers hook
-              (<!! (k/dissoc store :hook-test opts))
-              (is (= 3 (count @hook-events)))
-              (is (= :dissoc (:api-op (nth @hook-events 2))))
-              (is (= :hook-test (:key (nth @hook-events 2))))
+             (<!! (k/dissoc store :hook-test opts))
+             (is (= 3 (count @hook-events)))
+             (is (= :dissoc (:api-op (nth @hook-events 2))))
+             (is (= :hook-test (:key (nth @hook-events 2))))
 
             ;; Test bassoc triggers hook
-              (when binary?
-                (<!! (k/bassoc store :hook-bin (byte-array [1 2 3]) opts))
-                (is (= 4 (count @hook-events)))
-                (is (= :bassoc (:api-op (nth @hook-events 3))))
-                (is (= :hook-bin (:key (nth @hook-events 3)))))
+             (<!! (k/bassoc store :hook-bin (byte-array [1 2 3]) bin-opts))
+             (is (= 4 (count @hook-events)))
+             (is (= :bassoc (:api-op (nth @hook-events 3))))
+             (is (= :hook-bin (:key (nth @hook-events 3))))
 
             ;; Test multi-assoc triggers hook (if supported)
-              (when (utils/multi-key-capable? store)
-                (let [before (count @hook-events)]
-                  (<!! (k/multi-assoc store {:hook-m1 1 :hook-m2 2} opts))
-                  (is (= (inc before) (count @hook-events)))
-                  (is (= :multi-assoc (:api-op (last @hook-events))))
-                  (is (= {:hook-m1 1 :hook-m2 2} (:kvs (last @hook-events)))))
+             (when (utils/multi-key-capable? store)
+               (<!! (k/multi-assoc store {:hook-m1 1 :hook-m2 2} opts))
+               (is (= 5 (count @hook-events)))
+               (is (= :multi-assoc (:api-op (nth @hook-events 4))))
+               (is (= {:hook-m1 1 :hook-m2 2} (:kvs (nth @hook-events 4))))
               ;; Clean up multi-assoc keys
-                (<!! (k/dissoc store :hook-m1 opts))
-                (<!! (k/dissoc store :hook-m2 opts)))
+               (<!! (k/dissoc store :hook-m1 opts))
+               (<!! (k/dissoc store :hook-m2 opts)))
 
             ;; Test removing hook - should stop receiving events
-              (k/remove-write-hook! store ::test-hook)
-              (let [count-before (count @hook-events)]
-                (<!! (k/assoc-in store [:hook-after-remove] "test" opts))
-                (is (= count-before (count @hook-events))
-                    "No new events after hook removal"))
+             (k/remove-write-hook! store ::test-hook)
+             (let [count-before (count @hook-events)]
+               (<!! (k/assoc-in store [:hook-after-remove] "test" opts))
+               (is (= count-before (count @hook-events))
+                   "No new events after hook removal"))
 
             ;; Clean up
-              (when binary? (<!! (k/dissoc store :hook-bin opts)))
-              (<!! (k/dissoc store :hook-after-remove opts)))))))))
+             (<!! (k/dissoc store :hook-bin opts))
+             (<!! (k/dissoc store :hook-after-remove opts))))))))
 
 (defn async-compliance-test [store]
   (go

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -11,202 +11,212 @@
           (instance? Throwable thing)))
 
 #?(:clj
-   (defn compliance-test [store]
-     (doseq [opts [{:sync? false} {:sync? true}]
-             :let [<!! (if (:sync? opts) identity <!!)]]
+   (defn compliance-test
+     "Exercise the full store API against `store`.
 
-       (testing "Testing the append store functionality."
-         (<!! (k/append store :foolog {:bar 42} opts))
-         (<!! (k/append store :foolog {:bar 43} opts))
-         (is (= (<!! (k/log store :foolog opts))
-                '({:bar 42}
-                  {:bar 43})))
-         (is (= (<!! (k/reduce-log store
-                                   :foolog
-                                   (fn [acc elem]
-                                     (conj acc elem))
-                                   []
-                                   opts))
-                [{:bar 42} {:bar 43}]))
-         (let [{:keys [key type last-write]} (<!! (k/get-meta store :foolog nil opts))]
-           (are [x y] (= x y)
-             :foolog        key
-             :append-log    type
-             java.util.Date (clojure.core/type last-write))))
+     `:binary?` (default true) covers bassoc/bget. Pass false for stores that
+     cannot hold binary values — notably encrypted ones, where binary would bypass
+     the cipher and is refused."
+     ([store] (compliance-test store {}))
+     ([store {:keys [binary?] :or {binary? true}}]
+      (doseq [opts [{:sync? false} {:sync? true}]
+              :let [<!! (if (:sync? opts) identity <!!)]]
 
-       (testing "Test the core API."
-         (is (= nil (<!! (k/get store :foo nil opts))))
-         (is (false? (<!! (k/exists? store :foo opts))))
-         (<!! (k/assoc store :foo :bar opts))
-         (is (<!! (k/exists? store :foo opts)))
-         (is (= :bar (<!! (k/get store :foo nil opts))))
-         (<!! (k/assoc-in store [:foo] :bar2 opts))
-         (is (= :bar2 (<!! (k/get store :foo nil opts))))
-         (is (= :default (<!! (k/get-in store [:fuu] :default opts))))
-         (is (= :bar2 (<!! (k/get store :foo nil opts))))
-         (is (= :default (<!! (k/get-in store [:fuu] :default opts))))
-         (<!! (k/update-in store [:foo] name opts))
-         (is (= "bar2" (<!! (k/get store :foo nil opts))))
-         (<!! (k/assoc-in store [:baz] {:bar 42} opts))
-         (<!! (k/assoc-in store [:baz :barf] 43 opts))
-         (is (= 42 (<!! (k/get-in store [:baz :bar] nil opts))))
-         (<!! (k/update-in store [:baz :bar] inc opts))
-         (is (= 43 (<!! (k/get-in store [:baz :bar] nil opts))))
-         (<!! (k/update-in store [:baz :bar] (fn [x] (+ x 2 3)) opts))
-         (is (= 48 (<!! (k/get-in store [:baz :bar] nil opts))))
-         (is (= true (<!! (k/dissoc store :foo opts))))
-         (is (= false (<!! (k/dissoc store :not-there opts))))
-         (is (= nil (<!! (k/get-in store [:foo] nil opts))))
-         (<!! (k/bassoc store :binbar (byte-array (range 10)) opts))
-         (<!! (k/bget store :binbar (fn [{:keys [input-stream]}]
-                                      (go
-                                        (is (= (map byte (slurp input-stream))
-                                               (range 10)))
-                                        true))
-                      opts))
-         (let  [list-keys (<!! (k/keys store opts))]
-           (are [x y] (= x y)
-             #{{:key :baz
-                :type :edn}
-               {:key :binbar
-                :type :binary}
-               {:key :foolog
-                :type :append-log}}
-             (->> list-keys (map #(clojure.core/dissoc % :last-write)) set)
-             true
-             (every?
-              (fn [{:keys [:last-write]}]
-                (= (type (java.util.Date.)) (type last-write)))
-              list-keys)))
+        (testing "Testing the append store functionality."
+          (<!! (k/append store :foolog {:bar 42} opts))
+          (<!! (k/append store :foolog {:bar 43} opts))
+          (is (= (<!! (k/log store :foolog opts))
+                 '({:bar 42}
+                   {:bar 43})))
+          (is (= (<!! (k/reduce-log store
+                                    :foolog
+                                    (fn [acc elem]
+                                      (conj acc elem))
+                                    []
+                                    opts))
+                 [{:bar 42} {:bar 43}]))
+          (let [{:keys [key type last-write]} (<!! (k/get-meta store :foolog nil opts))]
+            (are [x y] (= x y)
+              :foolog        key
+              :append-log    type
+              java.util.Date (clojure.core/type last-write))))
 
-         (doseq [to-delete [:baz :binbar :foolog]]
-           (<!! (k/dissoc store to-delete opts)))
+        (testing "Test the core API."
+          (is (= nil (<!! (k/get store :foo nil opts))))
+          (is (false? (<!! (k/exists? store :foo opts))))
+          (<!! (k/assoc store :foo :bar opts))
+          (is (<!! (k/exists? store :foo opts)))
+          (is (= :bar (<!! (k/get store :foo nil opts))))
+          (<!! (k/assoc-in store [:foo] :bar2 opts))
+          (is (= :bar2 (<!! (k/get store :foo nil opts))))
+          (is (= :default (<!! (k/get-in store [:fuu] :default opts))))
+          (is (= :bar2 (<!! (k/get store :foo nil opts))))
+          (is (= :default (<!! (k/get-in store [:fuu] :default opts))))
+          (<!! (k/update-in store [:foo] name opts))
+          (is (= "bar2" (<!! (k/get store :foo nil opts))))
+          (<!! (k/assoc-in store [:baz] {:bar 42} opts))
+          (<!! (k/assoc-in store [:baz :barf] 43 opts))
+          (is (= 42 (<!! (k/get-in store [:baz :bar] nil opts))))
+          (<!! (k/update-in store [:baz :bar] inc opts))
+          (is (= 43 (<!! (k/get-in store [:baz :bar] nil opts))))
+          (<!! (k/update-in store [:baz :bar] (fn [x] (+ x 2 3)) opts))
+          (is (= 48 (<!! (k/get-in store [:baz :bar] nil opts))))
+          (is (= true (<!! (k/dissoc store :foo opts))))
+          (is (= false (<!! (k/dissoc store :not-there opts))))
+          (is (= nil (<!! (k/get-in store [:foo] nil opts))))
+          (when binary?
+            (<!! (k/bassoc store :binbar (byte-array (range 10)) opts))
+            (<!! (k/bget store :binbar (fn [{:keys [input-stream]}]
+                                         (go
+                                           (is (= (map byte (slurp input-stream))
+                                                  (range 10)))
+                                           true))
+                         opts)))
+          (let  [list-keys (<!! (k/keys store opts))]
+            (are [x y] (= x y)
+              (cond-> #{{:key :baz
+                         :type :edn}
+                        {:key :foolog
+                         :type :append-log}}
+                binary? (conj {:key :binbar
+                               :type :binary}))
+              (->> list-keys (map #(clojure.core/dissoc % :last-write)) set)
+              true
+              (every?
+               (fn [{:keys [:last-write]}]
+                 (= (type (java.util.Date.)) (type last-write)))
+               list-keys)))
+
+          (doseq [to-delete (cond-> [:baz :foolog] binary? (conj :binbar))]
+            (<!! (k/dissoc store to-delete opts)))
 
         ;; TODO fix by adding spec to core and cache namespace
-         #_(let [params (clojure.core/keys store)
-                 corruptor (fn [s k]
-                             (if (= (type (k s)) clojure.lang.Atom)
-                               (clojure.core/assoc-in s [k] (atom {}))
-                               (clojure.core/assoc-in s [k] (UnknownType.))))
-                 corrupt (reduce corruptor store params)]
-             (is (exception? (<!! (get corrupt :bad))))
-             (is (exception? (<!! (get-meta corrupt :bad))))
-             (is (exception? (<!! (assoc corrupt :bad 10))))
-             (is (exception? (<!! (dissoc corrupt :bad))))
-             (is (exception? (<!! (assoc-in corrupt [:bad :robot] 10))))
-             (is (exception? (<!! (update-in corrupt [:bad :robot] inc))))
-             (is (exception? (<!! (exists? corrupt :bad))))
-             (is (exception? (<!! (keys corrupt))))
-             (is (exception? (<!! (bget corrupt :bad (fn [_] nil)))))
-             (is (exception? (<!! (bassoc corrupt :binbar (byte-array (range 10))))))))
+          #_(let [params (clojure.core/keys store)
+                  corruptor (fn [s k]
+                              (if (= (type (k s)) clojure.lang.Atom)
+                                (clojure.core/assoc-in s [k] (atom {}))
+                                (clojure.core/assoc-in s [k] (UnknownType.))))
+                  corrupt (reduce corruptor store params)]
+              (is (exception? (<!! (get corrupt :bad))))
+              (is (exception? (<!! (get-meta corrupt :bad))))
+              (is (exception? (<!! (assoc corrupt :bad 10))))
+              (is (exception? (<!! (dissoc corrupt :bad))))
+              (is (exception? (<!! (assoc-in corrupt [:bad :robot] 10))))
+              (is (exception? (<!! (update-in corrupt [:bad :robot] inc))))
+              (is (exception? (<!! (exists? corrupt :bad))))
+              (is (exception? (<!! (keys corrupt))))
+              (is (exception? (<!! (bget corrupt :bad (fn [_] nil)))))
+              (is (exception? (<!! (bassoc corrupt :binbar (byte-array (range 10))))))))
 
        ;; Optional test for multi-key operations - runs if store supports it
-       (when (utils/multi-key-capable? store)
-         (testing "Testing multi-key operations"
+        (when (utils/multi-key-capable? store)
+          (testing "Testing multi-key operations"
              ;; Test multi-assoc with flat keys
-           (let [result (<!! (k/multi-assoc store {:multi1 42 :multi2 "value"} opts))]
-             (is (= result {:multi1 true :multi2 true}))
-             (is (= 42 (<!! (k/get store :multi1 nil opts))))
-             (is (= "value" (<!! (k/get store :multi2 nil opts)))))
+            (let [result (<!! (k/multi-assoc store {:multi1 42 :multi2 "value"} opts))]
+              (is (= result {:multi1 true :multi2 true}))
+              (is (= 42 (<!! (k/get store :multi1 nil opts))))
+              (is (= "value" (<!! (k/get store :multi2 nil opts)))))
 
              ;; Test multi-dissoc with existing keys
-           (let [result (<!! (k/multi-dissoc store [:multi1 :multi2] opts))]
-             (is (= result {:multi1 true :multi2 true}))
-             (is (= nil (<!! (k/get store :multi1 nil opts))))
-             (is (= nil (<!! (k/get store :multi2 nil opts)))))
+            (let [result (<!! (k/multi-dissoc store [:multi1 :multi2] opts))]
+              (is (= result {:multi1 true :multi2 true}))
+              (is (= nil (<!! (k/get store :multi1 nil opts))))
+              (is (= nil (<!! (k/get store :multi2 nil opts)))))
 
              ;; Test multi-dissoc with non-existing keys
-           (let [result (<!! (k/multi-dissoc store [:nonexistent1 :nonexistent2] opts))]
-             (is (= result {:nonexistent1 false :nonexistent2 false})))
+            (let [result (<!! (k/multi-dissoc store [:nonexistent1 :nonexistent2] opts))]
+              (is (= result {:nonexistent1 false :nonexistent2 false})))
 
              ;; Test multi-dissoc with mix of existing and non-existing keys
-           (<!! (k/multi-assoc store {:multi3 "test3" :multi4 "test4"} opts))
-           (let [result (<!! (k/multi-dissoc store [:multi3 :multi4 :nonexistent3] opts))]
-             (is (= result {:multi3 true :multi4 true :nonexistent3 false}))
-             (is (= nil (<!! (k/get store :multi3 nil opts))))
-             (is (= nil (<!! (k/get store :multi4 nil opts)))))
+            (<!! (k/multi-assoc store {:multi3 "test3" :multi4 "test4"} opts))
+            (let [result (<!! (k/multi-dissoc store [:multi3 :multi4 :nonexistent3] opts))]
+              (is (= result {:multi3 true :multi4 true :nonexistent3 false}))
+              (is (= nil (<!! (k/get store :multi3 nil opts))))
+              (is (= nil (<!! (k/get store :multi4 nil opts)))))
 
              ;; Test multi-get with existing keys
-           (<!! (k/multi-assoc store {:multi5 "value5" :multi6 {:nested "data"} :multi7 123} opts))
-           (let [result (<!! (k/multi-get store [:multi5 :multi6 :multi7] opts))]
-             (is (= result {:multi5 "value5" :multi6 {:nested "data"} :multi7 123})))
+            (<!! (k/multi-assoc store {:multi5 "value5" :multi6 {:nested "data"} :multi7 123} opts))
+            (let [result (<!! (k/multi-get store [:multi5 :multi6 :multi7] opts))]
+              (is (= result {:multi5 "value5" :multi6 {:nested "data"} :multi7 123})))
 
              ;; Test multi-get with some missing keys (sparse map behavior)
-           (let [result (<!! (k/multi-get store [:multi5 :nonexistent :multi7] opts))]
+            (let [result (<!! (k/multi-get store [:multi5 :nonexistent :multi7] opts))]
              ;; Should only contain found keys
-             (is (= result {:multi5 "value5" :multi7 123}))
+              (is (= result {:multi5 "value5" :multi7 123}))
              ;; Verify missing key is not in result
-             (is (not (contains? result :nonexistent))))
+              (is (not (contains? result :nonexistent))))
 
              ;; Test multi-get with all missing keys
-           (let [result (<!! (k/multi-get store [:missing1 :missing2 :missing3] opts))]
+            (let [result (<!! (k/multi-get store [:missing1 :missing2 :missing3] opts))]
              ;; Should return empty map
-             (is (= result {})))
+              (is (= result {})))
 
              ;; Test multi-get with empty key list
-           (let [result (<!! (k/multi-get store [] opts))]
+            (let [result (<!! (k/multi-get store [] opts))]
              ;; Should return empty map
-             (is (= result {})))
+              (is (= result {})))
 
              ;; Clean up multi-get test keys
-           (<!! (k/multi-dissoc store [:multi5 :multi6 :multi7] opts))))
+            (<!! (k/multi-dissoc store [:multi5 :multi6 :multi7] opts))))
 
       ;; Optional test for write hooks - runs if store supports it
-       (when (utils/write-hooks-capable? store)
-         (testing "Testing write hooks"
-           (let [hook-events (atom [])]
+        (when (utils/write-hooks-capable? store)
+          (testing "Testing write hooks"
+            (let [hook-events (atom [])]
             ;; Register a hook that captures events
-             (k/add-write-hook! store ::test-hook
-                                (fn [event]
-                                  (swap! hook-events conj event)))
+              (k/add-write-hook! store ::test-hook
+                                 (fn [event]
+                                   (swap! hook-events conj event)))
 
             ;; Test assoc-in triggers hook
-             (<!! (k/assoc-in store [:hook-test] {:value 42} opts))
-             (is (= 1 (count @hook-events)))
-             (is (= :assoc-in (:api-op (first @hook-events))))
-             (is (= :hook-test (:key (first @hook-events))))
-             (is (= {:value 42} (:value (first @hook-events))))
-             (is (= [:hook-test] (:key-vec (first @hook-events))))
+              (<!! (k/assoc-in store [:hook-test] {:value 42} opts))
+              (is (= 1 (count @hook-events)))
+              (is (= :assoc-in (:api-op (first @hook-events))))
+              (is (= :hook-test (:key (first @hook-events))))
+              (is (= {:value 42} (:value (first @hook-events))))
+              (is (= [:hook-test] (:key-vec (first @hook-events))))
 
             ;; Test update-in triggers hook
-             (<!! (k/update-in store [:hook-test :value] inc opts))
-             (is (= 2 (count @hook-events)))
-             (is (= :update-in (:api-op (second @hook-events))))
-             (is (= :hook-test (:key (second @hook-events))))
-             (is (= [:hook-test :value] (:key-vec (second @hook-events))))
+              (<!! (k/update-in store [:hook-test :value] inc opts))
+              (is (= 2 (count @hook-events)))
+              (is (= :update-in (:api-op (second @hook-events))))
+              (is (= :hook-test (:key (second @hook-events))))
+              (is (= [:hook-test :value] (:key-vec (second @hook-events))))
 
             ;; Test dissoc triggers hook
-             (<!! (k/dissoc store :hook-test opts))
-             (is (= 3 (count @hook-events)))
-             (is (= :dissoc (:api-op (nth @hook-events 2))))
-             (is (= :hook-test (:key (nth @hook-events 2))))
+              (<!! (k/dissoc store :hook-test opts))
+              (is (= 3 (count @hook-events)))
+              (is (= :dissoc (:api-op (nth @hook-events 2))))
+              (is (= :hook-test (:key (nth @hook-events 2))))
 
             ;; Test bassoc triggers hook
-             (<!! (k/bassoc store :hook-bin (byte-array [1 2 3]) opts))
-             (is (= 4 (count @hook-events)))
-             (is (= :bassoc (:api-op (nth @hook-events 3))))
-             (is (= :hook-bin (:key (nth @hook-events 3))))
+              (when binary?
+                (<!! (k/bassoc store :hook-bin (byte-array [1 2 3]) opts))
+                (is (= 4 (count @hook-events)))
+                (is (= :bassoc (:api-op (nth @hook-events 3))))
+                (is (= :hook-bin (:key (nth @hook-events 3)))))
 
             ;; Test multi-assoc triggers hook (if supported)
-             (when (utils/multi-key-capable? store)
-               (<!! (k/multi-assoc store {:hook-m1 1 :hook-m2 2} opts))
-               (is (= 5 (count @hook-events)))
-               (is (= :multi-assoc (:api-op (nth @hook-events 4))))
-               (is (= {:hook-m1 1 :hook-m2 2} (:kvs (nth @hook-events 4))))
+              (when (utils/multi-key-capable? store)
+                (let [before (count @hook-events)]
+                  (<!! (k/multi-assoc store {:hook-m1 1 :hook-m2 2} opts))
+                  (is (= (inc before) (count @hook-events)))
+                  (is (= :multi-assoc (:api-op (last @hook-events))))
+                  (is (= {:hook-m1 1 :hook-m2 2} (:kvs (last @hook-events)))))
               ;; Clean up multi-assoc keys
-               (<!! (k/dissoc store :hook-m1 opts))
-               (<!! (k/dissoc store :hook-m2 opts)))
+                (<!! (k/dissoc store :hook-m1 opts))
+                (<!! (k/dissoc store :hook-m2 opts)))
 
             ;; Test removing hook - should stop receiving events
-             (k/remove-write-hook! store ::test-hook)
-             (let [count-before (count @hook-events)]
-               (<!! (k/assoc-in store [:hook-after-remove] "test" opts))
-               (is (= count-before (count @hook-events))
-                   "No new events after hook removal"))
+              (k/remove-write-hook! store ::test-hook)
+              (let [count-before (count @hook-events)]
+                (<!! (k/assoc-in store [:hook-after-remove] "test" opts))
+                (is (= count-before (count @hook-events))
+                    "No new events after hook removal"))
 
             ;; Clean up
-             (<!! (k/dissoc store :hook-bin opts))
-             (<!! (k/dissoc store :hook-after-remove opts))))))))
+              (when binary? (<!! (k/dissoc store :hook-bin opts)))
+              (<!! (k/dissoc store :hook-after-remove opts)))))))))
 
 (defn async-compliance-test [store]
   (go

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -151,7 +151,10 @@
 #?(:clj
    (defn compliance-test [store]
      (doseq [opts [{:sync? false} {:sync? true}]
-             :let [<!! (if (:sync? opts) identity <!!)]]
+             :let [<!! (if (:sync? opts) identity <!!)
+                   bin-opts (cond-> opts
+                              (k/encrypted? store)
+                              (clojure.core/assoc :raw? true))]]
 
        (testing "Testing the append store functionality."
          (<!! (k/append store :foolog {:bar 42} opts))
@@ -195,13 +198,13 @@
          (is (= true (<!! (k/dissoc store :foo opts))))
          (is (= false (<!! (k/dissoc store :not-there opts))))
          (is (= nil (<!! (k/get-in store [:foo] nil opts))))
-         (<!! (k/bassoc store :binbar (byte-array (range 10)) opts))
+         (<!! (k/bassoc store :binbar (byte-array (range 10)) bin-opts))
          (<!! (k/bget store :binbar (fn [{:keys [input-stream]}]
                                       (go
                                         (is (= (map byte (slurp input-stream))
                                                (range 10)))
                                         true))
-                      opts))
+                      bin-opts))
          ;; EVERY DOCUMENTED INPUT SHAPE, not just the byte array. `bassoc`
          ;; promises an InputStream, a File, a String and a byte array, and
          ;; before this only the filestore handled any but the last — every
@@ -211,32 +214,32 @@
          #?(:clj
             (let [expected (map byte (range 10))]
               (<!! (k/bassoc store :bin-stream
-                             (java.io.ByteArrayInputStream. (byte-array (range 10))) opts))
+                             (java.io.ByteArrayInputStream. (byte-array (range 10))) bin-opts))
               (<!! (k/bget store :bin-stream
                            (fn [{:keys [input-stream]}]
                              (go (is (= expected (map byte (slurp input-stream)))
                                      "bassoc must accept an InputStream")
                                  true))
-                           opts))
+                           bin-opts))
               (let [f (java.io.File/createTempFile "konserve-compliance" ".bin")]
                 (try
                   (with-open [o (java.io.FileOutputStream. f)]
                     (.write o (byte-array (range 10))))
-                  (<!! (k/bassoc store :bin-file f opts))
+                  (<!! (k/bassoc store :bin-file f bin-opts))
                   (<!! (k/bget store :bin-file
                                (fn [{:keys [input-stream]}]
                                  (go (is (= expected (map byte (slurp input-stream)))
                                          "bassoc must accept a File")
                                      true))
-                               opts))
+                               bin-opts))
                   (finally (.delete f))))
-              (<!! (k/bassoc store :bin-string "hello konserve" opts))
+              (<!! (k/bassoc store :bin-string "hello konserve" bin-opts))
               (<!! (k/bget store :bin-string
                            (fn [{:keys [input-stream]}]
                              (go (is (= "hello konserve" (slurp input-stream))
                                      "bassoc must accept a String")
                                  true))
-                           opts))
+                           bin-opts))
               ;; cleaned up so the key-listing assertion below still describes
               ;; the same store it always did
               (doseq [kk [:bin-stream :bin-file :bin-string]]
@@ -380,7 +383,7 @@
              (is (= :hook-test (:key (nth @hook-events 2))))
 
             ;; Test bassoc triggers hook
-             (<!! (k/bassoc store :hook-bin (byte-array [1 2 3]) opts))
+             (<!! (k/bassoc store :hook-bin (byte-array [1 2 3]) bin-opts))
              (is (= 4 (count @hook-events)))
              (is (= :bassoc (:api-op (nth @hook-events 3))))
              (is (= :hook-bin (:key (nth @hook-events 3))))

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -609,19 +609,26 @@
 ;; Sealing raw bytes under the store's key
 ;; -----------------------------------------------------------------------------
 
+(defn encrypted?
+  "Does this store encrypt the values it writes? False for a store with no
+  encryptor configured (and for stores that have no encryptor at all, like the
+  in-memory one). Binary values are never encrypted regardless — see `bassoc`."
+  [store]
+  (let [{:keys [encryptor config]} store]
+    (boolean (when encryptor
+               (encryptor/encrypting? (encryptor (:encryptor config)))))))
+
 (defn- store-cipher
   "The store's configured encryptor, or an error if it has none. `seal`/`unseal`
   exist to encrypt bytes the store itself will not touch, so an unencrypted store
   quietly returning the plaintext would defeat the point."
   [store]
-  (let [{:keys [encryptor config]} store
-        enc (when encryptor (encryptor (:encryptor config)))]
-    (when-not (and enc (encryptor/encrypting? enc))
-      (throw (ex-info (str "This store has no encryptor configured, so there is no key "
-                           "to seal with. Configure one, e.g. "
-                           "{:encryptor {:type :aes-gcm :key ...}}.")
-                      {:type :konserve/no-encryptor})))
-    enc))
+  (when-not (encrypted? store)
+    (throw (ex-info (str "This store has no encryptor configured, so there is no key "
+                         "to seal with. Configure one, e.g. "
+                         "{:encryptor {:type :aes-gcm :key ...}}.")
+                    {:type :konserve/no-encryptor})))
+  ((:encryptor store) (:encryptor (:config store))))
 
 (defn seal
   "Encrypt `bytes` with this store's configured encryptor, bound to `key`.

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -2,8 +2,10 @@
   (:refer-clojure :exclude [get get-in update update-in assoc assoc-in exists? dissoc keys])
   (:require [clojure.core.async :refer [chan put! poll!]]
             [hasch.core :as hasch]
+            [konserve.encryptor :as encryptor]
             [konserve.protocols :as protocols :refer [-exists? -get-meta -get-in -assoc-in
                                                       -update-in -dissoc -bget -bassoc
+                                                      -encrypt -decrypt
                                                       -keys -multi-get -multi-assoc -multi-dissoc
                                                       -assoc-serializers -get-write-hooks -lock-free?]]
             [konserve.utils :refer [meta-update multi-key-capable? invoke-write-hooks! #?(:clj async+sync) *default-sync-translation*]
@@ -603,6 +605,69 @@
                           (reduce-fn acc elem))))
                     acc))))))
 
+;; -----------------------------------------------------------------------------
+;; Sealing raw bytes under the store's key
+;; -----------------------------------------------------------------------------
+
+(defn- store-cipher
+  "The store's configured encryptor, or an error if it has none. `seal`/`unseal`
+  exist to encrypt bytes the store itself will not touch, so an unencrypted store
+  quietly returning the plaintext would defeat the point."
+  [store]
+  (let [{:keys [encryptor config]} store
+        enc (when encryptor (encryptor (:encryptor config)))]
+    (when-not (and enc (encryptor/encrypting? enc))
+      (throw (ex-info (str "This store has no encryptor configured, so there is no key "
+                           "to seal with. Configure one, e.g. "
+                           "{:encryptor {:type :aes-gcm :key ...}}.")
+                      {:type :konserve/no-encryptor})))
+    enc))
+
+(defn seal
+  "Encrypt `bytes` with this store's configured encryptor, bound to `key`.
+
+  konserve does not encrypt binary values — `bassoc`/`bget` hand your bytes to
+  storage untouched, so the format is yours. `seal`/`unseal` let you encrypt them
+  under the store's own key without managing a second one, and bind the ciphertext
+  to `key` and to the store's layout version: bytes sealed under one key will not
+  unseal under another, and a tampered or truncated ciphertext is rejected rather
+  than returned as garbage (with an AEAD cipher like :aes-gcm).
+
+    (bassoc store :thumb (<? (seal store :thumb raw-bytes)) {:raw? true})
+    (bget store :thumb
+          (fn [{is :input-stream}]
+            (go (<? (unseal store :thumb (slurp-bytes is)))))
+          {:raw? true})
+
+  `bytes` is a byte[] on the JVM and a Uint8Array on JavaScript. Returns the
+  ciphertext, or a channel of it unless {:sync? true}."
+  ([store key bytes]
+   (seal store key bytes {:sync? false}))
+  ([store key bytes opts]
+   (async+sync (:sync? opts)
+               *default-sync-translation*
+               (go-try-
+                (let [enc (store-cipher store)
+                      aad (encryptor/associated-data (:version store)
+                                                     (defaults/key->store-key key)
+                                                     :binary)]
+                  (<?- (-encrypt enc bytes aad opts)))))))
+
+(defn unseal
+  "Decrypt bytes produced by `seal` under the same store and `key`. Raises if the
+  ciphertext does not authenticate — wrong key, wrong store key, or tampering."
+  ([store key bytes]
+   (unseal store key bytes {:sync? false}))
+  ([store key bytes opts]
+   (async+sync (:sync? opts)
+               *default-sync-translation*
+               (go-try-
+                (let [enc (store-cipher store)
+                      aad (encryptor/associated-data (:version store)
+                                                     (defaults/key->store-key key)
+                                                     :binary)]
+                  (<?- (-decrypt enc bytes aad opts)))))))
+
 (defn bget
   "Calls locked-cb with a platform specific binary representation inside
   the lock, e.g. wrapped InputStream on the JVM and Blob in
@@ -616,7 +681,12 @@
       (io/copy is tmp-file)))
 
   When called asynchronously (by default or w/ {:sync? false}), the locked-cb
-  must synchronously return a channel."
+  must synchronously return a channel.
+
+  Binary values are NOT encrypted: the bytes reach storage exactly as given. On a
+  store with an encryptor configured this therefore requires {:raw? true}, an
+  explicit statement that you own the format and its confidentiality. To encrypt
+  under the store's key instead, see `seal` / `unseal`."
   ([store key locked-cb]
    (bget store key locked-cb {:sync? false}))
   ([store key locked-cb opts]
@@ -629,7 +699,12 @@
 
 (defn bassoc
   "Copies given value (InputStream, Reader, File, byte[] or String on
-  JVM, Blob in JavaScript) under key in the store."
+  JVM, Blob in JavaScript) under key in the store.
+
+  The bytes are stored as given — konserve does not encrypt them. On a store with
+  an encryptor configured this therefore requires {:raw? true}, an explicit
+  statement that you own the format and its confidentiality. To encrypt under the
+  store's key instead, see `seal` / `unseal`."
   ([store key val]
    (bassoc store key val {:sync? false}))
   ([store key val opts]

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -2,9 +2,11 @@
   (:refer-clojure :exclude [get get-in update update-in assoc assoc-in exists? dissoc keys])
   (:require [clojure.core.async :refer [chan put! poll!]]
             [hasch.core :as hasch]
+            [konserve.encryptor :as encryptor]
             [konserve.protocols :as protocols :refer [PConditionalWrite -conditional-write-domain -revision
                                                       -exists? -get-meta -get-in -assoc-in
                                                       -update-in -dissoc -bget -bassoc
+                                                      -encrypt -decrypt
                                                       -keys -multi-get -multi-assoc -multi-dissoc
                                                       -assoc-serializers -get-write-hooks -lock-free?]]
             [konserve.utils :refer [meta-update multi-key-capable? kv-keys invoke-write-hooks! #?(:clj async+sync) *default-sync-translation*]
@@ -971,6 +973,51 @@
                                                         (reduce-fn acc elem))))
                                                   acc)))))))
 
+(defn encrypted?
+  "True when this store has a non-null value encryptor configured."
+  [store]
+  (let [{:keys [encryptor config]} store]
+    (boolean (when encryptor
+               (encryptor/encrypting? (encryptor (:encryptor config)))))))
+
+(defn- store-cipher [store]
+  (when-not (encrypted? store)
+    (throw (ex-info "This store has no encryptor configured."
+                    {:type :konserve/no-encryptor})))
+  ((:encryptor store) (:encryptor (:config store))))
+
+(defn seal
+  "Encrypt bytes under the store's configured key, bound to the Konserve key.
+
+  Returns a channel unless `{:sync? true}` is supplied."
+  ([store key bytes]
+   (seal store key bytes {:sync? false}))
+  ([store key bytes opts]
+   (async+sync
+    (:sync? opts) *default-sync-translation*
+    (go-try-
+     (<?- (-encrypt (store-cipher store)
+                    bytes
+                    (encryptor/associated-data (:version store)
+                                               (defaults/key->store-key key)
+                                               :binary)
+                    opts))))))
+
+(defn unseal
+  "Decrypt bytes produced by `seal` for the same store and Konserve key."
+  ([store key bytes]
+   (unseal store key bytes {:sync? false}))
+  ([store key bytes opts]
+   (async+sync
+    (:sync? opts) *default-sync-translation*
+    (go-try-
+     (<?- (-decrypt (store-cipher store)
+                    bytes
+                    (encryptor/associated-data (:version store)
+                                               (defaults/key->store-key key)
+                                               :binary)
+                    opts))))))
+
 (defn bget
   "Calls locked-cb with a platform specific binary representation inside the lock.
   You need to properly close/dispose the object when you are done!
@@ -1003,7 +1050,11 @@
   File stores accept `:streaming? true` to expose a bounded view over the stored
   payload instead of first materializing it. In that mode the callback must fully
   consume the stream before it (or its returned channel) completes; the view is
-  valid only while Konserve owns the locked backing object."
+  valid only while Konserve owns the locked backing object.
+
+  Binary payload bytes are not encrypted automatically. An encrypted store
+  therefore requires `{:raw? true}`; use `seal` and `unseal` when the bytes
+  should use the store's key."
   ([store key locked-cb]
    (bget store key locked-cb {:sync? false}))
   ([store key locked-cb opts]
@@ -1017,7 +1068,11 @@
 
 (defn bassoc
   "Copies given value (InputStream, Reader, File, byte[] or String on
-  JVM, Blob in JavaScript) under key in the store."
+  JVM, Blob in JavaScript) under key in the store.
+
+  Binary payload bytes are not encrypted automatically. An encrypted store
+  therefore requires `{:raw? true}`; use `seal` and `unseal` when the bytes
+  should use the store's key."
   ([store key val]
    (bassoc store key val {:sync? false}))
   ([store key val opts]

--- a/src/konserve/encryptor.cljc
+++ b/src/konserve/encryptor.cljc
@@ -1,25 +1,187 @@
 (ns konserve.encryptor
-  (:require [konserve.protocols :refer [PStoreSerializer -serialize -deserialize]]
+  "Value encryption for konserve blobs.
+
+   An encryptor transforms a whole serialized byte array into a whole stored byte
+   array and back (see `konserve.protocols/PEncryptor`). It is deliberately NOT a
+   `PStoreSerializer` decorator: an AEAD cipher has to verify its authentication
+   tag over the complete ciphertext before it may hand any plaintext to the
+   deserializer, so there is nothing to stream.
+
+   Two ciphers ship:
+
+   `:aes-gcm` (header byte 2) — AES-256-GCM via geheimnis v2. Authenticated: a
+   tampered, truncated or relocated blob is rejected rather than deserialized.
+   This is the one to use.
+
+   `:aes` (header byte 1) — DEPRECATED. Unauthenticated AES-256-CBC via geheimnis
+   v1, kept so existing stores stay readable. It cannot detect tampering, and its
+   per-blob salt comes from `Math.random` on ClojureScript rather than a CSPRNG.
+   Do not choose it for new stores."
+  (:require [clojure.core.async]        ;; go-try- expands to core.async/go — needs the ns loaded
+            [konserve.protocols :refer [PEncryptor]]
             [konserve.utils :refer [invert-map]]
             [geheimnis.aes :refer [encrypt decrypt]]
-            [hasch.core :refer [edn-hash uuid]])
-  #?(:clj (:import [java.io ByteArrayInputStream ByteArrayOutputStream])))
+            [org.replikativ.geheimnis.aead :as aead]
+            [org.replikativ.geheimnis.codec :as codec]
+            [org.replikativ.geheimnis.core :as csprng]
+            [org.replikativ.geheimnis.hash :as hash]
+            [superv.async :refer [go-try- <?-]]
+            [hasch.core :refer [edn-hash uuid]]))
 
-(def ^:const salt-size 64)
+;; -----------------------------------------------------------------------------
+;; associated data
+;;
+;; The AEAD tag covers the AAD, so binding the blob's identity into it means a
+;; ciphertext cannot be moved to another key or into another slot of the same
+;; blob and still verify. Both are things an attacker with write access to the
+;; storage medium can otherwise do without touching a single ciphertext byte.
+;; -----------------------------------------------------------------------------
 
-(defrecord NullEncryptor [serializer]
-  PStoreSerializer
-  (-deserialize [_ read-handlers bytes]
-    (-deserialize serializer read-handlers bytes))
-  (-serialize [_ bytes write-handlers val]
-    (-serialize serializer bytes write-handlers val)))
+(defn associated-data
+  "AAD binding a ciphertext to (layout version, store-key, slot). `part` is
+   :meta or :value."
+  [version store-key part]
+  (codec/str->bytes (str "konserve|" (int version) "|" store-key "|" (name part))))
+
+;; -----------------------------------------------------------------------------
+;; byte-array helpers (JVM byte[] / CLJS Uint8Array)
+;; -----------------------------------------------------------------------------
+
+(defn- byte-slice [bs from to]
+  #?(:clj  (java.util.Arrays/copyOfRange ^bytes bs (int from) (int to))
+     :cljs (.slice bs from to)))
+
+(defn- byte-array? [x]
+  #?(:clj (bytes? x) :cljs (instance? js/Uint8Array x)))
+
+;; -----------------------------------------------------------------------------
+;; null
+;; -----------------------------------------------------------------------------
+
+;; NOTE for every cipher below: the bodies live in plain functions rather than in
+;; the record methods, because ClojureScript cannot macroexpand a core.async `go`
+;; inside a deftype/defrecord method body.
+
+(defn- passthrough [bytes env]
+  (if (:sync? env) bytes (go-try- bytes)))
+
+(defrecord NullEncryptor []
+  PEncryptor
+  (-encrypt [_ plaintext _aad env] (passthrough plaintext env))
+  (-decrypt [_ ciphertext _aad env] (passthrough ciphertext env)))
 
 (defn null-encryptor [_config]
-  (fn [serializer]
-    (NullEncryptor. serializer)))
+  (NullEncryptor.))
 
-;; Following advise at
+(defn encrypting?
+  "Does this encryptor actually encrypt? (False for the null encryptor.)"
+  [encryptor]
+  (not (instance? NullEncryptor encryptor)))
+
+;; -----------------------------------------------------------------------------
+;; :aes-gcm — AES-256-GCM
+;;
+;; Layout per blob part:  [salt 32B][nonce 12B][ciphertext ‖ tag 16B]
+;;
+;; The per-blob key is HKDF(master, salt) with a fresh CSPRNG salt on every write,
+;; so no key ever encrypts more than one message and nonce reuse — GCM's one
+;; catastrophic failure mode — cannot arise, whatever the store's write volume.
+;; The bytes are identical on JVM and ClojureScript (geheimnis carries interop
+;; known-answer tests), so a store written by one platform reads on the other.
+;; -----------------------------------------------------------------------------
+
+(def ^:const gcm-key-size 32)
+(def ^:const gcm-salt-size 32)
+(def ^:const gcm-nonce-size 12)
+(def ^:const gcm-tag-size 16)
+
+(def ^:private gcm-info (codec/str->bytes "konserve-aes-gcm-v1"))
+(def ^:private gcm-prefix-size (+ gcm-salt-size gcm-nonce-size))
+
+#?(:cljs
+   (defn- no-sync-aead! []
+     (throw (ex-info (str "The :aes-gcm encryptor cannot run in {:sync? true} mode on "
+                          "ClojureScript: Web Crypto exposes no synchronous cipher. "
+                          "Use the store asynchronously.")
+                     {:type ::sync-aead-unsupported}))))
+
+(defn- gcm-encrypt [master-key plaintext aad env]
+  (let [salt     (csprng/random-bytes gcm-salt-size)
+        nonce    (csprng/random-bytes gcm-nonce-size)
+        blob-key (hash/hkdf master-key salt gcm-info gcm-key-size)]
+    (if (:sync? env)
+      #?(:clj  (codec/concat-bytes
+                [salt nonce (aead/aead-encrypt-sync blob-key nonce aad plaintext)])
+         :cljs (no-sync-aead!))
+      (go-try- (codec/concat-bytes
+                [salt nonce (<?- (aead/aead-encrypt blob-key nonce aad plaintext))])))))
+
+(defn- gcm-decrypt [master-key ciphertext aad env]
+  (when (< (codec/blen ciphertext) (+ gcm-prefix-size gcm-tag-size))
+    (throw (ex-info "Blob is too short to be an :aes-gcm ciphertext."
+                    {:type ::malformed-ciphertext
+                     :size (codec/blen ciphertext)})))
+  (let [salt     (byte-slice ciphertext 0 gcm-salt-size)
+        nonce    (byte-slice ciphertext gcm-salt-size gcm-prefix-size)
+        ct       (byte-slice ciphertext gcm-prefix-size (codec/blen ciphertext))
+        blob-key (hash/hkdf master-key salt gcm-info gcm-key-size)]
+    (if (:sync? env)
+      #?(:clj  (aead/aead-decrypt-sync blob-key nonce aad ct)
+         :cljs (no-sync-aead!))
+      (go-try- (<?- (aead/aead-decrypt blob-key nonce aad ct))))))
+
+(defrecord AESGCMEncryptor [key]
+  PEncryptor
+  (-encrypt [_ plaintext aad env] (gcm-encrypt key plaintext aad env))
+  (-decrypt [_ ciphertext aad env] (gcm-decrypt key ciphertext aad env)))
+
+(defn generate-key
+  "A fresh 256-bit master key for the :aes-gcm encryptor, as a 64-character hex
+   string. Store it outside the store you are encrypting."
+  []
+  (codec/bytes->hex (csprng/random-bytes gcm-key-size)))
+
+(defn- coerce-gcm-key [key]
+  (cond
+    (and (string? key) (re-matches #"(?i)[0-9a-f]{64}" key))
+    (codec/hex->bytes key)
+
+    (and (byte-array? key) (= gcm-key-size (codec/blen key)))
+    key
+
+    :else
+    (throw (ex-info (str "The :aes-gcm encryptor needs a 256-bit key: either 32 raw bytes "
+                         "or a 64-character hex string. It does not stretch passphrases — "
+                         "a guessable one would be brute-forced offline against the stored "
+                         "blobs. Generate one with (konserve.encryptor/generate-key).")
+                    {:type ::invalid-key
+                     :provided-type (type key)}))))
+
+(defn aes-gcm-encryptor [config]
+  (let [{:keys [key]} config]
+    (when (nil? key)
+      (throw (ex-info "AES-GCM key not provided."
+                      {:type   ::key-missing
+                       :config (dissoc config :key)})))
+    (AESGCMEncryptor. (coerce-gcm-key key))))
+
+;; -----------------------------------------------------------------------------
+;; :aes — DEPRECATED, unauthenticated AES-256-CBC (geheimnis v1)
+;;
+;; Kept read/write compatible byte-for-byte with konserve <= 0.7 so existing
+;; stores keep working. Layout: [salt 64B][CBC ciphertext], where both the key and
+;; the IV are derived from the salt, per
 ;; https://crypto.stackexchange.com/questions/84439/is-it-dangerous-to-encrypt-lots-of-small-files-with-the-same-key
+;;
+;; Note the salt is encoded differently on JVM and ClojureScript (the `inc` below,
+;; and the signed/unsigned reading in -decrypt). That asymmetry means a blob
+;; written by one platform fails to decrypt on the other whenever a salt byte
+;; lands on 128 — roughly one blob in five. It is preserved rather than fixed
+;; because fixing it would break the stores it currently works for. :aes-gcm has
+;; no such problem.
+;; -----------------------------------------------------------------------------
+
+(def ^:const salt-size 64)
 
 (defn get-initial-vector [salt key]
   (subvec (vec (edn-hash ["initial-value" salt key])) 0 16))
@@ -27,39 +189,37 @@
 (defn get-key [salt key]
   ["key" salt key])
 
-(defrecord AESEncryptor [serializer key]
-  PStoreSerializer
-  (-deserialize [_ read-handlers bytes]
-    (let [salt #?(:clj (let [salt-array (byte-array salt-size)]
-                         (.read ^ByteArrayInputStream bytes salt-array)
-                         (map int salt-array))
-                  :cljs
-                  (map (fn [b] (if (> b 128) (- b 256) b)) (.slice bytes 0 salt-size)))
-          data #?(:clj (.readAllBytes ^ByteArrayInputStream bytes)
-                  :cljs (.slice bytes salt-size))
-          decrypted (decrypt (get-key salt key) data :iv (get-initial-vector salt key))]
-      (-deserialize serializer read-handlers #?(:clj (ByteArrayInputStream. decrypted)
-                                                :cljs decrypted))))
-  (-serialize [_ bytes write-handlers val]
-    (let [unsigned-byte-offset 128
-          salt (map #(int (- (#?(:cljs inc :clj identity) %) unsigned-byte-offset)) (edn-hash (uuid)))]
-      #?(:cljs
-         (let [data (-serialize serializer bytes write-handlers val)
-               iv (get-initial-vector salt key)
-               bytes (encrypt (get-key salt key) (.from js/Array data) :iv iv)
-               output (js/Uint8Array. (+ salt-size (count bytes)))]
-           (.set output (js/Uint8Array.from (into-array salt)) 0)
-           (.set output (js/Uint8Array.from bytes) salt-size)
-           output)
-         :clj
-         (let [buffer-size (* 16 1024)
-               bos (ByteArrayOutputStream. buffer-size)
-               _ (.write ^ByteArrayOutputStream bytes (byte-array salt))
-               _ (-serialize serializer bos write-handlers val)
-               ba (.toByteArray bos)
-               iv (get-initial-vector salt key)
-               encrypted ^bytes (encrypt (get-key salt key) ba :iv iv)]
-           (.write ^ByteArrayOutputStream bytes encrypted))))))
+(defn- legacy-salt []
+  (let [unsigned-byte-offset 128]
+    (map #(int (- (#?(:cljs inc :clj identity) %) unsigned-byte-offset))
+         (edn-hash (uuid)))))
+
+(defn- legacy-encrypt [master-key plaintext env]
+  (let [salt      (legacy-salt)
+        iv        (get-initial-vector salt master-key)
+        encrypted #?(:clj  (encrypt (get-key salt master-key) plaintext :iv iv)
+                     :cljs (encrypt (get-key salt master-key) (.from js/Array plaintext) :iv iv))
+        out       #?(:clj  (codec/concat-bytes [(byte-array salt) encrypted])
+                     :cljs (let [out (js/Uint8Array. (+ salt-size (count encrypted)))]
+                             (.set out (js/Uint8Array.from (into-array salt)) 0)
+                             (.set out (js/Uint8Array.from encrypted) salt-size)
+                             out))]
+    (passthrough out env)))
+
+(defn- legacy-decrypt [master-key ciphertext env]
+  (let [salt      #?(:clj  (map int (byte-slice ciphertext 0 salt-size))
+                     :cljs (map (fn [b] (if (> b 128) (- b 256) b))
+                                (.slice ciphertext 0 salt-size)))
+        data      #?(:clj  (byte-slice ciphertext salt-size (codec/blen ciphertext))
+                     :cljs (.slice ciphertext salt-size))
+        decrypted (decrypt (get-key salt master-key) data
+                           :iv (get-initial-vector salt master-key))]
+    (passthrough decrypted env)))
+
+(defrecord AESEncryptor [key]
+  PEncryptor
+  (-encrypt [_ plaintext _aad env] (legacy-encrypt key plaintext env))
+  (-decrypt [_ ciphertext _aad env] (legacy-decrypt key ciphertext env)))
 
 (defn aes-encryptor [config]
   (let [{:keys [key]} config]
@@ -67,17 +227,20 @@
       (throw (ex-info "AES key not provided."
                       {:type   :aes-encryptor-key-missing
                        :config config}))
-      (fn [serializer]
-        (AESEncryptor. serializer key)))))
+      (AESEncryptor. key))))
+
+;; -----------------------------------------------------------------------------
 
 (def byte->encryptor
   {0 null-encryptor
-   1 aes-encryptor})
+   1 aes-encryptor
+   2 aes-gcm-encryptor})
 
 (def encryptor->byte
   (invert-map byte->encryptor))
 
 (defn get-encryptor [type]
   (case type
-    :aes aes-encryptor
+    :aes     aes-encryptor
+    :aes-gcm aes-gcm-encryptor
     null-encryptor))

--- a/src/konserve/encryptor.cljc
+++ b/src/konserve/encryptor.cljc
@@ -1,25 +1,120 @@
 (ns konserve.encryptor
-  (:require [konserve.protocols :refer [PStoreSerializer -serialize -deserialize]]
+  "Whole-value encryption for konserve blobs."
+  (:require [clojure.core.async]
+            [geheimnis.aes :refer [decrypt encrypt]]
+            [hasch.core :refer [edn-hash uuid]]
+            [konserve.protocols :refer [PEncryptor]]
             [konserve.utils :refer [invert-map]]
-            [geheimnis.aes :refer [encrypt decrypt]]
-            [hasch.core :refer [edn-hash uuid]])
-  #?(:clj (:import [java.io ByteArrayInputStream ByteArrayOutputStream])))
+            [org.replikativ.geheimnis.aead :as aead]
+            [org.replikativ.geheimnis.codec :as codec]
+            [org.replikativ.geheimnis.core :as csprng]
+            [org.replikativ.geheimnis.hash :as hash]
+            [superv.async :refer [go-try- <?-]]))
 
-(def ^:const salt-size 64)
+(defn associated-data
+  "AAD binding a ciphertext to its layout version, store key, and slot."
+  [version store-key part]
+  (codec/str->bytes (str "konserve|" (int version) "|" store-key "|" (name part))))
 
-(defrecord NullEncryptor [serializer]
-  PStoreSerializer
-  (-deserialize [_ read-handlers bytes]
-    (-deserialize serializer read-handlers bytes))
-  (-serialize [_ bytes write-handlers val]
-    (-serialize serializer bytes write-handlers val)))
+(defn- byte-slice [bs from to]
+  #?(:clj (java.util.Arrays/copyOfRange ^bytes bs (int from) (int to))
+     :cljs (.slice bs from to)))
+
+(defn- byte-array? [x]
+  #?(:clj (bytes? x)
+     :cljs (instance? js/Uint8Array x)))
+
+(defn- passthrough [bytes env]
+  (if (:sync? env) bytes (go-try- bytes)))
+
+(defrecord NullEncryptor []
+  PEncryptor
+  (-encrypt [_ plaintext _aad env] (passthrough plaintext env))
+  (-decrypt [_ ciphertext _aad env] (passthrough ciphertext env)))
 
 (defn null-encryptor [_config]
-  (fn [serializer]
-    (NullEncryptor. serializer)))
+  (->NullEncryptor))
 
-;; Following advise at
-;; https://crypto.stackexchange.com/questions/84439/is-it-dangerous-to-encrypt-lots-of-small-files-with-the-same-key
+(defn encrypting?
+  "True when encryptor is not the null implementation."
+  [encryptor]
+  (not (instance? NullEncryptor encryptor)))
+
+(def ^:const gcm-key-size 32)
+(def ^:const gcm-salt-size 32)
+(def ^:const gcm-nonce-size 12)
+(def ^:const gcm-tag-size 16)
+
+(def ^:private gcm-info (codec/str->bytes "konserve-aes-gcm-v1"))
+(def ^:private gcm-prefix-size (+ gcm-salt-size gcm-nonce-size))
+
+#?(:cljs
+   (defn- no-sync-aead! []
+     (throw (ex-info
+             "The :aes-gcm encryptor requires Konserve's asynchronous API on ClojureScript."
+             {:type ::sync-aead-unsupported}))))
+
+(defn- gcm-encrypt [master-key plaintext aad env]
+  (let [salt (csprng/random-bytes gcm-salt-size)
+        nonce (csprng/random-bytes gcm-nonce-size)
+        blob-key (hash/hkdf master-key salt gcm-info gcm-key-size)]
+    (if (:sync? env)
+      #?(:clj (codec/concat-bytes
+               [salt nonce (aead/aead-encrypt-sync blob-key nonce aad plaintext)])
+         :cljs (no-sync-aead!))
+      (go-try-
+       (codec/concat-bytes
+        [salt nonce (<?- (aead/aead-encrypt blob-key nonce aad plaintext))])))))
+
+(defn- gcm-decrypt [master-key ciphertext aad env]
+  (when (< (codec/blen ciphertext) (+ gcm-prefix-size gcm-tag-size))
+    (throw (ex-info "Blob is too short to be an :aes-gcm ciphertext."
+                    {:type ::malformed-ciphertext
+                     :size (codec/blen ciphertext)})))
+  (let [salt (byte-slice ciphertext 0 gcm-salt-size)
+        nonce (byte-slice ciphertext gcm-salt-size gcm-prefix-size)
+        ciphertext (byte-slice ciphertext gcm-prefix-size (codec/blen ciphertext))
+        blob-key (hash/hkdf master-key salt gcm-info gcm-key-size)]
+    (if (:sync? env)
+      #?(:clj (aead/aead-decrypt-sync blob-key nonce aad ciphertext)
+         :cljs (no-sync-aead!))
+      (go-try- (<?- (aead/aead-decrypt blob-key nonce aad ciphertext))))))
+
+(defrecord AESGCMEncryptor [key]
+  PEncryptor
+  (-encrypt [_ plaintext aad env] (gcm-encrypt key plaintext aad env))
+  (-decrypt [_ ciphertext aad env] (gcm-decrypt key ciphertext aad env)))
+
+(defn generate-key
+  "Generate a fresh 256-bit AES-GCM master key as hexadecimal."
+  []
+  (codec/bytes->hex (csprng/random-bytes gcm-key-size)))
+
+(defn- coerce-gcm-key [key]
+  (cond
+    (and (string? key) (re-matches #"(?i)[0-9a-f]{64}" key))
+    (codec/hex->bytes key)
+
+    (and (byte-array? key) (= gcm-key-size (codec/blen key)))
+    key
+
+    :else
+    (throw (ex-info
+            (str "The :aes-gcm encryptor needs a 256-bit key: 32 raw bytes or "
+                 "a 64-character hexadecimal string.")
+            {:type ::invalid-key
+             :provided-type (type key)}))))
+
+(defn aes-gcm-encryptor [{:keys [key] :as config}]
+  (when (nil? key)
+    (throw (ex-info "AES-GCM key not provided."
+                    {:type ::key-missing
+                     :config (dissoc config :key)})))
+  (->AESGCMEncryptor (coerce-gcm-key key)))
+
+;; Legacy unauthenticated AES-CBC. Its byte layout remains unchanged so existing
+;; stores stay readable. Do not select it for new stores.
+(def ^:const salt-size 64)
 
 (defn get-initial-vector [salt key]
   (subvec (vec (edn-hash ["initial-value" salt key])) 0 16))
@@ -27,52 +122,52 @@
 (defn get-key [salt key]
   ["key" salt key])
 
-(defrecord AESEncryptor [serializer key]
-  PStoreSerializer
-  (-deserialize [_ read-handlers bytes]
-    (let [salt #?(:clj (let [salt-array (byte-array salt-size)]
-                         (.read ^ByteArrayInputStream bytes salt-array)
-                         (map int salt-array))
-                  :cljs
-                  (map (fn [b] (if (> b 128) (- b 256) b)) (.slice bytes 0 salt-size)))
-          data #?(:clj (.readAllBytes ^ByteArrayInputStream bytes)
-                  :cljs (.slice bytes salt-size))
-          decrypted (decrypt (get-key salt key) data :iv (get-initial-vector salt key))]
-      (-deserialize serializer read-handlers #?(:clj (ByteArrayInputStream. decrypted)
-                                                :cljs decrypted))))
-  (-serialize [_ bytes write-handlers val]
-    (let [unsigned-byte-offset 128
-          salt (map #(int (- (#?(:cljs inc :clj identity) %) unsigned-byte-offset)) (edn-hash (uuid)))]
-      #?(:cljs
-         (let [data (-serialize serializer bytes write-handlers val)
-               iv (get-initial-vector salt key)
-               bytes (encrypt (get-key salt key) (.from js/Array data) :iv iv)
-               output (js/Uint8Array. (+ salt-size (count bytes)))]
-           (.set output (js/Uint8Array.from (into-array salt)) 0)
-           (.set output (js/Uint8Array.from bytes) salt-size)
-           output)
-         :clj
-         (let [buffer-size (* 16 1024)
-               bos (ByteArrayOutputStream. buffer-size)
-               _ (.write ^ByteArrayOutputStream bytes (byte-array salt))
-               _ (-serialize serializer bos write-handlers val)
-               ba (.toByteArray bos)
-               iv (get-initial-vector salt key)
-               encrypted ^bytes (encrypt (get-key salt key) ba :iv iv)]
-           (.write ^ByteArrayOutputStream bytes encrypted))))))
+(defn- legacy-salt []
+  (let [unsigned-byte-offset 128]
+    (map #(int (- (#?(:cljs inc :clj identity) %) unsigned-byte-offset))
+         (edn-hash (uuid)))))
 
-(defn aes-encryptor [config]
-  (let [{:keys [key]} config]
-    (if (nil? key)
-      (throw (ex-info "AES key not provided."
-                      {:type   :aes-encryptor-key-missing
-                       :config config}))
-      (fn [serializer]
-        (AESEncryptor. serializer key)))))
+(defn- legacy-encrypt [master-key plaintext env]
+  (let [salt (legacy-salt)
+        iv (get-initial-vector salt master-key)
+        encrypted #?(:clj (encrypt (get-key salt master-key) plaintext :iv iv)
+                     :cljs (encrypt (get-key salt master-key)
+                                    (.from js/Array plaintext)
+                                    :iv iv))
+        output #?(:clj (codec/concat-bytes [(byte-array salt) encrypted])
+                  :cljs (let [output (js/Uint8Array.
+                                      (+ salt-size (count encrypted)))]
+                          (.set output (js/Uint8Array.from (into-array salt)) 0)
+                          (.set output (js/Uint8Array.from encrypted) salt-size)
+                          output))]
+    (passthrough output env)))
+
+(defn- legacy-decrypt [master-key ciphertext env]
+  (let [salt #?(:clj (map int (byte-slice ciphertext 0 salt-size))
+                :cljs (map (fn [b] (if (> b 128) (- b 256) b))
+                           (.slice ciphertext 0 salt-size)))
+        data (byte-slice ciphertext salt-size (codec/blen ciphertext))
+        plaintext (decrypt (get-key salt master-key)
+                           data
+                           :iv (get-initial-vector salt master-key))]
+    (passthrough plaintext env)))
+
+(defrecord AESEncryptor [key]
+  PEncryptor
+  (-encrypt [_ plaintext _aad env] (legacy-encrypt key plaintext env))
+  (-decrypt [_ ciphertext _aad env] (legacy-decrypt key ciphertext env)))
+
+(defn aes-encryptor [{:keys [key] :as config}]
+  (if (nil? key)
+    (throw (ex-info "AES key not provided."
+                    {:type :aes-encryptor-key-missing
+                     :config config}))
+    (->AESEncryptor key)))
 
 (def byte->encryptor
   {0 null-encryptor
-   1 aes-encryptor})
+   1 aes-encryptor
+   2 aes-gcm-encryptor})
 
 (def encryptor->byte
   (invert-map byte->encryptor))
@@ -80,4 +175,5 @@
 (defn get-encryptor [type]
   (case type
     :aes aes-encryptor
+    :aes-gcm aes-gcm-encryptor
     null-encryptor))

--- a/src/konserve/encryptor.cljc
+++ b/src/konserve/encryptor.cljc
@@ -174,6 +174,27 @@
 
 (defn get-encryptor [type]
   (case type
+    nil null-encryptor
+    :none null-encryptor
     :aes aes-encryptor
     :aes-gcm aes-gcm-encryptor
-    null-encryptor))
+    (throw (ex-info "Unknown encryptor type" {:type ::unknown-encryptor :encryptor type}))))
+
+(defn validate-policy!
+  "Validate the optional authenticated-only read policy. Compatibility reads
+  remain the default; strict stores must also write authenticated values."
+  [config]
+  (when (and (contains? config :require-authenticated?)
+             (not (boolean? (:require-authenticated? config))))
+    (throw (ex-info "require-authenticated? must be boolean" {:type ::invalid-read-policy})))
+  (when (and (:require-authenticated? config) (not= :aes-gcm (:type config)))
+    (throw (ex-info "Authenticated-only stores require :aes-gcm" {:type ::invalid-read-policy})))
+  config)
+
+(defn assert-readable!
+  "Reject unauthenticated header-selected formats before decrypt/deserialization
+  when the caller explicitly requires authenticated records."
+  [factory config]
+  (when (and (:require-authenticated? config) (not= factory aes-gcm-encryptor))
+    (throw (ex-info "Unauthenticated record refused by store policy"
+                    {:type ::unauthenticated-record}))))

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -6,10 +6,11 @@
    [hasch.core :refer [uuid]]
    [konserve.serializers :refer [key->serializer]]
    [konserve.compressor :refer [get-compressor]]
-   [konserve.encryptor :refer [get-encryptor]]
+   [konserve.encryptor :refer [get-encryptor associated-data encrypting?]]
    [konserve.protocols :refer [PEDNKeyValueStore
                                PBinaryKeyValueStore
                                -serialize -deserialize
+                               -encrypt -decrypt
                                PAssocSerializers
                                PKeyIterable
                                PMultiKeySupport
@@ -54,6 +55,24 @@
 
 #?(:cljs (extend-type js/Uint8Array ICounted (-count [this] (alength this))))
 
+;; Binary values (bassoc/bget) pass through to the blob untouched, bypassing the
+;; serializer path entirely — so they were never encrypted, and a store configured
+;; with an encryptor silently wrote them in the clear. Rather than keep doing that
+;; quietly, make the caller say which they meant: seal the bytes with the store's
+;; own key (konserve.core/seal, which binds them to the key just like an EDN value),
+;; or declare `{:raw? true}` and own the format yourself. Encrypting binary by
+;; default needs chunked AEAD framing to stay streaming, which is a separate design;
+;; `:raw?` keeps its meaning when that lands.
+(def ^:private binary-encryption-msg
+  (str "Binary values (bassoc/bget) pass through unencrypted, and this store has an "
+       "encryptor configured. Either seal the payload yourself with "
+       "(konserve.core/seal store key bytes) / (konserve.core/unseal store key bytes), "
+       "which encrypts it under the store's key and binds it to this key; or pass "
+       "{:raw? true} to declare that you own the format and its confidentiality."))
+
+(defn- refuse-plaintext-binary? [enc env]
+  (and (encrypting? enc) (not (:raw? env))))
+
 (defn update-blob
   "This function writes first the meta-size, then the meta-data and then the
   actual updated data into the underlying backing store."
@@ -65,17 +84,22 @@
    (go-try-
     (let [[key & rkey] key-vec
           store-key (or store-key (key->store-key key))
+          enc       (encryptor (:encryptor config))
           to-array #?(:cljs
                       (fn [value]
-                        (-serialize ((encryptor  (:encryptor config)) (compressor serializer)) nil write-handlers value))
+                        (-serialize (compressor serializer) nil write-handlers value))
                       :clj
                       (fn [value]
                         (let [bos (ByteArrayOutputStream.)]
-                          (try (-serialize ((encryptor (:encryptor config)) (compressor serializer))
-                                           bos write-handlers value)
+                          (try (-serialize (compressor serializer) bos write-handlers value)
                                (.toByteArray bos)
                                (finally
                                  (.close bos))))))
+          ;; serialize (+ compress), then encrypt the finished byte array — an AEAD
+          ;; cipher must see the whole plaintext, and on decrypt must verify its tag
+          ;; before any of it reaches the deserializer.
+          seal (fn [part value]
+                 (-encrypt enc (to-array value) (associated-data version store-key part) env))
 
           meta  (up-fn-meta old-meta)
           value (when (= operation :write-edn)
@@ -89,7 +113,7 @@
           _ (when (and (:in-place? config) (not (:no-backup? config))) ;; let's back things up before writing then
               (log/trace :konserve/backup-blob {:backup-store-key backup-store-key :key key})
               (<?- (-copy backing store-key backup-store-key env)))
-          meta-arr             (to-array meta)
+          meta-arr             (<?- (seal :meta meta))
           meta-size            (count meta-arr)
           header               (create-header version
                                               serializer compressor encryptor meta-size)
@@ -99,7 +123,7 @@
         (<?- (-write-meta new-blob meta-arr env))
         (if (= operation :write-binary)
           (<?- (-write-binary new-blob meta-size input env))
-          (let [value-arr (to-array value)]
+          (let [value-arr (<?- (seal :value value))]
             (<?- (-write-value new-blob value-arr meta-size env))))
 
         (when (:sync-blob? config)
@@ -139,51 +163,54 @@
 
 (defn read-blob
   "Read meta, edn or binary from blob."
-  [blob read-handlers serializers {:keys [sync? operation locked-cb config _store-key] :as env}]
+  [blob read-handlers serializers {:keys [sync? operation locked-cb config store-key] :as env}]
   (async+sync
    sync? *default-sync-translation*
    (go-try-
-    (let [[_ serializer compressor encryptor meta-size header-size]
+    (let [[version serializer compressor encryptor meta-size header-size]
           (<?- (read-header blob serializers env))
           env (assoc env :header-size header-size)
-          fn-read (partial -deserialize
-                           (compressor ((encryptor (:encryptor config)) serializer))
-                           read-handlers)]
+          ;; the encryptor is named by the blob's own header, so a store can still
+          ;; read blobs written under a cipher it no longer writes with
+          enc (encryptor (:encryptor config))
+          fn-read (partial -deserialize (compressor serializer) read-handlers)
+          unseal (fn [part bytes]
+                   (-decrypt enc bytes (associated-data version store-key part) env))]
       (case operation
-        :read-meta #?(:cljs (fn-read (<?- (-read-meta blob meta-size env)))
+        :read-meta #?(:cljs (fn-read (<?- (unseal :meta (<?- (-read-meta blob meta-size env)))))
                       :clj
                       (let [bais-read (ByteArrayInputStream.
-                                       (<?- (-read-meta blob meta-size env)))
+                                       (<?- (unseal :meta (<?- (-read-meta blob meta-size env)))))
                             value     (fn-read bais-read)
                             _         (.close bais-read)]
                         value))
-        :read-edn #?(:cljs (fn-read (<?- (-read-value blob meta-size env)))
+        :read-edn #?(:cljs (fn-read (<?- (unseal :value (<?- (-read-value blob meta-size env)))))
                      :clj
                      (let [bais-read (ByteArrayInputStream.
-                                      (<?- (-read-value blob meta-size env)))
+                                      (<?- (unseal :value (<?- (-read-value blob meta-size env)))))
                            value     (fn-read bais-read)
                            _         (.close bais-read)]
                        value))
         :write-binary #?(:cljs
-                         (let [meta (fn-read (<?- (-read-meta blob meta-size env)))]
+                         (let [meta (fn-read (<?- (unseal :meta (<?- (-read-meta blob meta-size env)))))]
                            [meta nil])
                          :clj
                          (let [bais-read (ByteArrayInputStream.
-                                          (<?- (-read-meta blob meta-size env)))
+                                          (<?- (unseal :meta (<?- (-read-meta blob meta-size env)))))
                                meta      (fn-read bais-read)
                                _         (.close bais-read)]
                            [meta nil]))
         :write-edn #?(:cljs
-                      (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
-                            value (fn-read (<?- (-read-value blob meta-size env)))]
+                      (let [meta  (fn-read (<?- (unseal :meta (<?- (-read-meta blob meta-size env)))))
+                            value (fn-read (<?- (unseal :value (<?- (-read-value blob meta-size env)))))]
                         [meta value])
                       :clj
                       (let [bais-meta  (ByteArrayInputStream.
-                                        (<?- (-read-meta blob meta-size env)))
+                                        (<?- (unseal :meta (<?- (-read-meta blob meta-size env)))))
                             meta       (fn-read bais-meta)
                             _          (.close bais-meta)
                             bais-value (ByteArrayInputStream.
-                                        (<?- (-read-value blob meta-size env)))
+                                        (<?- (unseal :value (<?- (-read-value blob meta-size env)))))
                             value     (fn-read bais-value)
                             _          (.close bais-value)]
                         [meta value]))
@@ -260,12 +287,18 @@
 (defn io-operation
   "Read/Write blob. For better understanding use the flow-chart of konserve."
   [{:keys [backing]} serializers read-handlers write-handlers
-   {:keys [key-vec operation default-serializer sync? overwrite? config] :as env}]
+   {:keys [key-vec operation default-serializer sync? overwrite? config encryptor] :as env}]
   (async+sync
    sync? *default-sync-translation*
    (go-try-
     (let [key           (first  key-vec)
           store-key     (key->store-key key)
+          ;; before any I/O: a refused binary op must not leave a created blob behind
+          _             (when (and (#{:read-binary :write-binary} operation)
+                                   (refuse-plaintext-binary? (encryptor (:encryptor config)) env))
+                          (throw (ex-info binary-encryption-msg
+                                          {:type :konserve/unencrypted-binary
+                                           :key  key})))
           env           (assoc env :store-key store-key :header-size header-size)
           serializer    (get serializers default-serializer)
           migration-key (<?- (-migratable backing key store-key env))
@@ -421,17 +454,19 @@
    (:sync? env) *default-sync-translation*
    (go-try-
     (let [serializer (get serializers default-serializer)
+          enc (encryptor (:encryptor config))
           to-array #?(:cljs
                       (fn [value]
-                        (-serialize ((encryptor  (:encryptor config)) (compressor serializer)) nil write-handlers value))
+                        (-serialize (compressor serializer) nil write-handlers value))
                       :clj
                       (fn [value]
                         (let [bos (ByteArrayOutputStream.)]
-                          (try (-serialize ((encryptor (:encryptor config)) (compressor serializer))
-                                           bos write-handlers value)
+                          (try (-serialize (compressor serializer) bos write-handlers value)
                                (.toByteArray bos)
                                (finally
                                  (.close bos))))))
+          seal (fn [store-key part value]
+                 (-encrypt enc (to-array value) (associated-data version store-key part) env))
 
           ;; Process each key-value pair
           results (loop [pairs []
@@ -444,9 +479,9 @@
 
                             ;; Prepare serialized data
                             meta (meta-up-fn key :edn old-meta)
-                            meta-arr (to-array meta)
+                            meta-arr (<?- (seal store-key :meta meta))
                             meta-size (count meta-arr)
-                            value-arr (to-array val)
+                            value-arr (<?- (seal store-key :value val))
                             header (create-header version
                                                   serializer compressor encryptor meta-size)
 
@@ -579,7 +614,7 @@
 
   PBinaryKeyValueStore
   (-bget [this key locked-cb opts]
-    (let [{:keys [sync?]} opts]
+    (let [{:keys [sync? raw?]} opts]
       (io-operation this serializers read-handlers write-handlers
                     {:key-vec [key]
                      :operation :read-binary
@@ -589,12 +624,13 @@
                      :config    config
                      :version version
                      :sync? sync?
+                     :raw?  raw?
                      :buffer-size buffer-size
                      :locked-cb locked-cb
                      :msg       {:type :read-binary-error
                                  :key  key}})))
   (-bassoc [this key meta-up input opts]
-    (let [{:keys [sync?]} opts]
+    (let [{:keys [sync? raw?]} opts]
       (io-operation this serializers read-handlers write-handlers
                     {:key-vec [key]
                      :operation  :write-binary
@@ -606,6 +642,7 @@
                      :up-fn-meta meta-up
                      :config     config
                      :sync?      sync?
+                     :raw?       raw?
                      :buffer-size buffer-size
                      :msg        {:type :write-binary-error
                                   :key  key}})))

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -7,10 +7,10 @@
    [konserve.metrics :as metrics]
    [konserve.serializers :refer [key->serializer]]
    [konserve.compressor :refer [get-compressor null-compressor]]
-   [konserve.encryptor :refer [get-encryptor null-encryptor]]
+   [konserve.encryptor :refer [associated-data encrypting? get-encryptor null-encryptor]]
    [konserve.protocols :as protocols :refer [PEDNKeyValueStore
                                              PBinaryKeyValueStore
-                                             -serialize -deserialize
+                                             -serialize -deserialize -encrypt -decrypt
                                              PAssocSerializers
                                              PKeyIterable
                                              PMultiKeySupport PConditionalWrite
@@ -60,6 +60,14 @@
 
 #?(:cljs (extend-type js/Uint8Array ICounted (-count [this] (alength this))))
 
+(def ^:private binary-encryption-msg
+  (str "Binary values pass through unencrypted on an encrypted store. "
+       "Use konserve.core/seal and unseal, or pass {:raw? true} to declare "
+       "that the caller owns the binary format and its confidentiality."))
+
+(defn- refuse-plaintext-binary? [enc env]
+  (and (encrypting? enc) (not (:raw? env))))
+
 (defn update-blob*
   "This function writes first the meta-size, then the meta-data and then the
   actual updated data into the underlying backing store."
@@ -71,17 +79,22 @@
    (go-try-
     (let [[key & rkey] key-vec
           store-key (or store-key (key->store-key key))
+          enc (encryptor (:encryptor config))
           to-array #?(:cljs
                       (fn [value]
-                        (-serialize ((encryptor  (:encryptor config)) (compressor serializer)) nil write-handlers value))
+                        (-serialize (compressor serializer) nil write-handlers value))
                       :clj
                       (fn [value]
                         (let [bos (ByteArrayOutputStream.)]
-                          (try (-serialize ((encryptor (:encryptor config)) (compressor serializer))
-                                           bos write-handlers value)
+                          (try (-serialize (compressor serializer) bos write-handlers value)
                                (.toByteArray bos)
                                (finally
                                  (.close bos))))))
+          seal (fn [part value]
+                 (-encrypt enc
+                           (to-array value)
+                           (associated-data version store-key part)
+                           env))
 
           meta  (up-fn-meta old-meta)
           value (when (= operation :write-edn)
@@ -108,7 +121,7 @@
           _ (when (and (:in-place? config) (not (:no-backup? config))) ;; let's back things up before writing then
               (log/trace :konserve/backup-blob {:backup-store-key backup-store-key :key key})
               (<?- (-copy backing store-key backup-store-key env)))
-          meta-arr             (to-array meta)
+          meta-arr             (<?- (seal :meta meta))
           meta-size            (count meta-arr)
           header               (create-header version
                                               serializer compressor encryptor meta-size)
@@ -133,7 +146,7 @@
                             :cljs (when (instance? js/Uint8Array input) (.-length input)))]
               (metrics/bytes! config operation (+ meta-size n)))
             (<?- (-write-binary new-blob meta-size input env)))
-          (let [value-arr (to-array value)]
+          (let [value-arr (<?- (seal :value value))]
             (metrics/bytes! config operation (+ meta-size (count value-arr)))
             (<?- (-write-value new-blob value-arr meta-size env))))
 
@@ -189,65 +202,33 @@
 
 (defn read-blob*
   "Read meta, edn or binary from blob."
-  [blob read-handlers serializers {:keys [sync? operation locked-cb config _store-key] :as env}]
+  [blob read-handlers serializers {:keys [sync? operation locked-cb config store-key] :as env}]
   (async+sync
    sync? *default-sync-translation*
    (go-try-
-    (let [[_ serializer compressor encryptor meta-size header-size]
+    (let [[version serializer compressor encryptor meta-size header-size]
           (<?- (read-header blob serializers env))
           env (assoc env :header-size header-size)
-          fn-read (partial -deserialize
-                           ;; Encryptor OUTERMOST, matching the write path.
-                           ;;
-                           ;; Bytes on disk are encrypt(compress(serialize(v))),
-                           ;; so reading them must decrypt BEFORE decompressing.
-                           ;; This nested the other way -- compressor outermost --
-                           ;; and so tried to decompress ciphertext. Any
-                           ;; compressor combined with any encryptor failed:
-                           ;; zstd+aes with "Unknown frame descriptor", lz4+aes
-                           ;; with "Stream unsupported". Invisible while either
-                           ;; side is the null implementation, which is the
-                           ;; default and is what the tests used.
-                           ((encryptor (:encryptor config)) (compressor serializer))
-                           read-handlers)]
+          enc (encryptor (:encryptor config))
+          fn-read (partial -deserialize (compressor serializer) read-handlers)
+          decode (fn [part bytes]
+                   (async+sync
+                    sync? *default-sync-translation*
+                    (go-try-
+                     (let [plaintext
+                           (<?- (-decrypt enc
+                                          bytes
+                                          (associated-data version store-key part)
+                                          env))]
+                       #?(:cljs (fn-read plaintext)
+                          :clj (with-open [input (ByteArrayInputStream. plaintext)]
+                                 (fn-read input)))))))]
       (case operation
-        :read-meta #?(:cljs (fn-read (<?- (-read-meta blob meta-size env)))
-                      :clj
-                      (let [bais-read (ByteArrayInputStream.
-                                       (<?- (-read-meta blob meta-size env)))
-                            value     (fn-read bais-read)
-                            _         (.close bais-read)]
-                        value))
-        :read-edn #?(:cljs (fn-read (<?- (-read-value blob meta-size env)))
-                     :clj
-                     (let [bais-read (ByteArrayInputStream.
-                                      (<?- (-read-value blob meta-size env)))
-                           value     (fn-read bais-read)
-                           _         (.close bais-read)]
-                       value))
-        :write-binary #?(:cljs
-                         (let [meta (fn-read (<?- (-read-meta blob meta-size env)))]
-                           [meta nil])
-                         :clj
-                         (let [bais-read (ByteArrayInputStream.
-                                          (<?- (-read-meta blob meta-size env)))
-                               meta      (fn-read bais-read)
-                               _         (.close bais-read)]
-                           [meta nil]))
-        :write-edn #?(:cljs
-                      (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
-                            value (fn-read (<?- (-read-value blob meta-size env)))]
-                        [meta value])
-                      :clj
-                      (let [bais-meta  (ByteArrayInputStream.
-                                        (<?- (-read-meta blob meta-size env)))
-                            meta       (fn-read bais-meta)
-                            _          (.close bais-meta)
-                            bais-value (ByteArrayInputStream.
-                                        (<?- (-read-value blob meta-size env)))
-                            value     (fn-read bais-value)
-                            _          (.close bais-value)]
-                        [meta value]))
+        :read-meta (<?- (decode :meta (<?- (-read-meta blob meta-size env))))
+        :read-edn (<?- (decode :value (<?- (-read-value blob meta-size env))))
+        :write-binary [(<?- (decode :meta (<?- (-read-meta blob meta-size env)))) nil]
+        :write-edn [(<?- (decode :meta (<?- (-read-meta blob meta-size env))))
+                    (<?- (decode :value (<?- (-read-value blob meta-size env))))]
         ;; Both segments, from the one pass the blob is already open for. The
         ;; write path has always done this (`:write-edn` below); a READ needs it
         ;; so a caller can obtain a value AND the revision it is at without a
@@ -255,20 +236,8 @@
         ;; is RACY: between reading the value and reading its revision another
         ;; writer can move both, and the caller would fence against a revision
         ;; that never belonged to the value it computed from.
-        :read-edn-meta #?(:cljs
-                          (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
-                                value (fn-read (<?- (-read-value blob meta-size env)))]
-                            [meta value])
-                          :clj
-                          (let [bais-meta  (ByteArrayInputStream.
-                                            (<?- (-read-meta blob meta-size env)))
-                                meta       (fn-read bais-meta)
-                                _          (.close bais-meta)
-                                bais-value (ByteArrayInputStream.
-                                            (<?- (-read-value blob meta-size env)))
-                                value      (fn-read bais-value)
-                                _          (.close bais-value)]
-                            [meta value]))
+        :read-edn-meta [(<?- (decode :meta (<?- (-read-meta blob meta-size env))))
+                        (<?- (decode :value (<?- (-read-value blob meta-size env))))]
         :read-binary (<?- (-read-binary blob meta-size locked-cb env)))))))
 
 (declare get-lock cas-lock-suffix)
@@ -547,6 +516,13 @@
           overwrite?    (and (:overwrite? env) (nil? expected-revision))
           env           (assoc env :overwrite? overwrite?)
           store-key     (key->store-key key)
+          _             (when (and (#{:read-binary :write-binary} operation)
+                                   (refuse-plaintext-binary?
+                                    ((:encryptor env) (:encryptor config))
+                                    env))
+                          (throw (ex-info binary-encryption-msg
+                                          {:type :konserve/unencrypted-binary
+                                           :key key})))
           env           (assoc env :store-key store-key :header-size header-size)
           serializer    (get serializers default-serializer)
           migration-key (<?- (-migratable backing key store-key env))
@@ -930,14 +906,14 @@
    (:sync? env) *default-sync-translation*
    (go-try-
     (let [serializer (get serializers default-serializer)
+          enc (encryptor (:encryptor config))
           to-array #?(:cljs
                       (fn [value]
-                        (-serialize ((encryptor  (:encryptor config)) (compressor serializer)) nil write-handlers value))
+                        (-serialize (compressor serializer) nil write-handlers value))
                       :clj
                       (fn [value]
                         (let [bos (ByteArrayOutputStream.)]
-                          (try (-serialize ((encryptor (:encryptor config)) (compressor serializer))
-                                           bos write-handlers value)
+                          (try (-serialize (compressor serializer) bos write-handlers value)
                                (.toByteArray bos)
                                (finally
                                  (.close bos))))))
@@ -953,9 +929,15 @@
 
                             ;; Prepare serialized data
                             meta (meta-up-fn key :edn old-meta)
-                            meta-arr (to-array meta)
+                            meta-arr (<?- (-encrypt enc
+                                                    (to-array meta)
+                                                    (associated-data version store-key :meta)
+                                                    env))
                             meta-size (count meta-arr)
-                            value-arr (to-array val)
+                            value-arr (<?- (-encrypt enc
+                                                     (to-array val)
+                                                     (associated-data version store-key :value)
+                                                     env))
                             header (create-header version
                                                   serializer compressor encryptor meta-size)
 
@@ -1105,7 +1087,7 @@
 
   PBinaryKeyValueStore
   (-bget [this key locked-cb opts]
-    (let [{:keys [sync? streaming?]} opts]
+    (let [{:keys [sync? streaming? raw?]} opts]
       (io-operation this serializers read-handlers write-handlers
                     {:key-vec [key]
                      :operation :read-binary
@@ -1116,12 +1098,13 @@
                      :version version
                      :sync? sync?
                      :streaming? streaming?
+                     :raw? raw?
                      :buffer-size buffer-size
                      :locked-cb locked-cb
                      :msg       {:type :read-binary-error
                                  :key  key}})))
   (-bassoc [this key meta-up input opts]
-    (let [{:keys [sync?]} opts]
+    (let [{:keys [sync? raw?]} opts]
       (io-operation this serializers read-handlers write-handlers
                     {:key-vec [key]
                      :operation  :write-binary
@@ -1133,6 +1116,7 @@
                      :up-fn-meta meta-up
                      :config     config
                      :sync?      sync?
+                     :raw?       raw?
                      :buffer-size buffer-size
                      :msg        {:type :write-binary-error
                                   :key  key}})))

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -7,7 +7,8 @@
    [konserve.metrics :as metrics]
    [konserve.serializers :refer [key->serializer]]
    [konserve.compressor :refer [get-compressor null-compressor]]
-   [konserve.encryptor :refer [associated-data encrypting? get-encryptor null-encryptor]]
+   [konserve.encryptor :refer [associated-data encrypting? get-encryptor null-encryptor
+                               assert-readable! validate-policy!]]
    [konserve.protocols :as protocols :refer [PEDNKeyValueStore
                                              PBinaryKeyValueStore
                                              -serialize -deserialize -encrypt -decrypt
@@ -208,6 +209,7 @@
    (go-try-
     (let [[version serializer compressor encryptor meta-size header-size]
           (<?- (read-header blob serializers env))
+          _ (assert-readable! encryptor (:encryptor config))
           env (assoc env :header-size header-size)
           enc (encryptor (:encryptor config))
           fn-read (partial -deserialize (compressor serializer) read-handlers)
@@ -1466,6 +1468,7 @@
                                (select-keys enc [:compressor :encryptor]))
         compressor (get-compressor (get-in enc [:compressor :type]))
         encryptor (get-encryptor (get-in enc [:encryptor :type]))]
+    (validate-policy! (:encryptor complete-config))
     ;; A top-level `:compressor`/`:encryptor` is REFUSED rather than ignored.
     ;; Both are read from `config` above, so passing a function at the top
     ;; level -- which reads exactly like it should work, and which

--- a/src/konserve/indexeddb.cljs
+++ b/src/konserve/indexeddb.cljs
@@ -501,16 +501,19 @@
      - `konserve.indexeddb/read-web-stream` will accept the argument to the
        locked-cb and return a promise-chan receiving err|bytes at the cost of
        allocating a larger array for the chunks to be copied into"
-  [db-name & {:as params}]
+  [db-name & {:keys [config] :as params}]
   (let [store-config (merge {:default-serializer :FressianSerializer
                              :compressor         konserve.compressor/null-compressor
                              :encryptor          konserve.encryptor/null-encryptor
                              :read-handlers      (atom {})
                              :write-handlers     (atom {})
-                             :config             {:sync-blob? true
-                                                  :in-place? true
-                                                  :no-backup? true  ;; IndexedDB is transactional, no backup needed
-                                                  :lock-blob? true}}
+                             ;; the caller's :config is merged over the defaults, as in the
+                             ;; filestores — dropping it here silently ignored :encryptor
+                             :config             (merge {:sync-blob? true
+                                                         :in-place? true
+                                                         :no-backup? true  ;; IndexedDB is transactional, no backup needed
+                                                         :lock-blob? true}
+                                                        config)}
                             (dissoc params :config))
         backing            (IndexedDBackingStore. db-name nil)]
     (defaults/connect-default-store backing store-config)))

--- a/src/konserve/indexeddb.cljs
+++ b/src/konserve/indexeddb.cljs
@@ -514,16 +514,17 @@
      - `konserve.indexeddb/read-web-stream` will accept the argument to the
        locked-cb and return a promise-chan receiving err|bytes at the cost of
        allocating a larger array for the chunks to be copied into"
-  [db-name & {:as params}]
+  [db-name & {:keys [config] :as params}]
   (let [store-config (merge {:default-serializer :FressianSerializer
                              :compressor         konserve.compressor/null-compressor
                              :encryptor          konserve.encryptor/null-encryptor
                              :read-handlers      (atom {})
                              :write-handlers     (atom {})
-                             :config             {:sync-blob? true
-                                                  :in-place? true
-                                                  :no-backup? true  ;; IndexedDB is transactional, no backup needed
-                                                  :lock-blob? true}}
+                             :config             (merge {:sync-blob? true
+                                                         :in-place? true
+                                                         :no-backup? true
+                                                         :lock-blob? true}
+                                                        config)}
                             (dissoc params :config))
         backing            (IndexedDBackingStore. db-name nil)]
     (defaults/connect-default-store backing store-config)))

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -54,6 +54,19 @@
     "For the JVM we use streams, while for JavaScript we return the value for now.")
   (-deserialize [this read-handlers input-stream]))
 
+(defprotocol PEncryptor
+  "Decouples encryption from serialization. Both ops take and return a whole byte
+   array (JVM byte[] / CLJS Uint8Array): an AEAD cipher must authenticate the full
+   ciphertext before it may release any plaintext, so streaming is not an option.
+
+   `aad` is authenticated-but-not-encrypted associated data that binds a ciphertext
+   to the slot it lives in; it must be identical on encrypt and decrypt.
+
+   Both ops return a channel, unless `(:sync? env)` is true, in which case they
+   return the byte array directly (and throw on failure)."
+  (-encrypt [this plaintext aad env])
+  (-decrypt [this ciphertext aad env]))
+
 (defprotocol PWriteHookStore
   "Protocol for stores that support write hooks.
    Write hooks are callbacks invoked after successful write operations.

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -55,6 +55,14 @@
     "For the JVM we use streams, while for JavaScript we return the value for now.")
   (-deserialize [this read-handlers input-stream]))
 
+(defprotocol PEncryptor
+  "Whole-value encryption. Both operations consume and produce byte arrays.
+
+  Associated data binds ciphertext to its storage context. Operations return a
+  channel unless `(:sync? env)` is true."
+  (-encrypt [this plaintext aad env])
+  (-decrypt [this ciphertext aad env]))
+
 (defprotocol PWriteHookStore
   "Protocol for stores that support write hooks.
    Write hooks are callbacks invoked after successful write operations.
@@ -320,4 +328,3 @@
 (extend-protocol PLockFreeStore
   #?(:clj Object :cljs default)
   (-lock-free? [_] false))
-

--- a/test/konserve/authenticated_read_policy_test.clj
+++ b/test/konserve/authenticated_read_policy_test.clj
@@ -1,0 +1,78 @@
+(ns konserve.authenticated-read-policy-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.core.async :refer [<!!]]
+            [konserve.core :as k]
+            [konserve.encryptor :as enc]
+            [konserve.impl.defaults :as defaults]
+            [konserve.impl.storage-layout :as layout]
+            [konserve.simulation.crash :as crash]
+            [konserve.filestore :as fs])
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(defn with-store [f]
+  (let [path (str (Files/createTempDirectory "konserve-auth-policy-" (make-array FileAttribute 0)))]
+    (try (f path) (finally (fs/delete-store path)))))
+
+(defn open-store [path encryptor]
+  (fs/connect-fs-store path :config {:encoding {:encryptor encryptor}}
+                       :opts {:sync? true}))
+
+(deftest strict-reader-rejects-valid-plaintext-and-legacy-records
+  (doseq [legacy [nil {:type :aes :key (apply str (repeat 64 "1"))}]]
+    (with-store
+      (fn [path]
+        (let [key (apply str (repeat 64 "1"))
+              old (open-store path legacy)
+              _ (k/assoc old :checkpoint {:revision 7} {:sync? true})
+              strict (open-store path {:type :aes-gcm :key key :require-authenticated? true})]
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (k/get strict :checkpoint nil {:sync? true})))
+          (is (instance? Throwable (<!! (k/get strict :checkpoint nil {:sync? false}))))
+          ;; Rejected reads must not rewrite or remove the existing record.
+          (is (= {:revision 7} (k/get old :checkpoint nil {:sync? true}))))))))
+
+(deftest strict-gcm-roundtrip-and-compatibility-opt-in
+  (with-store
+    (fn [path]
+      (let [key (enc/generate-key)
+            strict (open-store path {:type :aes-gcm :key key :require-authenticated? true})]
+        (k/assoc strict :checkpoint {:revision 8} {:sync? true})
+        (is (= {:revision 8} (k/get strict :checkpoint nil {:sync? true})))
+        (k/assoc (open-store path nil) :legacy :plain {:sync? true})
+        (is (= :plain (k/get (open-store path {:type :aes-gcm :key key})
+                             :legacy nil {:sync? true})))))))
+
+(deftest encryption-config-fails-closed
+  (is (thrown? clojure.lang.ExceptionInfo (enc/get-encryptor :aes-gmc)))
+  (with-store
+    (fn [path]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (open-store path {:type :none :require-authenticated? true})))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (open-store path {:type :aes-gcm :key (enc/generate-key)
+                                     :require-authenticated? "true"}))))))
+
+(deftest authenticated-cbor-checkpoints-survive-crash-boundaries
+  (doseq [point [:after-write-header :after-write-meta :after-write-value
+                 :after-sync :after-atomic-move :after-sync-store]]
+    (let [{:keys [backing state-atom crash-point-atom]} (crash/create-crash-aware-store)
+          _ (layout/-create-store backing {:sync? true})
+          config {:opts {:sync? true}
+                  :config {:encoding {:serializer :BoringSerializer
+                                      :encryptor {:type :aes-gcm :key (enc/generate-key)
+                                                  :require-authenticated? true}}}}
+          store (defaults/connect-default-store backing config)]
+      (k/assoc store :checkpoint {:revision 0 :receipts {}} {:sync? true})
+      (crash/set-crash-point! crash-point-atom point)
+      (is (thrown? Exception (k/assoc store :checkpoint {:revision 1 :receipts {}}
+                                      {:sync? true})))
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+      (let [reopened (defaults/connect-default-store backing config)
+            recovered (k/get reopened :checkpoint nil {:sync? true})]
+        (is (contains? #{{:revision 0 :receipts {}} {:revision 1 :receipts {}}}
+                       recovered))
+        (k/assoc reopened :checkpoint {:revision 2 :receipts {}} {:sync? true})
+        (crash/simulate-crash! state-atom)
+        (is (= {:revision 2 :receipts {}} (k/get reopened :checkpoint nil {:sync? true})))))))

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -2,7 +2,8 @@
   (:refer-clojure :exclude [get get-in update update-in assoc assoc-in dissoc exists? keys])
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.core.async :refer [<!! go chan put! close! <!] :as async]
-            [konserve.core :refer [bassoc bget keys]]
+            [clojure.java.io :as io]
+            [konserve.core :as k :refer [bassoc bget keys]]
             [konserve.compliance-test :refer [compliance-test]]
             [konserve.filestore :refer [connect-fs-store delete-store]]
             [konserve.tests.cache :as ct]
@@ -199,3 +200,44 @@
   (<!! (et/async-encryptor-test "/tmp/encryptor-test"
                                 connect-fs-store
                                 (fn [p] (go (delete-store p))))))
+
+(deftest aes-gcm-sync-test
+  (et/sync-aes-gcm-test "/tmp/aes-gcm-test"
+                        connect-fs-store
+                        delete-store))
+
+(deftest aes-gcm-async-test
+  (<!! (et/async-aes-gcm-test "/tmp/aes-gcm-test"
+                              connect-fs-store
+                              (fn [p] (go (delete-store p))))))
+
+(deftest aes-gcm-wrong-key-test
+  (<!! (et/async-aes-gcm-wrong-key-test "/tmp/aes-gcm-test"
+                                        connect-fs-store
+                                        (fn [p] (go (delete-store p))))))
+
+(deftest seal-unseal-test
+  (<!! (et/async-seal-unseal-test "/tmp/aes-gcm-test"
+                                  connect-fs-store
+                                  (fn [p] (go (delete-store p))))))
+
+(deftest aes-gcm-tamper-test
+  (testing "a flipped byte in a stored blob is rejected, not deserialized"
+    (delete-store "/tmp/aes-gcm-tamper")
+    (let [config {:encryptor {:type :aes-gcm :key et/gcm-key}}
+          store  (<!! (connect-fs-store "/tmp/aes-gcm-tamper" :config config))]
+      (<!! (k/assoc store :tampered {:balance 100}))
+      (is (= {:balance 100} (<!! (k/get store :tampered)))))
+    ;; flip the last byte of every blob: that lands in the GCM tag or the ciphertext
+    (doseq [f (->> (file-seq (io/file "/tmp/aes-gcm-tamper"))
+                   (filter #(.isFile ^java.io.File %)))]
+      (let [bs (java.nio.file.Files/readAllBytes (.toPath ^java.io.File f))
+            i  (dec (alength bs))]
+        (aset bs i (unchecked-byte (bit-xor (aget bs i) 1)))
+        (java.nio.file.Files/write (.toPath ^java.io.File f) bs
+                                   ^"[Ljava.nio.file.OpenOption;" (into-array java.nio.file.OpenOption []))))
+    (let [config {:encryptor {:type :aes-gcm :key et/gcm-key}}
+          store  (<!! (connect-fs-store "/tmp/aes-gcm-tamper" :config config))
+          res    (<!! (k/get store :tampered))]
+      (is (instance? Throwable res) "tampering is detected"))
+    (delete-store "/tmp/aes-gcm-tamper")))

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -503,3 +503,13 @@
   (<!! (et/async-encryptor-test "/tmp/encryptor-test"
                                 connect-fs-store
                                 (fn [p] (go (delete-store p))))))
+
+(deftest aes-gcm-sync-test
+  (et/sync-aes-gcm-test "/tmp/aes-gcm-test"
+                        connect-fs-store
+                        delete-store))
+
+(deftest aes-gcm-async-test
+  (<!! (et/async-aes-gcm-test "/tmp/aes-gcm-test"
+                              connect-fs-store
+                              (fn [p] (go (delete-store p))))))

--- a/test/konserve/indexeddb_test.cljs
+++ b/test/konserve/indexeddb_test.cljs
@@ -345,3 +345,27 @@
                                         idb/connect-idb-store
                                         idb/delete-idb))
            (done))))
+
+(deftest aes-gcm-async-test
+  (async done
+         (go
+           (<! (et/async-aes-gcm-test "aes-gcm-test"
+                                      idb/connect-idb-store
+                                      idb/delete-idb))
+           (done))))
+
+(deftest aes-gcm-wrong-key-test
+  (async done
+         (go
+           (<! (et/async-aes-gcm-wrong-key-test "aes-gcm-test"
+                                                idb/connect-idb-store
+                                                idb/delete-idb))
+           (done))))
+
+(deftest seal-unseal-test
+  (async done
+         (go
+           (<! (et/async-seal-unseal-test "aes-gcm-test"
+                                          idb/connect-idb-store
+                                          idb/delete-idb))
+           (done))))

--- a/test/konserve/indexeddb_test.cljs
+++ b/test/konserve/indexeddb_test.cljs
@@ -345,6 +345,14 @@
                                         idb/connect-idb-store
                                         idb/delete-idb))
            (done))))
+
+(deftest aes-gcm-async-test
+  (async done
+         (go
+           (<! (et/async-aes-gcm-test "aes-gcm-test"
+                                      idb/connect-idb-store
+                                      idb/delete-idb))
+           (done))))
 (deftest ^:browser reconnect-existing-store-opens-its-handle-test
   ;; Connect no longer writes for an existing store — it must still OPEN it.
   ;; Before PBackingOpen, the second connect below skipped -create-store (which

--- a/test/konserve/node_filestore_test.cljs
+++ b/test/konserve/node_filestore_test.cljs
@@ -296,3 +296,30 @@
                                         (fn [store-name]
                                           (go (filestore/delete-store store-name)))))
            (done))))
+
+(deftest aes-gcm-async-test
+  (async done
+         (go
+           (<! (et/async-aes-gcm-test "/tmp/aes-gcm-test"
+                                      connect-fs-store
+                                      (fn [store-name]
+                                        (go (filestore/delete-store store-name)))))
+           (done))))
+
+(deftest aes-gcm-wrong-key-test
+  (async done
+         (go
+           (<! (et/async-aes-gcm-wrong-key-test "/tmp/aes-gcm-test"
+                                                connect-fs-store
+                                                (fn [store-name]
+                                                  (go (filestore/delete-store store-name)))))
+           (done))))
+
+(deftest seal-unseal-test
+  (async done
+         (go
+           (<! (et/async-seal-unseal-test "/tmp/aes-gcm-test"
+                                          connect-fs-store
+                                          (fn [store-name]
+                                            (go (filestore/delete-store store-name)))))
+           (done))))

--- a/test/konserve/node_filestore_test.cljs
+++ b/test/konserve/node_filestore_test.cljs
@@ -307,3 +307,12 @@
                                         (fn [store-name]
                                           (go (filestore/delete-store store-name)))))
            (done))))
+
+(deftest aes-gcm-async-test
+  (async done
+         (go
+           (<! (et/async-aes-gcm-test "/tmp/aes-gcm-test"
+                                      connect-fs-store
+                                      (fn [store-name]
+                                        (go (filestore/delete-store store-name)))))
+           (done))))

--- a/test/konserve/tests/encryptor.cljc
+++ b/test/konserve/tests/encryptor.cljc
@@ -87,8 +87,9 @@
      (let [store (create-store store-name
                                :config {:encryptor {:type :aes-gcm :key gcm-key}}
                                :opts {:sync? true})]
-       ;; binary is refused on an encrypted store — it would bypass the cipher
-       (compliance-test store {:binary? false})
+       ;; binary is covered too: compliance-test passes {:raw? true} on an encrypted
+       ;; store, which is the only legal way to write binary there
+       (compliance-test store)
 
        (testing "binary values are refused rather than silently written in the clear"
          (is (thrown? clojure.lang.ExceptionInfo
@@ -157,7 +158,7 @@
                                 :config {:encryptor {:type :aes
                                                      :key "s3cr3t"}}
                                 :opts {:sync? true})]
-       (compliance-test store {:binary? false})
+       (compliance-test store)
        (delete-store store-name))))
 
 #?(:clj

--- a/test/konserve/tests/encryptor.cljc
+++ b/test/konserve/tests/encryptor.cljc
@@ -1,10 +1,143 @@
 (ns konserve.tests.encryptor
   (:require [clojure.core.async :refer [go <!]]
-            [clojure.test :refer [deftest is]]
+            [clojure.test :refer [deftest is testing]]
+            [konserve.core :as k]
+            [konserve.encryptor :as e]
+            [konserve.protocols :refer [-decrypt]]
             [konserve.compliance-test :refer
              [#?(:clj compliance-test)
               async-compliance-test]]
-            [superv.async :refer [<?-]]))
+            [org.replikativ.geheimnis.codec :as codec]
+            [superv.async :refer [<?-]]
+            #?(:clj [clojure.java.io :as io])))
+
+;; A 256-bit key, hex. Fixed here so a test failure is reproducible; real stores
+;; want (konserve.encryptor/generate-key).
+(def gcm-key "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+(def other-gcm-key "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100")
+
+#?(:clj
+   (defn- contains-subarray? [^bytes haystack ^bytes needle]
+     (let [h (alength haystack) n (alength needle)]
+       (boolean
+        (some (fn [i]
+                (loop [j 0]
+                  (cond (= j n)                             true
+                        (= (aget haystack (+ i j)) (aget needle j)) (recur (inc j))
+                        :else                               false)))
+              (range 0 (inc (- h n))))))))
+
+;; -----------------------------------------------------------------------------
+;; :aes-gcm
+;; -----------------------------------------------------------------------------
+
+(defn async-aes-gcm-test
+  [store-name create-store delete-store-async]
+  (go
+    (<! (delete-store-async store-name))
+    (let [config {:encryptor {:type :aes-gcm :key gcm-key}}
+          store  (<?- (create-store store-name :config config))]
+      (<! (async-compliance-test store))
+      #?(:cljs (when (.-close (:backing store)) (<! (.close (:backing store)))))
+      (<! (delete-store-async store-name)))))
+
+(defn async-aes-gcm-wrong-key-test
+  "A blob written under one key must not be readable under another. The AEAD tag
+   makes that a hard error rather than a garbage deserialization."
+  [store-name create-store delete-store-async]
+  (go
+    (<! (delete-store-async store-name))
+    (let [store (<?- (create-store store-name
+                                   :config {:encryptor {:type :aes-gcm :key gcm-key}}))]
+      (<! (k/assoc store :secret {:very "confidential"}))
+      #?(:cljs (when (.-close (:backing store)) (<! (.close (:backing store))))))
+    (let [store (<?- (create-store store-name
+                                   :config {:encryptor {:type :aes-gcm :key other-gcm-key}}))
+          res   (<! (k/get store :secret))]
+      (is (instance? #?(:clj Throwable :cljs js/Error) res)
+          "reading with the wrong key is rejected, not silently wrong")
+      #?(:cljs (when (.-close (:backing store)) (<! (.close (:backing store))))))
+    (<! (delete-store-async store-name))))
+
+(defn async-seal-unseal-test
+  "seal/unseal over the store's key, on whichever cipher the platform runs
+   (Web Crypto on JS, javax.crypto on the JVM)."
+  [store-name create-store delete-store-async]
+  (go
+    (<! (delete-store-async store-name))
+    (let [store   (<?- (create-store store-name
+                                     :config {:encryptor {:type :aes-gcm :key gcm-key}}))
+          payload (codec/str->bytes "raw bytes konserve never looks at")
+          sealed  (<?- (k/seal store :blob payload))]
+      (is (not= (codec/bytes->hex payload) (codec/bytes->hex sealed))
+          "the plaintext is not in the output")
+      (is (= (codec/bytes->hex payload)
+             (codec/bytes->hex (<?- (k/unseal store :blob sealed))))
+          "round-trips under the same key")
+      (is (instance? #?(:clj Throwable :cljs js/Error)
+                     (<! (k/unseal store :a-different-key sealed)))
+          "does not unseal under another key")
+      #?(:cljs (when (.-close (:backing store)) (<! (.close (:backing store)))))
+      (<! (delete-store-async store-name)))))
+
+#?(:clj
+   (defn sync-aes-gcm-test
+     [store-name create-store delete-store]
+     (delete-store store-name)
+     (let [store (create-store store-name
+                               :config {:encryptor {:type :aes-gcm :key gcm-key}}
+                               :opts {:sync? true})]
+       ;; binary is refused on an encrypted store — it would bypass the cipher
+       (compliance-test store {:binary? false})
+
+       (testing "binary values are refused rather than silently written in the clear"
+         (is (thrown? clojure.lang.ExceptionInfo
+                      (k/bassoc store :bin (byte-array (range 10)) {:sync? true}))))
+
+       (testing "{:raw? true} is the explicit opt-out: bytes pass through untouched"
+         (let [payload (byte-array (range 10))]
+           (k/bassoc store :bin payload {:sync? true :raw? true})
+           (k/bget store :bin
+                   (fn [{:keys [input-stream]}]
+                     (let [bs (java.io.ByteArrayOutputStream.)]
+                       (io/copy input-stream bs)
+                       (is (= (seq payload) (seq (.toByteArray bs))))))
+                   {:sync? true :raw? true})))
+
+       (testing "seal/unseal encrypt raw bytes under the store's key"
+         (let [payload (.getBytes "ANOTHER-SECRET-MARKER")
+               sealed  (k/seal store :sealed-bin payload {:sync? true})]
+           (is (not (contains-subarray? sealed (.getBytes "ANOTHER-SECRET-MARKER"))))
+           (k/bassoc store :sealed-bin sealed {:sync? true :raw? true})
+           (k/bget store :sealed-bin
+                   (fn [{:keys [input-stream]}]
+                     (let [bs (java.io.ByteArrayOutputStream.)]
+                       (io/copy input-stream bs)
+                       (is (= (seq payload)
+                              (seq (k/unseal store :sealed-bin (.toByteArray bs)
+                                             {:sync? true}))))))
+                   {:sync? true :raw? true})
+
+           (testing "and bind the ciphertext to the key it was sealed under"
+             (is (thrown? javax.crypto.AEADBadTagException
+                          (k/unseal store :some-other-key sealed {:sync? true}))))))
+
+       (testing "the value never reaches the disk in the clear"
+         (k/assoc store :leak-check "SUPER-SECRET-MARKER" {:sync? true})
+         (let [marker (.getBytes "SUPER-SECRET-MARKER")
+               blobs  (->> (file-seq (io/file store-name))
+                           (filter #(.isFile ^java.io.File %)))]
+           (is (seq blobs) "the store wrote something")
+           (is (not-any? (fn [f]
+                           (let [bs (java.io.ByteArrayOutputStream.)]
+                             (io/copy f bs)
+                             (contains-subarray? (.toByteArray bs) marker)))
+                         blobs))))
+       (delete-store store-name))))
+
+;; -----------------------------------------------------------------------------
+;; :aes — deprecated, but stores written with it must keep working
+;; -----------------------------------------------------------------------------
 
 (defn async-encryptor-test
   [store-name create-store delete-store-async]
@@ -24,5 +157,18 @@
                                 :config {:encryptor {:type :aes
                                                      :key "s3cr3t"}}
                                 :opts {:sync? true})]
-       (compliance-test store)
+       (compliance-test store {:binary? false})
        (delete-store store-name))))
+
+#?(:clj
+   ;; Golden vector produced by konserve <= 0.7's AESEncryptor on the JVM:
+   ;; [salt 64B][AES-256-CBC ciphertext]. It pins the legacy on-disk layout, so a
+   ;; store encrypted by an older konserve keeps decrypting after this refactor.
+   (deftest legacy-aes-format-test
+     (let [blob (codec/hex->bytes
+                 (str "6917da4cff96500eaebdb6a363ee5d88f20f4c61d372d32316fdea028c35dfcd"
+                      "e953638a33934c90bba14dbc55a9fcbed6500e8352d8cd26de00b8144830e3d0"
+                      "e43abc2ea89e6818a862c96b80ce9d66ac58637fc956c570ce371b100c8684bc"))
+           enc  (e/aes-encryptor {:key "s3cr3t"})]
+       (is (= "konserve legacy aes payload"
+              (String. ^bytes (-decrypt enc blob nil {:sync? true})))))))

--- a/test/konserve/tests/encryptor.cljc
+++ b/test/konserve/tests/encryptor.cljc
@@ -1,16 +1,119 @@
 (ns konserve.tests.encryptor
   (:require [clojure.core.async :refer [go <!]]
-            [clojure.test :refer [deftest is]]
+            [clojure.test :refer [deftest is testing]]
             [konserve.compliance-test :refer
              [#?(:clj compliance-test)
               async-compliance-test]]
-            [superv.async :refer [<?-]]))
+            [konserve.core :as k]
+            [konserve.encryptor :as e]
+            [konserve.protocols :refer [-decrypt]]
+            [org.replikativ.geheimnis.codec :as codec]
+            [superv.async :refer [<?-]]
+            #?(:clj [clojure.java.io :as io])))
+
+(def gcm-key
+  "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+
+(def other-gcm-key
+  "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100")
+
+#?(:clj
+   (defn- contains-subarray? [^bytes haystack ^bytes needle]
+     (let [h (alength haystack)
+           n (alength needle)]
+       (boolean
+        (some (fn [i]
+                (loop [j 0]
+                  (cond
+                    (= j n) true
+                    (= (aget haystack (+ i j)) (aget needle j)) (recur (inc j))
+                    :else false)))
+              (range 0 (inc (- h n))))))))
+
+(defn async-aes-gcm-test
+  [store-name create-store delete-store-async]
+  (go
+    (<! (delete-store-async store-name))
+    (let [store (<?- (create-store
+                      store-name
+                      :config {:encoding
+                               {:encryptor {:type :aes-gcm :key gcm-key}}}))
+          payload (codec/str->bytes "raw bytes konserve never looks at")]
+      (<?- (k/assoc store :secret {:very "confidential"}))
+      (is (= {:very "confidential"} (<?- (k/get store :secret))))
+      (let [sealed (<?- (k/seal store :blob payload))]
+        (is (not= (codec/bytes->hex payload) (codec/bytes->hex sealed)))
+        (is (= (codec/bytes->hex payload)
+               (codec/bytes->hex (<?- (k/unseal store :blob sealed)))))
+        (is (instance? #?(:clj Throwable :cljs js/Error)
+                       (<! (k/unseal store :other-key sealed)))))
+      #?(:cljs (when (.-close (:backing store))
+                 (<! (.close (:backing store))))))
+    (let [wrong-store (<?- (create-store
+                            store-name
+                            :config {:encoding
+                                     {:encryptor
+                                      {:type :aes-gcm :key other-gcm-key}}}))]
+      (is (instance? #?(:clj Throwable :cljs js/Error)
+                     (<! (k/get wrong-store :secret)))
+          "a wrong key must fail authentication")
+      #?(:cljs (when (.-close (:backing wrong-store))
+                 (<! (.close (:backing wrong-store))))))
+    (<! (delete-store-async store-name))))
+
+#?(:clj
+   (defn sync-aes-gcm-test
+     [store-name create-store delete-store]
+     (delete-store store-name)
+     (let [store (create-store
+                  store-name
+                  :config {:encoding
+                           {:encryptor {:type :aes-gcm :key gcm-key}}}
+                  :opts {:sync? true})]
+       (compliance-test store)
+
+       (testing "binary is never silently written in cleartext"
+         (is (thrown? clojure.lang.ExceptionInfo
+                      (k/bassoc store :bin (byte-array (range 10))
+                                {:sync? true}))))
+
+       (testing "raw binary and explicit sealing"
+         (let [payload (.getBytes "ANOTHER-SECRET-MARKER")
+               sealed (k/seal store :sealed-bin payload {:sync? true})]
+           (is (not (contains-subarray? sealed payload)))
+           (k/bassoc store :sealed-bin sealed {:sync? true :raw? true})
+           (k/bget store
+                   :sealed-bin
+                   (fn [{:keys [input-stream]}]
+                     (let [output (java.io.ByteArrayOutputStream.)]
+                       (io/copy input-stream output)
+                       (is (= (seq payload)
+                              (seq (k/unseal store
+                                             :sealed-bin
+                                             (.toByteArray output)
+                                             {:sync? true}))))))
+                   {:sync? true :raw? true})
+           (is (thrown? javax.crypto.AEADBadTagException
+                        (k/unseal store :other-key sealed {:sync? true})))))
+
+       (testing "plaintext does not occur in the stored files"
+         (k/assoc store :leak-check "SUPER-SECRET-MARKER" {:sync? true})
+         (let [marker (.getBytes "SUPER-SECRET-MARKER")
+               blobs (filter #(.isFile ^java.io.File %)
+                             (file-seq (io/file store-name)))]
+           (is (seq blobs))
+           (is (not-any? (fn [file]
+                           (let [output (java.io.ByteArrayOutputStream.)]
+                             (io/copy file output)
+                             (contains-subarray? (.toByteArray output) marker)))
+                         blobs))))
+       (delete-store store-name))))
 
 (defn async-encryptor-test
   [store-name create-store delete-store-async]
   (go
     (<! (delete-store-async store-name))
-    (let [config {:encryptor {:type :aes :key "s3cr3t"}}
+    (let [config {:encoding {:encryptor {:type :aes :key "s3cr3t"}}}
           store  (<?- (create-store store-name :config config))]
       (<! (async-compliance-test store))
       #?(:cljs (when (.-close (:backing store)) (<! (.close (:backing store)))))
@@ -21,8 +124,19 @@
      [store-name create-store delete-store]
      (delete-store store-name)
      (let [store  (create-store store-name
-                                :config {:encryptor {:type :aes
-                                                     :key "s3cr3t"}}
+                                :config {:encoding
+                                         {:encryptor {:type :aes
+                                                      :key "s3cr3t"}}}
                                 :opts {:sync? true})]
        (compliance-test store)
        (delete-store store-name))))
+
+#?(:clj
+   (deftest legacy-aes-format-test
+     (let [blob (codec/hex->bytes
+                 (str "6917da4cff96500eaebdb6a363ee5d88f20f4c61d372d32316fdea028c35dfcd"
+                      "e953638a33934c90bba14dbc55a9fcbed6500e8352d8cd26de00b8144830e3d0"
+                      "e43abc2ea89e6818a862c96b80ce9d66ac58637fc956c570ce371b100c8684bc"))
+           enc (e/aes-encryptor {:key "s3cr3t"})]
+       (is (= "konserve legacy aes payload"
+              (String. ^bytes (-decrypt enc blob nil {:sync? true})))))))


### PR DESCRIPTION
## Why

Konserve's legacy `:aes` mode is unauthenticated AES-CBC. A modified blob can
reach the deserializer without cryptographic authentication. This PR adds an
authenticated, portable mode and makes the previously implicit raw-binary
boundary explicit.

The branch uses released `org.replikativ/geheimnis` **0.2.39**, including the
synchronous JVM AEAD APIs. The temporary Git pin has been removed; focused
authenticated-read and filestore tests pass against the release (29 tests,
731 assertions).

## What

### `:aes-gcm` (header byte 2)

- AES-256-GCM through Geheimnis, with a fresh 32-byte CSPRNG salt and 12-byte
  nonce for each metadata/value segment.
- HKDF-SHA-256 derives a per-segment key from the store master key.
- Associated data binds ciphertext to layout version, store key, and
  `:meta` / `:value`, rejecting relocation and slot swaps.
- Keys are exactly 32 bytes or 64 hexadecimal characters;
  `konserve.encryptor/generate-key` creates one.
- JVM supports sync and async APIs. ClojureScript uses Web Crypto and therefore
  supports the async API.

### Whole-value encryption protocol

`PEncryptor` separates encryption from serialization. Authentication succeeds
over the complete ciphertext before plaintext reaches a serializer. This also
fixes the old compressor/encryptor inversion: the path is now always
`serialize -> compress -> encrypt`, reversed on read.

Custom encryptors must migrate from the old `PStoreSerializer` decorator to
`PEncryptor`.

### Binary values

Streaming binary bypasses value serialization and remains byte-for-byte raw.
Encrypted stores now refuse `bassoc` / `bget` unless the caller explicitly
passes `{:raw? true}`. Materialized payloads can use
`konserve.core/seal` / `unseal`, which use the store key and bind the
ciphertext to its Konserve key. Bulk or streaming AEAD framing remains a
separate follow-up.

### Compatibility

- Legacy `:aes` header byte 1 remains readable and writable, pinned by its old
  on-disk golden vector.
- IndexedDB now preserves the caller's nested encoding configuration instead of
  silently discarding encryptor/compressor settings.
- The public examples use the current canonical
  `:config {:encoding {...}}` shape.

## Verification

- JVM: **271 tests / 4,407 assertions**, zero failures.
- Node/ClojureScript: release build with zero warnings; **70 tests / 439
  assertions**, zero failures.
- Focused coverage includes sync and async AES-GCM, wrong-key and cross-key
  rejection, explicit raw binary, sealed binary, absence of plaintext markers
  on disk, multi-key writes, and legacy AES compatibility.
- Formatting is clean. Lint has zero errors and only the existing repository
  warnings.
