### PR TITLE
chore(deps): bump fress 0.4.312 → 0.4.317 (BIGDEC handlers)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,7 @@
         org.replikativ/logging {:mvn/version "0.1.3"}
         ;; cljs
         com.github.pkpkpk/cljs-node-io {:mvn/version "2.0.339"}
-        com.github.pkpkpk/fress {:mvn/version "0.4.312"}
+        com.github.pkpkpk/fress {:mvn/version "0.4.317"}
         org.clojars.mmb90/cljs-cache {:mvn/version "0.1.4"}}
  :aliases {:dev {:extra-deps {criterium/criterium {:mvn/version "0.4.6"}
                               metasoarous/oz {:mvn/version "2.0.0-alpha5"}


### PR DESCRIPTION
Bumps `com.github.pkpkpk/fress` **0.4.312 → 0.4.317**.

fress 0.4.317 adds the default, dependency-free Fressian **BIGDEC (0xC7)** read/write handlers, plus `fress.impl.bigdec/bigdec?` and the `Bigdec` type (unscaled `js/BigInt` + scale). Serialization is where these belong, so konserve is the right layer to carry them — a cljs `:db.type/bigdec` value now round-trips through konserve's fressian path.

**Why:** datahike consumes fress transitively via konserve; this bump lets datahike recognise + store browser decimals (`:db.type/bigdec`) without declaring a direct fress dep. First domino in fress 0.4.317 → konserve → datahike → kontor.

**Safety:** additive over 0.4.312 (bigint handling unchanged). clj suite green: **81 tests / 1291 assertions, 0 failures, 0 errors**.