### PR TITLE
Stream filestore binary reads on demand

### DIFF
--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -643,7 +643,12 @@
       (io/copy is tmp-file)))
 
   When called asynchronously (by default or w/ {:sync? false}), the locked-cb
-  must synchronously return a channel."
+  must synchronously return a channel.
+
+  File stores accept `:streaming? true` to expose a bounded view over the stored
+  payload instead of first materializing it. In that mode the callback must fully
+  consume the stream before it (or its returned channel) completes; the view is
+  valid only while Konserve owns the locked backing object."
   ([store key locked-cb]
    (bget store key locked-cb {:sync? false}))
   ([store key locked-cb opts]

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -15,11 +15,46 @@
    [superv.async :refer [go-try- <?-]]
    [replikativ.logging :as log])
   (:import
-   [java.io ByteArrayInputStream FileInputStream Closeable]
+   [java.io ByteArrayInputStream FileInputStream InputStream Closeable]
    [java.nio.channels FileChannel AsynchronousFileChannel CompletionHandler FileLock]
    [java.nio ByteBuffer]
    [java.nio.file Files StandardCopyOption FileSystem FileSystems Path Paths OpenOption LinkOption StandardOpenOption]
    [java.util Date UUID]))
+
+(defn- channel-input-stream
+  "Return a bounded, positional InputStream over a file channel.
+
+  Closing this view is intentionally a no-op: Konserve owns the channel and keeps
+  it locked until the bget callback (or its returned channel) completes. Positional
+  reads avoid mutating the channel's shared position."
+  ^InputStream [channel start end]
+  (let [position (atom (long start))
+        read-at (if (instance? FileChannel channel)
+                  (fn [^ByteBuffer buffer pos]
+                    (.read ^FileChannel channel buffer (long pos)))
+                  (fn [^ByteBuffer buffer pos]
+                    (.get (.read ^AsynchronousFileChannel channel buffer (long pos)))))]
+    (proxy [InputStream] []
+      (read
+        ([]
+         (let [one (byte-array 1)
+               n (.read ^InputStream this one 0 1)]
+           (if (neg? n) -1 (bit-and 0xff (aget one 0)))))
+        ([buffer]
+         (.read ^InputStream this buffer 0 (alength ^bytes buffer)))
+        ([buffer offset length]
+         (let [remaining (- (long end) @position)]
+           (if (or (not (pos? remaining)) (zero? length))
+             (if (zero? length) 0 -1)
+             (let [requested (int (min remaining (long length)))
+                   n (long (read-at (ByteBuffer/wrap ^bytes buffer
+                                                     (int offset) requested)
+                                    @position))]
+               (when (pos? n) (swap! position + n))
+               n)))))
+      (available []
+        (int (min Integer/MAX_VALUE (max 0 (- (long end) @position)))))
+      (close [] nil))))
 
 ;; =============================================================================
 ;; Path Helpers - Support for custom FileSystems (e.g., Jimfs for testing)
@@ -337,27 +372,28 @@
                                    (assoc msg :exception t))))))
       ch))
   (-read-binary [this meta-size locked-cb env]
-    (let [{:keys [msg header-size]} env
-          total-size (.size this)]
-      ;; TODO use FileInputStream to not load the file in memory
+    (let [{:keys [msg header-size streaming?]} env
+          total-size (.size this)
+          payload-start (+ header-size meta-size)]
       (go-try-
        (<?-
-        (locked-cb {:input-stream (ByteArrayInputStream.
-                                   (<?-
-                                    (let [ch (chan)
-                                          buffer (ByteBuffer/allocate (- total-size
-                                                                         meta-size
-                                                                         header-size))]
-                                      (.read this buffer (+ header-size meta-size)
-                                             total-size
-                                             (proxy [CompletionHandler] []
-                                               (completed [_res _]
-                                                 (put! ch (.array buffer)))
-                                               (failed [t _att]
-                                                 (put! ch (ex-info "Could not read key."
-                                                                   (assoc msg :exception t))))))
-                                      ch)))
-                    :size         total-size}))
+        (locked-cb
+         {:input-stream
+          (if streaming?
+            (channel-input-stream this payload-start total-size)
+            (ByteArrayInputStream.
+             (<?-
+              (let [ch (chan)
+                    buffer (ByteBuffer/allocate (- total-size payload-start))]
+                (.read this buffer payload-start total-size
+                       (proxy [CompletionHandler] []
+                         (completed [_res _]
+                           (put! ch (.array buffer)))
+                         (failed [t _att]
+                           (put! ch (ex-info "Could not read key."
+                                             (assoc msg :exception t))))))
+                ch))))
+          :size (- total-size payload-start)}))
        (catch Exception e
          (log/trace :konserve/read-binary-error {:error e})
          e)))))
