### PR TITLE
fix(tiered): :frontend-only must not delete the shared backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ All notable, user-visible changes to konserve are documented here.
   follow-up.)
 
 ### Fixed
+- **A `:frontend-only` tiered store no longer deletes the shared backend.** `-delete-store
+  :tiered` deleted the backend unconditionally. Under `:write-policy :frontend-only` the
+  store is a read-through **cache** over a backend that another peer OWNS and that this
+  one must never write — deleting is the most destructive write there is, so a cache peer
+  calling `delete-store` (or Datahike's `delete-database`) would take the authoritative
+  data with it. It now deletes only its own cache; under every other policy the store owns
+  its backend and both tiers go. This was latent while tiered delete silently did nothing
+  (see below) — fixing the missing await made it reachable.
 - **Node file backend: `delete-store-async` was broken in three ways, and never ran.**
   Wiring `-delete-store :file` to the async variant (above) exposed it. `iofs/arm-r`
   yields **`[?err]`** — a vector — but it was bound as a bare `?err`, so the success

--- a/src/konserve/store.cljc
+++ b/src/konserve/store.cljc
@@ -423,19 +423,21 @@
   (store-exists? backend-config opts))
 
 (defmethod -delete-store :tiered
-  [{:keys [backend-config frontend-config] :as config} opts]
+  [{:keys [backend-config frontend-config write-policy] :as config} opts]
   ;; Mirrors -release-store :tiered below. Both sub-deletes MUST be awaited: an async
-  ;; backend (:s3, …) hands back a channel, and the previous version called
-  ;; `(delete-store backend-config)` with no opts — i.e. the {:sync? false} default —
-  ;; and dropped the channel on the floor. Deleting a tiered store over S3 therefore
-  ;; removed nothing at all, silently, with any error swallowed into a channel nobody
-  ;; read.
+  ;; backend (:s3, …) hands back a channel, and dropping it deletes nothing at all.
   (async+sync
    (:sync? opts)
    *default-sync-translation*
    (go-try-
-    ;; Backend is the authoritative source.
-    (<?- (delete-store backend-config opts))
+    ;; :frontend-only means this store is a read-through CACHE over a backend that
+    ;; SOMEONE ELSE owns and that this peer must never write (see write-policies above).
+    ;; Deleting is the most destructive write there is, so a :frontend-only store deletes
+    ;; only its own cache — deleting the shared backend from a cache peer would take the
+    ;; authoritative data with it. Under every other policy this store owns its backend,
+    ;; so deleting the store deletes both tiers.
+    (when-not (= :frontend-only write-policy)
+      (<?- (delete-store backend-config opts)))
     ;; Only delete the frontend if it has persistence (a memory cache needs no delete).
     (when (and frontend-config (#{:file :indexeddb :lmdb :rocksdb} (:backend frontend-config)))
       (<?- (delete-store frontend-config opts)))

--- a/src/konserve/store.cljc
+++ b/src/konserve/store.cljc
@@ -424,22 +424,20 @@
 
 (defmethod -delete-store :tiered
   [{:keys [backend-config frontend-config write-policy] :as config} opts]
-  ;; Mirrors -release-store :tiered below. Both sub-deletes MUST be awaited: an async
-  ;; backend (:s3, …) hands back a channel, and dropping it deletes nothing at all.
+  ;; Config plumbing only — WHICH tiers a delete may touch is a tiered-store question, so it
+  ;; is answered by konserve.tiered (`owns-backend?`, `persistent-frontend-backends`), the
+  ;; same way -create-store/-connect-store delegate construction to `connect-tiered-store`.
+  ;;
+  ;; Both sub-deletes MUST be awaited: an async backend (:s3, …) hands back a channel, and
+  ;; dropping it deletes nothing at all.
   (async+sync
    (:sync? opts)
    *default-sync-translation*
    (go-try-
-    ;; :frontend-only means this store is a read-through CACHE over a backend that
-    ;; SOMEONE ELSE owns and that this peer must never write (see write-policies above).
-    ;; Deleting is the most destructive write there is, so a :frontend-only store deletes
-    ;; only its own cache — deleting the shared backend from a cache peer would take the
-    ;; authoritative data with it. Under every other policy this store owns its backend,
-    ;; so deleting the store deletes both tiers.
-    (when-not (= :frontend-only write-policy)
+    (when (tiered/owns-backend? write-policy)
       (<?- (delete-store backend-config opts)))
-    ;; Only delete the frontend if it has persistence (a memory cache needs no delete).
-    (when (and frontend-config (#{:file :indexeddb :lmdb :rocksdb} (:backend frontend-config)))
+    (when (and frontend-config
+               (tiered/persistent-frontend-backends (:backend frontend-config)))
       (<?- (delete-store frontend-config opts)))
     nil)))
 

--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -30,6 +30,23 @@
 ;; Read policies
 (def read-policies #{:frontend-first :frontend-only})
 
+(defn owns-backend?
+  "Does a tiered store with this write-policy OWN its backend, or is it merely a CACHE over
+   a backend that another peer owns?
+
+   `:frontend-only` is a read-through cache: the backend is read-only to this peer and must
+   never be mutated by it (see the write-policy note above). Deleting is the most destructive
+   mutation there is — a cache peer deleting the shared backend would take the authoritative
+   data down with it — so `delete-store` on such a store removes only its own cache. Under
+   every other policy the store owns both tiers and deleting it deletes both."
+  [write-policy]
+  (not= :frontend-only write-policy))
+
+(def persistent-frontend-backends
+  "Frontend backends with durable storage, i.e. something to delete. A `:memory` frontend is
+   ephemeral: it goes away with the process and has no store to remove."
+  #{:file :indexeddb :lmdb :rocksdb})
+
 ;; Default sync strategies
 (defn populate-missing-strategy
   "Sync strategy that only adds keys missing from frontend."

--- a/test/konserve/store_test.cljc
+++ b/test/konserve/store_test.cljc
@@ -276,6 +276,34 @@
            (is (false? (store/store-exists? (:frontend-config cfg) {:sync? true}))
                "async tiered delete must have deleted the FRONTEND by the time it delivers"))))))
 
+#?(:clj
+   (deftest delete-store-frontend-only-must-not-delete-the-backend
+     ;; :frontend-only means this store is a read-through CACHE over a backend that
+     ;; someone else OWNS and that this peer must never write. Deleting is the most
+     ;; destructive write there is: a cache peer deleting the shared backend would take
+     ;; the authoritative data with it — exactly the invariant the policy exists to
+     ;; enforce. So a :frontend-only delete removes only the cache.
+     (testing ":frontend-only — delete removes the cache, NOT the shared backend"
+       (let [id  #uuid "550e8400-e29b-41d4-a716-4466554400c0"
+             tmp (System/getProperty "java.io.tmpdir")
+             be  {:backend :file :id id :path (str tmp "/konserve-fo-backend-" (System/currentTimeMillis))}
+             fe  {:backend :file :id id :path (str tmp "/konserve-fo-frontend-" (System/currentTimeMillis))}
+             cfg {:backend :tiered :id id
+                  :write-policy :frontend-only
+                  :read-policy  :frontend-first
+                  :frontend-config fe
+                  :backend-config  be}]
+         (store/create-store cfg {:sync? true})
+         (is (true? (store/store-exists? be {:sync? true})) "backend exists to begin with")
+
+         (<!! (store/delete-store cfg))
+
+         (is (true? (store/store-exists? be {:sync? true}))
+             "a :frontend-only cache must NOT delete the shared, writer-owned backend")
+         (is (false? (store/store-exists? fe {:sync? true}))
+             "it must delete its own cache")
+         (store/delete-store be {:sync? true})))))
+
 ;; =============================================================================
 ;; ClojureScript IndexedDB Tests
 ;; =============================================================================


### PR DESCRIPTION
## The bug

`-delete-store :tiered` deleted the backend **unconditionally**:

```clojure
(<?- (delete-store backend-config opts))    ;; regardless of :write-policy
```

Under **`:write-policy :frontend-only`** the tiered store is a read-through **cache** over a backend that *another peer owns and that this one must never write*. That is the entire invariant the policy exists to enforce — and deleting is the most destructive write there is. So a cache peer calling `delete-store` (or Datahike's `delete-database`) takes the authoritative data down with it.

Concretely: a Datahike **Tier-4 read replica** — local LMDB over the writer's shared S3, `:frontend-only` — deleting a tenant would delete that tenant out of **the writer's S3**, from a node whose entire contract is that it never writes it.

## Why now

This was latent while tiered delete silently did nothing at all: it called `(delete-store backend-config)` with no opts and dropped the returned channel on the floor (#152). **Fixing that missing await is what made this reachable** — so it ships now rather than after someone loses a bucket.

## The fix

A `:frontend-only` store deletes only its own cache. Under every other policy the store owns its backend and both tiers go, as before.

## Test

New `delete-store-frontend-only-must-not-delete-the-backend`: asserts the backend **survives** a `:frontend-only` delete and the cache does not. **It fails without the fix:**

```
FAIL: a :frontend-only cache must NOT delete the shared, writer-owned backend
```

Full JVM suite: **77 tests, 1281 assertions, 0 failures.**

Found by an audit of a db-per-tenant SaaS template built on Datahike Tier-4 replicas, where per-tenant delete on a replica would have deleted the tenant from the writer's shared bucket.