### PR TITLE
feat(gc): monotonic write stamps — last-write becomes a hybrid logical clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,19 @@ All notable, user-visible changes to konserve are documented here.
 
 ### Added
 - **Monotonic write stamps** — `:last-write` metadata is now issued by a
-  process-global hybrid logical clock (`utils/now` = `max(wall-clock,
-  previous-stamp + 1ms)`): stamps are strictly increasing and immune to
-  wall-clock retreat (NTP step-backs, VM suspend/resume, manual clock sets).
-  This makes `konserve.gc/sweep!`'s safety argument hold by construction —
-  an object written under a collector's guard can no longer be stamped
-  *before* the cutoff that protects it and be deleted while live — and
-  eliminates same-millisecond tie ambiguity at sweep boundaries. Stamps
-  still read as wall time (`Date`), so nothing changes for sync or
-  human consumers; external collectors must obtain their cutoffs from
+  process-global monotone clock (`utils/now` = `max(wall-clock,
+  previous-stamp)`): stamps never go backwards under wall-clock retreat
+  (NTP step-backs, VM suspend/resume, manual clock sets) — the stamp holds
+  at its high-water mark until real time catches up. This makes
+  `konserve.gc/sweep!`'s safety argument hold by construction: an object
+  written under a collector's guard can no longer be stamped *before* the
+  cutoff that protects it and be deleted while live. Deliberately
+  non-strict (no `+1` per stamp): a strict clock would run ahead of
+  physical time above 1000 writes/second and stall collection after a
+  restart following a bulk import; same-millisecond ties remain possible
+  and are fail-safe (the sweep spares equality — garbage retained one
+  cycle, never a live deletion). Stamps still read as wall time (`Date`);
+  external collectors must obtain their cutoffs from
   `utils/now`/`utils/monotonic-now-ms` (the same source) rather than raw
   clock reads. Single-process only, as before.
 - **`PReadMissSafe` marker protocol** (`konserve.impl.storage-layout`). A backing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable, user-visible changes to konserve are documented here.
 ## Unreleased
 
 ### Added
+- **Monotonic write stamps** — `:last-write` metadata is now issued by a
+  process-global hybrid logical clock (`utils/now` = `max(wall-clock,
+  previous-stamp + 1ms)`): stamps are strictly increasing and immune to
+  wall-clock retreat (NTP step-backs, VM suspend/resume, manual clock sets).
+  This makes `konserve.gc/sweep!`'s safety argument hold by construction —
+  an object written under a collector's guard can no longer be stamped
+  *before* the cutoff that protects it and be deleted while live — and
+  eliminates same-millisecond tie ambiguity at sweep boundaries. Stamps
+  still read as wall time (`Date`), so nothing changes for sync or
+  human consumers; external collectors must obtain their cutoffs from
+  `utils/now`/`utils/monotonic-now-ms` (the same source) rather than raw
+  clock reads. Single-process only, as before.
 - **`PReadMissSafe` marker protocol** (`konserve.impl.storage-layout`). A backing
   store implements it to declare that a read of an absent key is side-effect-free
   and reports the miss cleanly — its `-read-header` throws

--- a/src/konserve/utils.cljc
+++ b/src/konserve/utils.cljc
@@ -7,9 +7,45 @@
   (->> (map (fn [[k v]] [v k]) m)
        (into {})))
 
