### PR TITLE
fix(store): -delete-store must honour :sync? — and :tiered must actually delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,22 @@ All notable, user-visible changes to konserve are documented here.
   honours `:ignore-existence?`; the multi-key GC delete path is a separate
   follow-up.)
 
+### Fixed
+- **`delete-store` now honours `:sync?` — and `:tiered` actually deletes.**
+  `-delete-store` was the one store method that ignored its `opts`: `:memory` and
+  `:file` (JVM and Node) returned a plain value whatever `:sync?` said, so an async
+  caller could not await the deletion — and `delete-store` defaults to
+  `{:sync? false}`, so async is the *common* path. Worse, `:tiered` called
+  `(delete-store backend-config)` with **no opts** — the async default — and then
+  dropped the returned channel, so **deleting a tiered store over an async backend
+  (e.g. S3) removed nothing at all**, silently, with any error swallowed into a
+  channel nobody read. All four implementations now follow the same contract every
+  other store method obeys: a value under `{:sync? true}`, otherwise a channel that
+  delivers when the deletion is *complete*. The Node file backend now also uses its
+  existing non-blocking `delete-store-async` on the async path.
+  The contract is documented on the `-delete-store` multimethod and pinned by tests
+  (previously `memory-store-delete` *asserted* the broken behaviour).
+
 ### Changed
 - **Probe-elision now covers non-overwrite writes, not only reads.** On a
   `PReadMissSafe` backing, `update-in` / `update` / nested `assoc-in` / `bassoc`

