### PR TITLE
feat(multi-assoc): ordered batches — [k v] pairs, order is apply order

### DIFF
--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -109,6 +109,24 @@
              (is (= 42 (<!! (k/get store :multi1 nil opts))))
              (is (= "value" (<!! (k/get store :multi2 nil opts)))))
 
+             ;; multi-assoc also takes an ORDERED seq of [k v] pairs — the form used when a
+             ;; batch writes immutable values plus a mutable pointer that makes them
+             ;; reachable, with the pointer LAST (see konserve.core/multi-assoc).
+           (let [batch  [[:ord-a 1] [:ord-b 2] [:ord-root {:refs [:ord-a :ord-b]}]]
+                 result (<!! (k/multi-assoc store batch
+                                            (k/uniform-meta [[:ord-a 1] [:ord-b 2]]
+                                                            {:immutable? true})
+                                            opts))]
+             (is (= result {:ord-a true :ord-b true :ord-root true}))
+             (is (= 1 (<!! (k/get store :ord-a nil opts))))
+             (is (= 2 (<!! (k/get store :ord-b nil opts))))
+             (is (= {:refs [:ord-a :ord-b]} (<!! (k/get store :ord-root nil opts))))
+             ;; per-key meta applied only to the pair-seq keys we named
+             (is (true? (:immutable? (<!! (k/get-meta store :ord-a nil opts)))))
+             (is (nil? (:immutable? (<!! (k/get-meta store :ord-root nil opts))))
+                 "the mutable pointer is not marked immutable"))
+           (<!! (k/multi-dissoc store [:ord-a :ord-b :ord-root] opts))
+
              ;; Test multi-dissoc with existing keys
            (let [result (<!! (k/multi-dissoc store [:multi1 :multi2] opts))]
              (is (= result {:multi1 true :multi2 true}))
@@ -195,7 +213,19 @@
                (is (= {:hook-m1 1 :hook-m2 2} (:kvs (nth @hook-events 4))))
               ;; Clean up multi-assoc keys
                (<!! (k/dissoc store :hook-m1 opts))
-               (<!! (k/dissoc store :hook-m2 opts)))
+               (<!! (k/dissoc store :hook-m2 opts))
+
+              ;; An ORDERED batch must reach the hook VERBATIM, order intact — a sync layer
+              ;; relays it in this order so a subscriber applies the mutable pointer last.
+               (let [batch [[:hook-o1 1] [:hook-o2 2] [:hook-root 3]]
+                     before (count @hook-events)]
+                 (<!! (k/multi-assoc store batch opts))
+                 (let [ev (nth @hook-events before)]
+                   (is (= :multi-assoc (:api-op ev)))
+                   (is (= batch (:kvs ev)) "ordered kvs forwarded verbatim")
+                   (is (= [:hook-o1 :hook-o2 :hook-root] (mapv first (:kvs ev)))
+                       "batch order preserved onto the write hook")))
+               (<!! (k/multi-dissoc store [:hook-o1 :hook-o2 :hook-root] opts)))
 
             ;; Test removing hook - should stop receiving events
              (k/remove-write-hook! store ::test-hook)

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -36,7 +36,8 @@
     :key-vec <full key path> (for assoc-in/update-in)
     :value <written value>
     :old-value <previous value> (for update operations)
-    :kvs <map of key->value> (for multi-assoc)}
+    :kvs <the multi-assoc batch, forwarded VERBATIM — a map, or an ordered seq of
+          [k v] pairs whose order is the apply order (see multi-assoc)>}
 
    Parameters:
    - store: A store implementing PWriteHookStore
@@ -418,21 +419,47 @@
   "Build a per-key meta map applying the same `meta` to every key — a convenience
    for `multi-assoc`'s per-key `meta` when a whole batch shares one annotation:
    `(multi-assoc store nodes (uniform-meta nodes {:immutable? true}) opts)`.
-   `kvs` may be the kv-map itself or a seq of keys."
+   `kvs` may be a kv-map, an ordered seq of [k v] pairs, or a plain seq of keys.
+   Note the result is a plain lookup map — per-key meta is unordered by nature;
+   ordering lives in `kvs` (see `multi-assoc`)."
   [kvs meta]