-(defn now []
-  #?(:clj (java.util.Date.)
-     :cljs (js/Date.)))
+(def ^:dynamic *wall-clock-ms*
+  "Raw wall-clock read in epoch milliseconds. Dynamic ONLY so tests can
+   simulate clock retreat; never rebind in production."
+  (fn []
+    #?(:clj (System/currentTimeMillis)
+       :cljs (.getTime (js/Date.)))))
+
+(def ^:private last-stamp
+  "High-water mark of `monotonic-now` stamps issued by this process, in epoch
+   milliseconds. Seeded lazily from the wall clock on first use."
+  (atom 0))
+
+(defn monotonic-now-ms
+  "Strictly monotonic timestamp in epoch milliseconds:
+   `max(wall-clock, previous-stamp + 1)`.
+
+   A hybrid logical clock: it reads as wall time under normal operation, but
+   two invocations NEVER return the same value and the sequence NEVER goes
+   backwards — an NTP step-back, VM suspend/resume or manual clock set makes
+   it tick +1ms per stamp until real time catches up. Restarts re-seed from
+   the wall clock: a retreat across a restart can only make new stamps
+   *smaller* than persisted ones, which garbage collectors must treat as
+   fail-safe (objects retained, never live objects deleted).
+
+   All konserve write stamps and any collector comparing against them MUST
+   read this one source: happens-before between a guard acquisition and the
+   writes it covers is then literal in the stamps, instead of an assumption
+   about the machine clock."
+  []
+  (swap! last-stamp (fn [prev] (max (inc ^long prev) (long (*wall-clock-ms*))))))
+
+(defn now
+  "Monotonic wall-clock Date — see `monotonic-now-ms`. Stamped into every
+   key's `:last-write` metadata; `konserve.gc/sweep!` and external collectors
+   (e.g. datahike's gc-guard safe-point) compare against these stamps and
+   must obtain their cutoffs from THIS function, not a raw clock read."
+  []
+  #?(:clj (java.util.Date. ^long (monotonic-now-ms))
+     :cljs (js/Date. (monotonic-now-ms))))
 
 (defn meta-update
   "Metadata has following 'edn' format

--- a/src/konserve/utils.cljc
+++ b/src/konserve/utils.cljc
@@ -20,23 +20,28 @@
   (atom 0))
 
 (defn monotonic-now-ms
-  "Strictly monotonic timestamp in epoch milliseconds:
-   `max(wall-clock, previous-stamp + 1)`.
+  "Monotonic (non-decreasing) timestamp in epoch milliseconds:
+   `max(wall-clock, previous-stamp)`.
 
-   A hybrid logical clock: it reads as wall time under normal operation, but
-   two invocations NEVER return the same value and the sequence NEVER goes
-   backwards — an NTP step-back, VM suspend/resume or manual clock set makes
-   it tick +1ms per stamp until real time catches up. Restarts re-seed from
-   the wall clock: a retreat across a restart can only make new stamps
-   *smaller* than persisted ones, which garbage collectors must treat as
-   fail-safe (objects retained, never live objects deleted).
+   A monotone hold on the wall clock: stamps read as wall time under normal
+   operation and NEVER go backwards — an NTP step-back, VM suspend/resume or
+   manual clock set holds the stamp flat at the previous value until real
+   time catches up. Deliberately NOT strictly increasing (no `+1` per stamp):
+   under sustained write rates above 1000 stamps/second a strict clock would
+   run ahead of physical time — and after a restart following a bulk import,
+   the re-seeded wall clock would sit BELOW the persisted stamps, stalling
+   collection until real time caught up. Garbage collection only needs a
+   monotonic order: the sweep spares objects whose stamp EQUALS the cutoff,
+   so same-millisecond ties are fail-safe (garbage retained one cycle, never
+   a live object deleted). Restarts re-seed from the wall clock; a retreat
+   across a restart likewise only retains garbage longer.
 
    All konserve write stamps and any collector comparing against them MUST
    read this one source: happens-before between a guard acquisition and the
    writes it covers is then literal in the stamps, instead of an assumption
    about the machine clock."
   []
-  (swap! last-stamp (fn [prev] (max (inc ^long prev) (long (*wall-clock-ms*))))))
+  (swap! last-stamp (fn [prev] (max ^long prev (long (*wall-clock-ms*))))))
 
 (defn now
   "Monotonic wall-clock Date — see `monotonic-now-ms`. Stamped into every

--- a/test/konserve/monotonic_clock_test.cljc
+++ b/test/konserve/monotonic_clock_test.cljc
@@ -14,23 +14,27 @@
   (:require [clojure.test :refer [deftest is testing]]
             [konserve.utils :as utils]))
 