@@ -417,16 +453,17 @@
       (.read this buffer (+ header-size meta-size))
       (.array buffer)))
   (-read-binary [this meta-size locked-cb env]
-    (let [{:keys [header-size]} env
-          total-size (.size this)]
-      ;; TODO use FileInputStream to not load the file in memory
-      (locked-cb {:input-stream (ByteArrayInputStream.
-                                 (let [buffer (ByteBuffer/allocate (- total-size
-                                                                      meta-size
-                                                                      header-size))]
-                                   (.read this buffer (+ header-size meta-size))
-                                   (.array buffer)))
-                  :size         total-size}))))
+    (let [{:keys [header-size streaming?]} env
+          total-size (.size this)
+          payload-start (+ header-size meta-size)]
+      (locked-cb {:input-stream (if streaming?
+                                  (channel-input-stream this payload-start total-size)
+                                  (ByteArrayInputStream.
+                                   (let [buffer (ByteBuffer/allocate
+                                                 (- total-size payload-start))]
+                                     (.read this buffer payload-start)
+                                     (.array buffer))))
+                  :size         (- total-size payload-start)}))))
 
 (extend-type FileLock
   PBackingLock

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -579,7 +579,7 @@
 
   PBinaryKeyValueStore
   (-bget [this key locked-cb opts]
-    (let [{:keys [sync?]} opts]
+    (let [{:keys [sync? streaming?]} opts]
       (io-operation this serializers read-handlers write-handlers
                     {:key-vec [key]
                      :operation :read-binary
@@ -589,6 +589,7 @@
                      :config    config
                      :version version
                      :sync? sync?
+                     :streaming? streaming?
                      :buffer-size buffer-size
                      :locked-cb locked-cb
                      :msg       {:type :read-binary-error

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -144,6 +144,37 @@
         (is (= (<!! (keys store))
                #{}))))))
 
+(deftest binary-file-reads-are-streaming
+  (let [folder "/tmp/konserve-streaming-read-test"
+        source (java.io.File/createTempFile "konserve-stream" ".bin")
+        size (+ (* 2 1024 1024) 17)]
+    (try
+      (with-open [out (java.io.BufferedOutputStream.
+                       (java.io.FileOutputStream. source))]
+        (let [block (byte-array (map unchecked-byte (range 251)))]
+          (loop [remaining size]
+            (when (pos? remaining)
+              (let [n (min remaining (alength block))]
+                (.write out block 0 n)
+                (recur (- remaining n)))))))
+      (delete-store folder)
+      (let [store (connect-fs-store folder :opts {:sync? true})]
+        (is (true? (bassoc store :large (java.io.FileInputStream. source)
+                           {:sync? true})))
+        (is (= size
+               (bget store :large
+                     (fn [{:keys [input-stream size]}]
+                       (is (not (instance? java.io.ByteArrayInputStream input-stream)))
+                       (is (= size (.available ^java.io.InputStream input-stream)))
+                       (loop [total 0]
+                         (let [n (.read ^java.io.InputStream input-stream
+                                        (byte-array 8192))]
+                           (if (neg? n) total (recur (+ total n))))))
+                     {:sync? true :streaming? true}))))
+      (finally
+        (.delete source)
+        (delete-store folder)))))
+
 #!============
 #! Cache tests
 


### PR DESCRIPTION
## Summary
- add opt-in streaming mode to JVM filestore binary reads
- expose a bounded positional InputStream without materializing the payload
- retain materialized default behavior for callback-lifetime compatibility
- report binary payload size rather than complete record size

## Verification
- 78 tests, 1285 assertions, 0 failures

This was extracted from #156 so GC clock work and binary streaming can land independently.