-  (let [ks (if (map? kvs) (clojure.core/keys kvs) kvs)]
+  (let [ks (cond
+             (map? kvs)                      (clojure.core/keys kvs)
+             ;; seq of [k v] pairs (an ordered multi-assoc batch)
+             (and (sequential? (first kvs))
+                  (= 2 (count (first kvs))))  (clojure.core/map first kvs)
+             :else                            kvs)]
     (zipmap ks (clojure.core/repeat meta))))
 
 (defn multi-assoc
-  "Atomically associates multiple key-value pairs with flat keys.
-  Takes a map of keys to values and stores them in a single atomic transaction.
-  All operations must succeed or all must fail (all-or-nothing semantics).
+  "Associates multiple key-value pairs with flat keys, as one batch. Atomically where the
+  backend can (IndexedDB); ordered everywhere (see below), which is the weaker guarantee
+  that actually suffices.
 
-  Example:
+  `kvs` is either a map, or — preferred when the batch has internal dependencies — an
+  ORDERED sequence of `[k v]` pairs. **Sequence order is apply order**, and it is preserved
+  end-to-end: through the backing store's writes and verbatim onto the `:multi-assoc`
+  write-hook (so a sync layer can relay the batch in the same order). A map has no order,
+  so a map batch makes no ordering promise.
+
+  Why that matters: not every backend can write multiple keys atomically (S3, filesystems
+  cannot; IndexedDB can). For a batch that writes a set of immutable, content-addressed
+  values plus a MUTABLE pointer that makes them reachable, you do not need atomicity — you
+  need order. Put the pointer LAST:
+
   ```
-  (multi-assoc store {:user1 {:name \"Alice\"}
-                      :user2 {:name \"Bob\"}})
+  (multi-assoc store [[node-a v] [node-b v] [:root {:refs [node-a node-b]}]]
+               (uniform-meta [node-a node-b] {:immutable? true}))
   ```
+
+  Then any prefix of the batch leaves the store consistent: the values are written but
+  unreachable (harmless orphans, collectable), and the pointer flips only once everything it
+  references exists. A torn batch can never produce a dangling pointer. This is the
+  write-the-leaves-then-flip-the-root discipline, and it is what lets non-atomic backends be
+  crash-safe.
+
+  Atomic backends still apply the batch all-or-nothing, in which case the order is simply
+  redundant — passing an ordered seq is always safe.
 
   Returns a map of keys to results (typically true for each key).
 

--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -10,7 +10,7 @@
                                                       PEDNKeyValueStore PBinaryKeyValueStore
                                                       PKeyIterable PAssocSerializers PMultiKeySupport
                                                       PMultiKeyEDNValueStore]]
-            [konserve.utils :refer [meta-update multi-key-capable? invoke-write-hooks! #?(:clj async+sync) *default-sync-translation*]
+            [konserve.utils :refer [meta-update multi-key-capable? kv-keys invoke-write-hooks! #?(:clj async+sync) *default-sync-translation*]
              #?@(:cljs [:refer-macros [async+sync]])]
             [superv.async :refer [go-try- <?-]]
             [replikativ.logging :as log]))
@@ -380,7 +380,7 @@
                      (try
                        (<?- (-multi-assoc frontend-store kvs meta-up-fn opts))
                        (catch #?(:clj Exception :cljs js/Error) e
-                         (log/warn :konserve/tiered-frontend-multi-assoc-failed {:kvs-keys (clojure.core/keys kvs) :error e})))
+                         (log/warn :konserve/tiered-frontend-multi-assoc-failed {:kvs-keys (kv-keys kvs) :error e})))
                      backend-result)
 
                    :write-behind
@@ -389,17 +389,17 @@
                      (go (try
                            (<?- (-multi-assoc backend-store kvs meta-up-fn opts))
                            (catch #?(:clj Exception :cljs js/Error) e
-                             (log/warn :konserve/tiered-backend-multi-assoc-failed {:kvs-keys (clojure.core/keys kvs) :error e}))))
+                             (log/warn :konserve/tiered-backend-multi-assoc-failed {:kvs-keys (kv-keys kvs) :error e}))))
                      frontend-result)
 
                    :write-around
                    (let [result (<?- (-multi-assoc backend-store kvs meta-up-fn opts))]
                      ;; Invalidate all affected keys from frontend
                      (go (try
-                           (doseq [k (clojure.core/keys kvs)]
+                           (doseq [k (kv-keys kvs)]
                              (<?- (-dissoc frontend-store k opts)))
                            (catch #?(:clj Exception :cljs js/Error) e
-                             (log/warn :konserve/tiered-frontend-invalidation-failed {:kvs-keys (clojure.core/keys kvs) :error e}))))
+                             (log/warn :konserve/tiered-frontend-invalidation-failed {:kvs-keys (kv-keys kvs) :error e}))))
                      result)
 
                    :frontend-only