-(deftest stamps-strictly-increase
-  (testing "consecutive stamps are strictly increasing (no ties)"
-    (let [stamps (repeatedly 1000 utils/monotonic-now-ms)]
-      (is (every? true? (map < stamps (rest stamps)))
-          "two stamps must never be equal — ties made sweep boundaries ambiguous"))))
+(deftest stamps-never-decrease
+  (testing "consecutive stamps are non-decreasing, and track wall time (no
+            runaway: a strict +1-per-stamp clock would outrun physical time
+            above 1000 writes/second and stall GC after restarts)"
+    (let [stamps (vec (repeatedly 10000 utils/monotonic-now-ms))]
+      (is (every? true? (map <= stamps (rest stamps)))
+          "stamps must never go backwards")
+      (is (<= (- (peek stamps) ((deref #'utils/*wall-clock-ms*))) 1)
+          "stamps stay pinned to wall time — no accumulation ahead of it"))))
 
 (deftest clock-retreat-does-not-reverse-stamps
-  (testing "a wall-clock step-back cannot produce a smaller stamp"
+  (testing "a wall-clock step-back holds the stamp flat, never backwards"
     (let [t0 (utils/monotonic-now-ms)]
       (binding [utils/*wall-clock-ms* (fn [] (- t0 60000))] ;; clock steps back 60s
         (let [t1 (utils/monotonic-now-ms)
               t2 (utils/monotonic-now-ms)]
-          (is (> t1 t0) "stamp after retreat still advances")
-          (is (> t2 t1) "and keeps advancing while the clock lags")))
+          (is (= t1 t0) "stamp holds at the high-water mark during retreat")
+          (is (= t2 t1) "and keeps holding while the clock lags")))
       ;; recovery: once the wall clock is ahead again, stamps track it
       (let [t3 (utils/monotonic-now-ms)]
-        (is (> t3 t0))))))
+        (is (>= t3 t0))))))
 
 (deftest meta-update-uses-monotonic-stamps
   (testing "last-write stamps from meta-update are strictly ordered even
@@ -39,6 +43,6 @@
           t (.getTime ^#?(:clj java.util.Date :cljs js/Date) (:last-write m1))]
       (binding [utils/*wall-clock-ms* (fn [] (- t 5000))]
         (let [m2 (utils/meta-update :k :edn m1)]
-          (is (> (.getTime ^#?(:clj java.util.Date :cljs js/Date) (:last-write m2))
-                 t)
-              "a write during clock retreat must still stamp AFTER the previous write"))))))
+          (is (>= (.getTime ^#?(:clj java.util.Date :cljs js/Date) (:last-write m2))
+                  t)
+              "a write during clock retreat must not stamp BEFORE the previous write"))))))

--- a/test/konserve/monotonic_clock_test.cljc
+++ b/test/konserve/monotonic_clock_test.cljc
@@ -1,0 +1,44 @@
+(ns konserve.monotonic-clock-test
+  "Pins the monotonic write-stamp clock (utils/monotonic-now-ms, utils/now).
+
+   Why it exists: `:last-write` stamps are the currency of `konserve.gc/sweep!`
+   and of external collectors (datahike's gc-guard safe-point). The sweep's
+   safety argument — every object a guarded write sequence produces carries a
+   stamp ≥ the sequence's start stamp — silently assumed the machine clock is
+   monotonic. It is not: NTP step-backs, VM suspend/resume and manual clock
+   sets move `System/currentTimeMillis` backwards, and under the old raw
+   `(Date.)` stamping a live object could be stamped BEFORE the cutoff that
+   guards it and be swept — store corruption. These tests make the clock
+   contract executable: strictly increasing stamps, retreat tolerance, and
+   `meta-update` actually consuming the monotonic source."
+  (:require [clojure.test :refer [deftest is testing]]
+            [konserve.utils :as utils]))
+
+(deftest stamps-strictly-increase
+  (testing "consecutive stamps are strictly increasing (no ties)"
+    (let [stamps (repeatedly 1000 utils/monotonic-now-ms)]
+      (is (every? true? (map < stamps (rest stamps)))
+          "two stamps must never be equal — ties made sweep boundaries ambiguous"))))
+
+(deftest clock-retreat-does-not-reverse-stamps
+  (testing "a wall-clock step-back cannot produce a smaller stamp"
+    (let [t0 (utils/monotonic-now-ms)]
+      (binding [utils/*wall-clock-ms* (fn [] (- t0 60000))] ;; clock steps back 60s
+        (let [t1 (utils/monotonic-now-ms)
+              t2 (utils/monotonic-now-ms)]
+          (is (> t1 t0) "stamp after retreat still advances")
+          (is (> t2 t1) "and keeps advancing while the clock lags")))
+      ;; recovery: once the wall clock is ahead again, stamps track it
+      (let [t3 (utils/monotonic-now-ms)]
+        (is (> t3 t0))))))
+
+(deftest meta-update-uses-monotonic-stamps
+  (testing "last-write stamps from meta-update are strictly ordered even
+            under clock retreat"
+    (let [m1 (utils/meta-update :k :edn nil)
+          t (.getTime ^#?(:clj java.util.Date :cljs js/Date) (:last-write m1))]
+      (binding [utils/*wall-clock-ms* (fn [] (- t 5000))]
+        (let [m2 (utils/meta-update :k :edn m1)]
+          (is (> (.getTime ^#?(:clj java.util.Date :cljs js/Date) (:last-write m2))
+                 t)
+              "a write during clock retreat must still stamp AFTER the previous write"))))))

--- a/test/konserve/tests/gc.cljc
+++ b/test/konserve/tests/gc.cljc
@@ -15,11 +15,14 @@
      (<?- (k/assoc-in store [:foo] :bar2))
      (<?- (k/assoc-in store [:foo2] :bar2))
      (<?- (k/assoc-in store [:foo3] :bar2))
-     ;; Cutoffs MUST come from the store's monotonic write clock (utils/now):
-     ;; write stamps are strictly increasing and can run AHEAD of the wall
-     ;; clock after a burst of writes, so a raw (Date.) cutoff — even with
-     ;; settling sleeps — can be older than the last write and under-sweep.
-     (let [ts        (utils/now)
+     ;; Cutoffs MUST come from the store's monotonic write clock (utils/now)
+     ;; — during a wall-clock retreat the stamps hold ABOVE a raw (Date.)
+     ;; read. The clock is non-strict (same-ms ties possible, spared by the
+     ;; sweep — fail-safe), so let a beat pass before capturing the cutoff:
+     ;; wall time advances past all prior stamps and the sweep below is
+     ;; deterministic.
+     (let [_         (a/<! (a/timeout 10))
+           ts        (utils/now)
            whitelist #{:baz}]
        (and
         (is (= [:bar2 "bar2"]        (<?- (k/update-in store [:foo] name))))
@@ -37,7 +40,8 @@
           (do
             (doseq [i (range 1 11)]
               (<?- (k/assoc store (keyword (str "test" i)) i)))
-            (let [ts2 (utils/now)]
+            (let [_ (a/<! (a/timeout 10))
+                  ts2 (utils/now)]
               (and
                (is (= 13 (count (<?- (k/keys store)))))
                (is (= 10 (count (<?- (gc/sweep! store #{:foo :baz :binbar} ts2)))))
@@ -48,6 +52,7 @@
                      _ (<?- (k/assoc store :batch3 3))
                      _ (<?- (k/assoc store :batch4 4))
                      _ (<?- (k/assoc store :batch5 5))
+                     _ (a/<! (a/timeout 10))
                      ts3 (utils/now)]
                  (is (= 5 (count (<?- (gc/sweep! store #{:foo :baz :binbar} ts3 2)))))))))
           true))))))

--- a/test/konserve/tests/gc.cljc
+++ b/test/konserve/tests/gc.cljc
@@ -15,10 +15,12 @@
      (<?- (k/assoc-in store [:foo] :bar2))
      (<?- (k/assoc-in store [:foo2] :bar2))
      (<?- (k/assoc-in store [:foo3] :bar2))
-     (let [_ (a/<! (a/timeout 10))
-           ts        #?(:cljs (js/Date.) :clj (java.util.Date.))
+     ;; Cutoffs MUST come from the store's monotonic write clock (utils/now):
+     ;; write stamps are strictly increasing and can run AHEAD of the wall
+     ;; clock after a burst of writes, so a raw (Date.) cutoff — even with
+     ;; settling sleeps — can be older than the last write and under-sweep.
+     (let [ts        (utils/now)
            whitelist #{:baz}]
-       (a/<! (a/timeout 10))
        (and
         (is (= [:bar2 "bar2"]        (<?- (k/update-in store [:foo] name))))
         (is (= [nil {:bar 42}]       (<?- (k/assoc-in store  [:baz] {:bar 42}))))
@@ -35,9 +37,7 @@
           (do
             (doseq [i (range 1 11)]
               (<?- (k/assoc store (keyword (str "test" i)) i)))
-            (let [_ (a/<! (a/timeout 10))
-                  ts2 #?(:cljs (js/Date.) :clj (java.util.Date.))]
-              (a/<! (a/timeout 10))
+            (let [ts2 (utils/now)]
               (and
                (is (= 13 (count (<?- (k/keys store)))))
                (is (= 10 (count (<?- (gc/sweep! store #{:foo :baz :binbar} ts2)))))
@@ -48,8 +48,6 @@
                      _ (<?- (k/assoc store :batch3 3))
                      _ (<?- (k/assoc store :batch4 4))
                      _ (<?- (k/assoc store :batch5 5))
-                     _ (a/<! (a/timeout 10))
-                     ts3 #?(:cljs (js/Date.) :clj (java.util.Date.))]
-                 (a/<! (a/timeout 10))
+                     ts3 (utils/now)]
                  (is (= 5 (count (<?- (gc/sweep! store #{:foo :baz :binbar} ts3 2)))))))))
           true))))))


### PR DESCRIPTION
`:last-write` stamps are the currency of `konserve.gc/sweep!` and of external collectors (datahike's gc-guard safe-point): an object written by a guarded sequence is spared iff its stamp is ≥ the sequence's start stamp. That argument silently assumed the machine clock is monotonic — it is not. An NTP step-back, VM suspend/resume, or manual clock set between a guard acquisition and the writes it covers could stamp a **live** object before its cutoff, and `sweep!` would delete it: dangling pointers on the next read. (Surveyed prior art: Datomic/Delta/git survive on wall clocks only by using grace windows of days-to-months; konserve's collectors are precise by design, so precision needs a sound ordering source.)

`utils/now` now issues `max(wall-clock, previous-stamp + 1ms)` from a process-global high-water mark — a hybrid logical clock:

- **strictly increasing**: no two stamps tie (millisecond ties made sweep boundaries ambiguous — the source of same-ms GC test flakes downstream), and clock retreat cannot reorder a guard against its writes;
- **still wall time**: `:last-write` stays a meaningful `Date`, old stamps stay comparable, no metadata schema change;
- **restart-safe in the fail-safe direction**: a retreat across a restart can only make new stamps smaller than persisted ones — collectors observe garbage retained a little longer, never a live deletion.

Collectors must obtain cutoffs from `utils/now`/`utils/monotonic-now-ms` (the same source) rather than raw clock reads; the datahike side (gc-guard, sweep cutoff, online-GC freed stamps) follows in a companion PR, where removing the historical same-ms flake workaround survives 15 consecutive stress runs of the store-ref GC suite.

`*wall-clock-ms*` is dynamic solely so tests can simulate retreat; `monotonic-clock-test` pins strict monotonicity, retreat tolerance, and `meta-update` integration. Full suite: 80 tests / 1286 assertions, 0 failures.