--- a/src/konserve/node_filestore.cljs
+++ b/src/konserve/node_filestore.cljs
@@ -604,7 +604,13 @@
 
 (defmethod store/-delete-store :file
   [{:keys [path]} opts]
-  (delete-store path))
+  ;; Honour :sync? like -store-exists?/-release-store do. This used to call the
+  ;; blocking `delete-store` and ignore opts entirely, so an async caller got a plain
+  ;; value where the contract promises a channel — and the non-blocking variant that
+  ;; already existed went unused.
+  (if (:sync? opts)
+    (delete-store path)
+    (delete-store-async path)))
 
 (defmethod store/-release-store :file
   [_config _store opts]

--- a/src/konserve/store.cljc
+++ b/src/konserve/store.cljc
@@ -105,7 +105,18 @@
 (defmulti -delete-store
   "Private multimethod for deleting stores with fixed arity.
 
-   Dispatch is based on :backend in config."
+   Dispatch is based on :backend in config.
+
+   CONTRACT (the same one every other store method obeys): the return value must
+   follow `opts`. With `{:sync? true}` return the value directly; otherwise return a
+   CHANNEL that delivers when the deletion is COMPLETE. `delete-store` defaults to
+   `{:sync? false}`, so async is the common path, not the exotic one.
+
+   Getting this wrong is invisible in tests and catastrophic in production: a method
+   that returns a plain value on the async path leaves callers unable to await it, and
+   one that returns an *un-awaited* inner channel reports success while nothing has been
+   deleted — with any error swallowed into a channel nobody reads. Every implementation
+   here previously did one or the other."
   (fn [config _opts]
     (validate-store-config config)
     (:backend config)))
@@ -240,11 +251,13 @@
     (if (:sync? opts) false (go-try- false))))
 
 (defmethod -delete-store :memory
-  [{:keys [id] :as config} _opts]
+  [{:keys [id] :as config} opts]
   ;; Only delete from registry if :id provided
   (when id
     (konserve.memory/delete-mem-store id))
-  nil)
+  ;; Honour :sync? like every other store method — see the note on -delete-store's
+  ;; contract at the multimethod definition.
+  (if (:sync? opts) nil (go-try- nil)))
 
 (defmethod -release-store :memory
   [_config _store opts]
@@ -289,8 +302,9 @@
 
 #?(:clj
    (defmethod -delete-store :file
-     [{:keys [path filesystem] :as config} _opts]
-     (konserve.filestore/delete-store filesystem path)))
+     [{:keys [path filesystem] :as config} opts]
+     (let [res (konserve.filestore/delete-store filesystem path)]
+       (if (:sync? opts) res (go-try- res)))))
 
 #?(:clj
    (defmethod -release-store :file
@@ -409,14 +423,23 @@
   (store-exists? backend-config opts))
 
 (defmethod -delete-store :tiered
-  [{:keys [backend-config frontend-config] :as config} _opts]
-  ;; Delete backend (authoritative source)
-  ;; Optionally delete frontend if it's persistent
-  (delete-store backend-config)
-  ;; Only delete frontend if it has persistence (e.g., file-based)
-  (when (and frontend-config (#{:file :indexeddb :lmdb :rocksdb} (:backend frontend-config)))
-    (delete-store frontend-config))
-  nil)
+  [{:keys [backend-config frontend-config] :as config} opts]
+  ;; Mirrors -release-store :tiered below. Both sub-deletes MUST be awaited: an async
+  ;; backend (:s3, …) hands back a channel, and the previous version called
+  ;; `(delete-store backend-config)` with no opts — i.e. the {:sync? false} default —
+  ;; and dropped the channel on the floor. Deleting a tiered store over S3 therefore
+  ;; removed nothing at all, silently, with any error swallowed into a channel nobody
+  ;; read.
+  (async+sync
+   (:sync? opts)
+   *default-sync-translation*
+   (go-try-
+    ;; Backend is the authoritative source.
+    (<?- (delete-store backend-config opts))
+    ;; Only delete the frontend if it has persistence (a memory cache needs no delete).
+    (when (and frontend-config (#{:file :indexeddb :lmdb :rocksdb} (:backend frontend-config)))
+      (<?- (delete-store frontend-config opts)))
+    nil)))
 
 (defmethod -release-store :tiered
   [{:keys [frontend-config backend-config]} store opts]

--- a/test/konserve/store_test.cljc
+++ b/test/konserve/store_test.cljc
@@ -1,5 +1,6 @@
 (ns konserve.store-test
   (:require [clojure.core.async :as a :refer [go <! take! #?(:clj <!!)]]
+            #?(:clj [clojure.core.async.impl.protocols])
             [clojure.test :refer [deftest #?(:cljs async) is testing]]
             [konserve.store :as store]
             [konserve.core :as k]))
@@ -44,10 +45,16 @@
 
 #?(:clj
    (deftest memory-store-delete
-     (testing "delete-store :memory does nothing"
-       (let [id #uuid "550e8400-e29b-41d4-a716-446655440004"]
-         ;; Memory store doesn't have persistent storage to delete
-         (is (nil? (store/delete-store {:backend :memory :id id})))))))
+     (testing "delete-store :memory removes the store from the registry"
+       ;; NB: this used to assert `(nil? (store/delete-store {...}))` with no opts —
+       ;; i.e. it asserted that the ASYNC path returns a plain nil. That was the bug
+       ;; written down as a test. delete-store defaults to {:sync? false} and must
+       ;; return a channel; the value is delivered on it.
+       (let [id #uuid "550e8400-e29b-41d4-a716-446655440004"
+             cfg {:backend :memory :id id}]
+         (store/create-store cfg {:sync? true})
+         (is (nil? (<!! (store/delete-store cfg))))
+         (is (false? (store/store-exists? cfg {:sync? true})))))))
 
 #?(:clj
    (deftest memory-store-release
@@ -177,6 +184,97 @@
 
          ;; Cleanup
          (store/delete-store {:backend :file :path path :id id})))))
+
+;; =============================================================================
+;; -delete-store contract
+;; =============================================================================
+;; Regression: -delete-store was the ONE store method that ignored `opts`.
+;; :memory and :file returned a plain value whatever :sync? said (so an async caller
+;; could not await the deletion), and :tiered went further — it called
+;; `(delete-store backend-config)` with no opts, i.e. the {:sync? false} DEFAULT, and
+;; then dropped the returned channel, so deleting a tiered store over an async backend
+;; removed nothing at all, silently.
+;;
+;; The polymorphism tests above never exercised delete-store; they only used it (with
+;; no opts, un-awaited) as cleanup. Hence: assert the contract explicitly.
+
+#?(:clj
+   (deftest delete-store-async-returns-a-channel-and-completes
+     (testing ":memory — async delete-store returns a channel; store is gone when it delivers"
+       (let [id #uuid "550e8400-e29b-41d4-a716-4466554400a1"
+             cfg {:backend :memory :id id}]
+         (store/create-store cfg {:sync? true})
+         (is (true? (store/store-exists? cfg {:sync? true})))
+         (let [res (store/delete-store cfg)]      ;; default {:sync? false}
+           (is (satisfies? clojure.core.async.impl.protocols/ReadPort res)
+               "async delete-store must return a channel, not a plain value")
+           (<!! res))
+         (is (false? (store/store-exists? cfg {:sync? true}))
+             "store must be gone once the async delete-store channel delivers")))
+
+     (testing ":memory — sync delete-store returns a value, not a channel"
+       (let [id #uuid "550e8400-e29b-41d4-a716-4466554400a2"
+             cfg {:backend :memory :id id}]
+         (store/create-store cfg {:sync? true})
+         (let [res (store/delete-store cfg {:sync? true})]
+           (is (not (satisfies? clojure.core.async.impl.protocols/ReadPort res))
+               "sync delete-store must return a value, not a channel"))
+         (is (false? (store/store-exists? cfg {:sync? true})))))
+
+     (testing ":file — async delete-store returns a channel; store is gone when it delivers"
+       (let [path (str (System/getProperty "java.io.tmpdir")
+                       "/konserve-delete-contract-" (System/currentTimeMillis))
+             id #uuid "550e8400-e29b-41d4-a716-4466554400a3"
+             cfg {:backend :file :path path :id id}]
+         (store/create-store cfg {:sync? true})
+         (is (true? (store/store-exists? cfg {:sync? true})))
+         (let [res (store/delete-store cfg)]
+           (is (satisfies? clojure.core.async.impl.protocols/ReadPort res)
+               "async delete-store must return a channel, not a plain value")
+           (<!! res))
+         (is (false? (store/store-exists? cfg {:sync? true}))
+             "store must be gone once the async delete-store channel delivers")))))
+
+#?(:clj
+   (deftest delete-store-tiered-actually-deletes-the-backend
+     ;; The nasty one: :tiered called (delete-store backend-config) with NO opts —
+     ;; the async default — and never awaited it, so on an async backend it deleted
+     ;; nothing while reporting success.
+     (testing ":tiered — deleting removes BOTH tiers, sync and async"
+       (let [mk (fn [n]
+                  {:backend :tiered
+                   :id #uuid "550e8400-e29b-41d4-a716-4466554400b0"
+                   :frontend-config {:backend :file
+                                     :path (str (System/getProperty "java.io.tmpdir")
+                                                "/konserve-tiered-del-f" n "-"
+                                                (System/currentTimeMillis))
+                                     :id #uuid "550e8400-e29b-41d4-a716-4466554400b0"}
+                   :backend-config  {:backend :file
+                                     :path (str (System/getProperty "java.io.tmpdir")
+                                                "/konserve-tiered-del-b" n "-"
+                                                (System/currentTimeMillis))
+                                     :id #uuid "550e8400-e29b-41d4-a716-4466554400b0"}})]
+         ;; sync
+         (let [cfg (mk "s")]
+           (store/create-store cfg {:sync? true})
+           (is (true? (store/store-exists? cfg {:sync? true})))
+           (store/delete-store cfg {:sync? true})
+           (is (false? (store/store-exists? cfg {:sync? true})))
+           (is (false? (store/store-exists? (:backend-config cfg) {:sync? true}))
+               "tiered delete must delete the authoritative BACKEND")
+           (is (false? (store/store-exists? (:frontend-config cfg) {:sync? true}))
+               "tiered delete must delete a persistent frontend"))
+         ;; async
+         (let [cfg (mk "a")
+               _   (store/create-store cfg {:sync? true})
+               res (store/delete-store cfg)]
+           (is (satisfies? clojure.core.async.impl.protocols/ReadPort res)
+               "async tiered delete-store must return a channel")
+           (<!! res)
+           (is (false? (store/store-exists? (:backend-config cfg) {:sync? true}))
+               "async tiered delete must have deleted the BACKEND by the time it delivers")
+           (is (false? (store/store-exists? (:frontend-config cfg) {:sync? true}))
+               "async tiered delete must have deleted the FRONTEND by the time it delivers"))))))
 
 ;; =============================================================================
 ;; ClojureScript IndexedDB Tests


### PR DESCRIPTION
## The bug

`-delete-store` was the **one store method that ignored its `opts`**. Every sibling (`-connect-store`, `-create-store`, `-store-exists?`, `-release-store`) returns a value under `{:sync? true}` and a **channel** otherwise. `-delete-store` did not:

```clojure
:memory       [config _opts] -> nil                             ;; whatever :sync? says
:file (JVM)   [config _opts] -> (filestore/delete-store …)
:file (Node)  [config opts]  -> (delete-store path)             ;; opts bound, unused
:tiered       [config _opts] -> (delete-store backend-config)   ;; NO opts, NOT awaited
```

This matters because **`delete-store` defaults to `{:sync? false}`** — async is the common path, not the exotic one.

- `:memory` / `:file` returned a plain value on the async path, so a caller doing `(<! (delete-store cfg))` couldn't await the deletion (and `<?-` on a non-channel throws).
- **`:tiered` is the serious one.** It called `(delete-store backend-config)` with no opts, got a channel back from any async backend, and **threw it away**. So deleting a tiered store over S3 deleted *nothing* — silently, with any error swallowed into a channel nobody read. It then returned `nil`, reporting success.

## The fix

All four implementations now follow the contract, which is written down on the multimethod so the next backend author doesn't rediscover this. `:tiered` mirrors `-release-store :tiered` directly below it (`async+sync` + `go-try-` + `<?-` on both sub-stores). The Node file backend now uses its **already-existing** non-blocking `delete-store-async` on the async path instead of the blocking variant.

## Tests

New `-delete-store` contract suite: async returns a channel; the store is gone once it delivers; sync returns a value; tiered deletes **both** tiers on both paths. **It fails without the fix.**

Note that `memory-store-delete` previously *asserted the broken behaviour*:

```clojure
(is (nil? (store/delete-store {:backend :memory :id id})))   ;; no opts => async path
```

i.e. it pinned "the async path returns a plain nil". The bug was written down as a test. Rewritten.

**Full JVM suite: 76 tests, 1278 assertions, 0 failures.**

## How it was found

Downstream: Datahike's `d/delete-database` on an S3 store silently deleted nothing — objects stayed in the bucket, `database-exists?` kept returning `true`. konserve-s3 had the same missing-await bug in its own `-delete-store` (replikativ/konserve-s3#12, merged). This PR fixes the same class of bug in konserve's built-in backends, and pins the contract so it can't recur.

Same method, four implementations, one contract, zero of them honouring it — worth the multimethod docstring.