--- a/src/konserve/utils.cljc
+++ b/src/konserve/utils.cljc
@@ -23,6 +23,15 @@
     {:key key :type type :last-write (now)}
     (clojure.core/assoc old :last-write (now))))
 
+(defn kv-keys
+  "The keys of a `multi-assoc` kvs argument, which may be a map OR an ORDERED
+   sequence of [k v] pairs (see `konserve.core/multi-assoc`). For a pair-seq the
+   key order is preserved; for a map it is unspecified, as always."
+  [kvs]
+  (if (map? kvs)
+    (clojure.core/keys kvs)
+    (clojure.core/map first kvs)))
+
 (defn multi-key-capable?
   "Checks whether the store supports multi-key operations.
 

--- a/test/konserve/tests/tiered.cljc
+++ b/test/konserve/tests/tiered.cljc
@@ -85,7 +85,17 @@
           (is (not (contains? ks :only-backend)) "keys excludes the not-yet-cached backend key"))
         ;; reading it falls through (frontend-first) and warms the frontend cache
         (is (= {:v 2} (<?- (k/get-in store [:only-backend]))) "cold read falls through to backend")
-        (is (= {:v 2} (<?- (k/get-in frontend-store [:only-backend]))) "read-through warmed the frontend")
+        ;; The warm is deliberately FIRE-AND-FORGET — warming must not block the read — so
+        ;; poll for it instead of assuming it has already landed. Asserting immediately is a
+        ;; race: it wins on a fast machine and loses under CI load.
+        (let [warmed (loop [tries 0]
+                       (let [v (<?- (k/get-in frontend-store [:only-backend]))]
+                         (cond
+                           (some? v)   v
+                           (>= tries 100) nil
+                           :else (do (<! (timeout 20))
+                                     (recur (inc tries))))))]
+          (is (= {:v 2} warmed) "read-through warmed the frontend"))
         ;; dissoc removes from the frontend ONLY — a backend copy is untouched
         (<?- (k/assoc-in backend-store [:cached] {:v 99}))
         (<?- (k/dissoc store :cached))


### PR DESCRIPTION
## Why

`multi-assoc` took a **map**, so a batch had no order. That's fine when the backend writes atomically — but **not every backend can**: S3 and filesystems cannot write multiple keys atomically (only IndexedDB implements `-multi-write-blobs`).

And for the batch shape that actually matters, atomicity **isn't what you need**:

> a set of **immutable, content-addressed values** plus a **mutable pointer** that makes them reachable

There, **order** suffices. Put the pointer **last**, and any prefix of the batch leaves the store consistent: the values are written but *unreachable* (harmless orphans, collectable), and the pointer flips only once everything it references exists. A torn batch can never produce a dangling pointer.

That's the *write-the-leaves-then-flip-the-root* discipline — the thing that lets a non-atomic backend be crash-safe at all.

## What

`multi-assoc` now also accepts an **ordered sequence of `[k v]` pairs**, and **sequence order is apply order** — preserved through the backing writes and forwarded **verbatim** onto the `:multi-assoc` write hook.

```clojure
(multi-assoc store [[node-a v] [node-b v] [:root {:refs [node-a node-b]}]]
             (uniform-meta [node-a node-b] {:immutable? true}))
```

That last part is the point: a sync layer can now **relay a batch in the order it was written**, instead of reconstructing an order by guessing at key types.

## Scope — mostly a contract

The plumbing already preserved order; it was just typed as a map:
- `prepare-multi-assoc` already did `(seq kvs)` and looped;
- `memory`'s `-multi-assoc` already `reduce`d over pairs.

Fixed the two places that genuinely assumed a map:
- `tiered`'s `-multi-assoc` called `(keys kvs)` in 4 spots → new `konserve.utils/kv-keys` (map- and pair-seq-safe);
- `uniform-meta` would zipmap a pair-seq's **pairs** as keys → now handles pairs.

**Backwards compatible**: maps still work and still make no ordering promise. Atomic backends apply the batch all-or-nothing, where order is simply redundant — passing an ordered seq is always safe.

## Tests

Added to the **compliance suite**, so every multi-key-capable store gets them:
- an ordered pair-seq batch writes all keys, with per-key meta applied only to the named keys (pointer left mutable);
- the ordered batch reaches the write hook **verbatim, order intact**.

**74 tests, 1262 assertions, 0 failures** (was 1232 — new assertions ran).