### PR TITLE
fix(node-filestore): delete-store-async was broken three ways — and never ran

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ All notable, user-visible changes to konserve are documented here.
   follow-up.)
 
 ### Fixed
+- **Node file backend: `delete-store-async` was broken in three ways, and never ran.**
+  Wiring `-delete-store :file` to the async variant (above) exposed it. `iofs/arm-r`
+  yields **`[?err]`** — a vector — but it was bound as a bare `?err`, so the success
+  value `[nil]` was truthy and the function **always took the error branch**: it
+  returned `[nil]` *as if it were an error* and never reached the fsync at all. Once
+  that was fixed, two more surfaced: it fsynced `base` — the directory `arm-r` had just
+  deleted — where the sync twin correctly fsyncs the **parent**; and `sync-base-async`
+  called `.force` on the result of `open-async-file-channel` without checking whether
+  it was an `Error`. It now returns nil on success and the error on failure, matching
+  the sync `delete-store`.
 - **`delete-store` now honours `:sync?` — and `:tiered` actually deletes.**
   `-delete-store` was the one store method that ignored its `opts`: `:memory` and
   `:file` (JVM and Node) returned a plain value whatever `:sync?` said, so an async

--- a/src/konserve/node_filestore.cljs
+++ b/src/konserve/node_filestore.cljs
@@ -423,13 +423,19 @@
           (first (<! (iofs/aunlink test-path)))))))
 
 (defn- sync-base-async
-  "Helper Function to synchronize the base of the filestore"
+  "Helper Function to synchronize the base of the filestore.
+
+   `open-async-file-channel` yields `err | fc`, so the error has to be checked before
+   the channel is used — calling `.force` on an Error is a TypeError. This went
+   unnoticed because the only caller (`delete-store-async`) never actually reached it."
   [^string base]
   ;; https://www.reddit.com/r/node/comments/4r8k11/how_to_call_fsync_on_a_directory/
   (go
     (let [fc (<! (open-async-file-channel base {:flags "r"}))]
-      (or (<! (.force fc true))
-          (<! (.close fc))))))
+      (if (instance? js/Error fc)
+        fc
+        (or (<! (.force fc true))
+            (<! (.close fc)))))))
 
 (defn- store-exists?-async
   "Checks if path exists."
@@ -443,14 +449,37 @@
              (put! out yes?)))))
 
 (defn delete-store-async
-  "Permanently deletes the base of the store with all files."
+  "Permanently deletes the base of the store with all files.
+
+   Returns nil on success and the error on failure — the same contract as the sync
+   `delete-store` above.
+
+   Two bugs lived here, both hidden because `-delete-store :file` only ever called the
+   SYNC variant until the store multimethod was taught to honour `:sync?`:
+
+   1. `iofs/arm-r` yields **`[?err]`** — a vector (see its docstring) — not a bare err.
+      Binding it as `?err` made the success value `[nil]`, which is truthy, so this
+      ALWAYS took the error branch: it returned `[nil]` as if it were an error, and
+      `sync-base-async` was never called — the parent directory was never fsynced.
+      Sibling helpers here already destructure it correctly (`_lock-async`).
+   2. It fsynced `base` — the directory `arm-r` had just deleted — where the sync twin
+      correctly fsyncs the PARENT (that is the point: you fsync the parent after
+      removing a child). Opening the deleted dir failed, and `sync-base-async` then
+      called `.force` on the resulting Error.
+   3. Even on the intended path it piped `sync-base-async`'s value straight through
+      instead of normalising to nil like the sync twin does."
   [^string base]
-  (with-promise out
-    (take! (iofs/arm-r base)
-           (fn [?err]
-             (if (some? ?err)
-               (put! out ?err)
-               (take! (sync-base-async base) #(put! out %))))))) ;; TODO pipe bad
+  (let [parent-base (.getParent (io/file base))]
+    (with-promise out
+      (take! (iofs/arm-r base)
+             (fn [[?err]]
+               (if (some? ?err)
+                 (put! out ?err)
+                 (take! (sync-base-async parent-base)
+                        (fn [?sync-err]
+                          (if (some? ?sync-err)
+                            (put! out ?sync-err)
+                            (close! out))))))))))
 
 ;;==============================================================================
 


### PR DESCRIPTION
Follow-up to #152, which wired `-delete-store :file` to the async variant on the async path. That exposed dead code: **`delete-store-async` had never been called by anything**, and it was broken in three independent ways.

Caught by datahike's `node-cljs-test` in CI.

## 1. It always took the error branch

`iofs/arm-r` yields **`[?err]`** — a vector. Its own docstring says so:

```
@return {!Channel} yielding [?err]
```

konserve bound it as a bare `?err`:

```clojure
(take! (iofs/arm-r base)
       (fn [?err]                       ;; actually [?err]
         (if (some? ?err)               ;; [nil] is TRUTHY on success
           (put! out ?err)              ;; => returns [nil] as an "error"
           (take! (sync-base-async base) …))))   ;; never reached
```

So on success it returned `[nil]` *as if it were an error*, and the fsync the function exists to perform **never ran**. Sibling helpers in the same file already destructure this correctly (`_lock-async` uses `(fn [[?err lock]] …)`).

Downstream symptom: datahike's node tests asserting `(nil? deleted)` after `d/delete-database` got `[nil]`.

## 2. Fixing that exposed a crash in `sync-base-async`

Running for the first time, it died with `TypeError: inst.force is not a function`. Two causes:

- `delete-store-async` fsynced **`base`** — the directory `arm-r` had *just deleted* — where the sync twin correctly fsyncs the **parent**. (That's the point of the fsync: you sync the parent directory after removing a child.) Opening the deleted dir yields an `Error`.
- `open-async-file-channel` returns `err | fc`, and `sync-base-async` called `.force` on it without checking which.

## 3. It didn't normalise its success value

It piped `sync-base-async`'s value straight through instead of returning `nil` like the sync `delete-store` does.

## Why none of this was caught

Nothing called it. `-delete-store :file` only ever used the blocking variant until #152 taught the multimethod to honour `:sync?`. Dead code doesn't fail.

## Verification

- konserve **node cljs**: 44 tests, 304 assertions, **0 failures** (incl. `node-filestore-test`)
- konserve **JVM**: 76 tests, 1278 assertions, **0 failures**
- datahike **node cljs** (which caught this): back to 126 tests, 1028 assertions, **0 failures**