### PR TITLE
The GC safe point belongs to the store (konserve.gc-guard + store identity)

### DIFF
--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -64,6 +64,45 @@
                                                (range 10)))
                                         true))
                       opts))
+         ;; EVERY DOCUMENTED INPUT SHAPE, not just the byte array. `bassoc`
+         ;; promises an InputStream, a File, a String and a byte array, and
+         ;; before this only the filestore handled any but the last — every
+         ;; other backing mishandled four of them, undetected, because this
+         ;; suite only ever passed bytes. konserve-s3 stashes the blob and
+         ;; later calls `(.write baos value)`, which needs an array.
+         #?(:clj
+            (let [expected (map byte (range 10))]
+              (<!! (k/bassoc store :bin-stream
+                             (java.io.ByteArrayInputStream. (byte-array (range 10))) opts))
+              (<!! (k/bget store :bin-stream
+                           (fn [{:keys [input-stream]}]
+                             (go (is (= expected (map byte (slurp input-stream)))
+                                     "bassoc must accept an InputStream")
+                                 true))
+                           opts))
+              (let [f (java.io.File/createTempFile "konserve-compliance" ".bin")]
+                (try
+                  (with-open [o (java.io.FileOutputStream. f)]
+                    (.write o (byte-array (range 10))))
+                  (<!! (k/bassoc store :bin-file f opts))
+                  (<!! (k/bget store :bin-file
+                               (fn [{:keys [input-stream]}]
+                                 (go (is (= expected (map byte (slurp input-stream)))
+                                         "bassoc must accept a File")
+                                     true))
+                               opts))
+                  (finally (.delete f))))
+              (<!! (k/bassoc store :bin-string "hello konserve" opts))
+              (<!! (k/bget store :bin-string
+                           (fn [{:keys [input-stream]}]
+                             (go (is (= "hello konserve" (slurp input-stream))
+                                     "bassoc must accept a String")
+                                 true))
+                           opts))
+              ;; cleaned up so the key-listing assertion below still describes
+              ;; the same store it always did
+              (doseq [kk [:bin-stream :bin-file :bin-string]]
+                (<!! (k/dissoc store kk opts)))))
          (let  [list-keys (<!! (k/keys store opts))]
            (are [x y] (= x y)
              #{{:key :baz

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -468,7 +468,6 @@
                                      (.array buffer))))
                   :size         (- total-size payload-start)}))))
 
-
 ;; The filestore drains `-write-binary` input through a fixed buffer, so it takes
 ;; the caller's blob untouched rather than a materialized byte array. That is what
 ;; lets it store a value larger than the heap — and it has to, because Lucene's

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -6,7 +6,8 @@
    [konserve.impl.defaults :refer [update-blob connect-default-store key->store-key store-key->uuid-key normalize-store-config]]
    [konserve.impl.storage-layout :refer [PBackingStore
                                          PBackingBlob -close
-                                         PBackingLock header-size]]
+                                         PBackingLock header-size
+                                         PStreamingBinaryWrite]]
    [konserve.nio-helpers :refer [blob->channel]]
    [konserve.protocols :as kp]
    [konserve.utils :refer [async+sync *default-sync-translation*]]
@@ -466,6 +467,17 @@
                                      (.read this buffer payload-start)
                                      (.array buffer))))
                   :size         (- total-size payload-start)}))))
+
+
+;; The filestore drains `-write-binary` input through a fixed buffer, so it takes
+;; the caller's blob untouched rather than a materialized byte array. That is what
+;; lets it store a value larger than the heap — and it has to, because Lucene's
+;; default merge policy produces segments up to 5 GB while a byte array stops at 2.
+(extend-protocol PStreamingBinaryWrite
+  AsynchronousFileChannel
+  (-streaming-binary-write? [_] true)
+  FileChannel
+  (-streaming-binary-write? [_] true))
 
 (extend-type FileLock
   PBackingLock

--- a/src/konserve/gc.cljc
+++ b/src/konserve/gc.cljc
@@ -1,9 +1,49 @@
 (ns konserve.gc
   (:require [clojure.core.async :as async]
             [konserve.core :as k]
-            [konserve.utils :as utils]
+            #?(:clj [konserve.utils :as utils :refer [async+sync *default-sync-translation*]]
+               :cljs [konserve.utils :as utils :refer [*default-sync-translation*]
+                      :refer-macros [async+sync]])
             [superv.async :refer [go-try- <?- reduce<?-]])
   #?(:clj (:import [java.util Date])))
+
+(def sweep-sync-translation
+  "`*default-sync-translation*` plus `reduce<?-`, which it does not name.
+
+   The default map rewrites `go-try-` to `try` and `<?-` to `do`, so in sync
+   mode the batch fn returns a VALUE — and `reduce<?-` would then try to take
+   from something that is not a channel. `reduce` is what it degrades to."
+  (merge *default-sync-translation* '{reduce<?- reduce}))
+
+(defn- delete-batch!
+  "Delete one batch of keys, concurrently where the platform allows it.
+
+   `:ignore-existence?` because GC never uses `dissoc`'s `existed?` return, and
+   it lets miss-safe backings skip the per-key HEAD probe — a delete here is
+   idempotent by construction.
+
+   The concurrency is worth keeping rather than simplifying away: the stores
+   that most need it are exactly the ones that take this path. A backing with
+   multi-key support batches into one round trip above; everything else — the
+   FILESTORE included, which is what scriptum and proximum run on — deletes key
+   by key, and doing that serially against a remote store costs one round trip
+   per key.
+
+   Async mode merges the per-key channels. Sync mode has no channels to merge,
+   so the JVM uses `pmap` for the same effect; ClojureScript runs serially,
+   which costs it nothing it could have had — sync mode there is single-threaded
+   by definition."
+  [store batch sync?]
+  (if sync?
+    #?(:clj (dorun (pmap (fn [{:keys [key]}]
+                           (k/dissoc store key {:sync? true :ignore-existence? true}))
+                         batch))
+       :cljs (doseq [{:keys [key]} batch]
+               (k/dissoc store key {:sync? true :ignore-existence? true})))
+    (let [pending (mapv (fn [{:keys [key]}]
+                          (k/dissoc store key {:ignore-existence? true}))
+                        batch)]
+      (async/into [] (async/merge pending)))))
 
 (defn sweep!
   "Delete every key that is neither in `whitelist` nor written at/after `cutoff`.
@@ -34,35 +74,32 @@
    (sweep! store whitelist cutoff 1000 {}))
   ([store whitelist cutoff batch-size]
    (sweep! store whitelist cutoff batch-size {}))
-  ([store whitelist cutoff batch-size _opts]
-   (go-try-
-    (let [ts cutoff
-          to-delete (->> (<?- (k/keys store))
-                         (filter (fn [{:keys [key last-write] :as meta}]
-                                   (not
-                                    (or (contains? whitelist key)
-                                        (<= (.getTime ^Date ts)
-                                            (.getTime (if last-write
-                                                        ^Date last-write
-                                                        ;; old name
-                                                        ^Date (:konserve.core/timestamp meta))))))))
-                         (partition-all batch-size))]
-      (<?-
-       (reduce<?-
-        (fn [deleted-files batch]
-          (go-try-
-           (if (utils/multi-key-capable? store)
-             ;; Use multi-dissoc for batch deletion if supported
-             (let [keys-to-delete (mapv :key batch)]
-               (<?- (k/multi-dissoc store keys-to-delete))
-               (into deleted-files keys-to-delete))
-             ;; Fallback to single operations for stores without multi-key support.
-             ;; GC does not use dissoc's existed? return, so :ignore-existence? lets
-             ;; miss-safe backings skip the per-key HEAD probe (idempotent delete).
-             (let [pending-deletes (mapv (fn [{:keys [key]}]
-                                           (k/dissoc store key {:ignore-existence? true}))
-                                         batch)]
-               (<?- (async/into [] (async/merge pending-deletes)))
-               (into deleted-files (map :key batch))))))
-        #{}
-        to-delete))))))
+  ([store whitelist cutoff batch-size opts]
+   (async+sync
+    (:sync? opts)
+    sweep-sync-translation
+    (go-try-
+     (let [sync? (:sync? opts)
+           to-delete (->> (<?- (k/keys store (select-keys opts [:sync?])))
+                          (filter (fn [{:keys [key last-write] :as meta}]
+                                    (not
+                                     (or (contains? whitelist key)
+                                         (<= (.getTime ^Date cutoff)
+                                             (.getTime (if last-write
+                                                         ^Date last-write
+                                                         ;; old name
+                                                         ^Date (:konserve.core/timestamp meta))))))))
+                          (partition-all batch-size))]
+       (<?-
+        (reduce<?-
+         (fn [deleted-files batch]
+           (go-try-
+            (if (utils/multi-key-capable? store)
+              ;; one round trip for the whole batch where the backing allows it
+              (let [keys-to-delete (mapv :key batch)]
+                (<?- (k/multi-dissoc store keys-to-delete (select-keys opts [:sync?])))
+                (into deleted-files keys-to-delete))
+              (do (<?- (delete-batch! store batch sync?))
+                  (into deleted-files (map :key batch))))))
+         #{}
+         to-delete)))))))

--- a/src/konserve/gc.cljc
+++ b/src/konserve/gc.cljc
@@ -2,6 +2,7 @@
   (:require [clojure.core.async :as async]
             [konserve.core :as k]
             [konserve.gc-guard :as guard]
+            [konserve.protocols :as p]
             [konserve.utils :as utils]
             [superv.async :refer [go-try- <?- reduce<?-]])
   #?(:clj (:import [java.util Date])))
@@ -10,22 +11,27 @@
   "Delete every key that is neither in `whitelist` nor written at/after the
    cutoff. `ts` is the instant the collection started.
 
-   PASS `:store-id` whenever writers on this store take `konserve.gc-guard`.
-   The sweep then derives its own cutoff as `min(ts, safe-point)` instead of
-   trusting `ts`, which is what keeps it from deleting objects that a
-   values-then-pointer sequence has already written but not yet made reachable
-   (see `konserve.gc-guard`). Getting that combination right is fiddly — the
-   guard must be read AFTER `ts` — so it belongs here rather than in every
-   caller. Without `:store-id` the behaviour is unchanged and `ts` is used
-   verbatim, which is only safe if the caller computed it via
-   `konserve.gc-guard/cutoff` itself."
+   The cutoff is `min(ts, safe-point)`, not `ts`, so a values-then-pointer
+   sequence that has written its objects but not yet made them reachable is
+   spared (see `konserve.gc-guard`). Getting that combination right is fiddly —
+   the guard must be read AFTER `ts`, or a sequence opening in between is
+   missed — so it lives here rather than in every caller.
+
+   The store names itself: `store-id` comes from `PStoreIdentity`, which every
+   store connected through `konserve.store` carries. Pass `:store-id`
+   explicitly only for a store built through a backend constructor directly
+   (`connect-fs-store` and friends), which never took an id. When neither is
+   available the guard cannot be consulted and `ts` is used verbatim — safe
+   only if no writer on this store takes the guard, or the caller computed `ts`
+   via `konserve.gc-guard/cutoff` itself."
   ([store whitelist ts]
    (sweep! store whitelist ts 1000 {}))
   ([store whitelist ts batch-size]
    (sweep! store whitelist ts batch-size {}))
   ([store whitelist ts batch-size {:keys [store-id]}]
    (go-try-
-    (let [ts (if store-id (guard/cutoff store-id ts) ts)
+    (let [store-id (or store-id (p/-store-id store))
+          ts (if store-id (guard/cutoff store-id ts) ts)
           to-delete (->> (<?- (k/keys store))
                          (filter (fn [{:keys [key last-write] :as meta}]
                                    (not

--- a/src/konserve/gc.cljc
+++ b/src/konserve/gc.cljc
@@ -1,16 +1,32 @@
 (ns konserve.gc
   (:require [clojure.core.async :as async]
             [konserve.core :as k]
+            [konserve.gc-guard :as guard]
             [konserve.utils :as utils]
             [superv.async :refer [go-try- <?- reduce<?-]])
   #?(:clj (:import [java.util Date])))
 
 (defn sweep!
+  "Delete every key that is neither in `whitelist` nor written at/after the
+   cutoff. `ts` is the instant the collection started.
+
+   PASS `:store-id` whenever writers on this store take `konserve.gc-guard`.
+   The sweep then derives its own cutoff as `min(ts, safe-point)` instead of
+   trusting `ts`, which is what keeps it from deleting objects that a
+   values-then-pointer sequence has already written but not yet made reachable
+   (see `konserve.gc-guard`). Getting that combination right is fiddly — the
+   guard must be read AFTER `ts` — so it belongs here rather than in every
+   caller. Without `:store-id` the behaviour is unchanged and `ts` is used
+   verbatim, which is only safe if the caller computed it via
+   `konserve.gc-guard/cutoff` itself."
   ([store whitelist ts]
-   (sweep! store whitelist ts 1000))
+   (sweep! store whitelist ts 1000 {}))
   ([store whitelist ts batch-size]
+   (sweep! store whitelist ts batch-size {}))
+  ([store whitelist ts batch-size {:keys [store-id]}]
    (go-try-
-    (let [to-delete (->> (<?- (k/keys store))
+    (let [ts (if store-id (guard/cutoff store-id ts) ts)
+          to-delete (->> (<?- (k/keys store))
                          (filter (fn [{:keys [key last-write] :as meta}]
                                    (not
                                     (or (contains? whitelist key)

--- a/src/konserve/gc.cljc
+++ b/src/konserve/gc.cljc
@@ -30,7 +30,7 @@
    (sweep! store whitelist ts batch-size {}))
   ([store whitelist ts batch-size {:keys [store-id]}]
    (go-try-
-    (let [store-id (or store-id (p/-store-id store))
+    (let [store-id (or store-id (p/store-id store))
           ts (if store-id (guard/cutoff store-id ts) ts)
           to-delete (->> (<?- (k/keys store))
                          (filter (fn [{:keys [key last-write] :as meta}]

--- a/src/konserve/gc.cljc
+++ b/src/konserve/gc.cljc
@@ -1,37 +1,42 @@
 (ns konserve.gc
   (:require [clojure.core.async :as async]
             [konserve.core :as k]
-            [konserve.gc-guard :as guard]
-            [konserve.protocols :as p]
             [konserve.utils :as utils]
             [superv.async :refer [go-try- <?- reduce<?-]])
   #?(:clj (:import [java.util Date])))
 
 (defn sweep!
-  "Delete every key that is neither in `whitelist` nor written at/after the
-   cutoff. `ts` is the instant the collection started.
+  "Delete every key that is neither in `whitelist` nor written at/after `cutoff`.
 
-   The cutoff is `min(ts, safe-point)`, not `ts`, so a values-then-pointer
-   sequence that has written its objects but not yet made them reachable is
-   spared (see `konserve.gc-guard`). Getting that combination right is fiddly —
-   the guard must be read AFTER `ts`, or a sequence opening in between is
-   missed — so it lives here rather than in every caller.
+   PRECONDITION, and the whole reason `konserve.gc-guard` exists: on a store
+   with guarded writers, `cutoff` must come from `konserve.gc-guard/cutoff`,
+   and it must be read BEFORE the caller computes `whitelist`:
 
-   The store names itself: `store-id` comes from `PStoreIdentity`, which every
-   store connected through `konserve.store` carries. Pass `:store-id`
-   explicitly only for a store built through a backend constructor directly
-   (`connect-fs-store` and friends), which never took an id. When neither is
-   available the guard cannot be consulted and `ts` is used verbatim — safe
-   only if no writer on this store takes the guard, or the caller computed `ts`
-   via `konserve.gc-guard/cutoff` itself."
-  ([store whitelist ts]
-   (sweep! store whitelist ts 1000 {}))
-  ([store whitelist ts batch-size]
-   (sweep! store whitelist ts batch-size {}))
-  ([store whitelist ts batch-size {:keys [store-id]}]
+       (let [cutoff    (guard/cutoff store-id (utils/now))   ; 1. guard
+             whitelist (mark-reachable! store)]              ; 2. mark
+         (sweep! store whitelist cutoff))                    ; 3. sweep
+
+   That order is not a style preference. A values-then-pointer sequence that is
+   open at step 1 pins the cutoff at or before its own writes, so they survive
+   however step 2 turns out. Mark first and the same sequence can land its
+   pointer in between: step 2 walked roots that did not name its values yet, and
+   by step 3 the guard is closed again, so nothing spares them — they are older
+   than the cutoff and unreachable from the whitelist, and the sweep deletes
+   objects a live pointer names.
+
+   `sweep!` DELIBERATELY DOES NOT CONSULT THE GUARD ITSELF. It cannot: it
+   receives `whitelist` already computed, so any reading it does is necessarily
+   after the caller's mark — the broken order above, wearing the appearance of
+   safety. Only the caller is in a position to interleave the two correctly.
+
+   Passing a raw `(utils/now)` is correct only on a store no writer guards."
+  ([store whitelist cutoff]
+   (sweep! store whitelist cutoff 1000 {}))
+  ([store whitelist cutoff batch-size]
+   (sweep! store whitelist cutoff batch-size {}))
+  ([store whitelist cutoff batch-size _opts]
    (go-try-
-    (let [store-id (or store-id (p/store-id store))
-          ts (if store-id (guard/cutoff store-id ts) ts)
+    (let [ts cutoff
           to-delete (->> (<?- (k/keys store))
                          (filter (fn [{:keys [key last-write] :as meta}]
                                    (not

--- a/src/konserve/gc.cljc
+++ b/src/konserve/gc.cljc
@@ -7,14 +7,6 @@
             [superv.async :refer [go-try- <?- reduce<?-]])
   #?(:clj (:import [java.util Date])))
 
-(def sweep-sync-translation
-  "`*default-sync-translation*` plus `reduce<?-`, which it does not name.
-
-   The default map rewrites `go-try-` to `try` and `<?-` to `do`, so in sync
-   mode the batch fn returns a VALUE — and `reduce<?-` would then try to take
-   from something that is not a channel. `reduce` is what it degrades to."
-  (merge *default-sync-translation* '{reduce<?- reduce}))
-
 (defn- delete-batch!
   "Delete one batch of keys, concurrently where the platform allows it.
 
@@ -32,7 +24,18 @@
    Async mode merges the per-key channels. Sync mode has no channels to merge,
    so the JVM uses `pmap` for the same effect; ClojureScript runs serially,
    which costs it nothing it could have had — sync mode there is single-threaded
-   by definition."
+   by definition.
+
+   `pmap`'s thread cost here is bounded at `cpus + 2`, measured at 11 on an
+   8-core machine, drawn from the cached pool `future` uses. THAT BOUND DEPENDS
+   ON `batch` NOT BEING CHUNKED: `pmap` realizes a chunk at a time, so a chunked
+   seq jumps to 32 + lookahead (35, measured, for a `range`). `sweep!` passes
+   `partition-all` output, which is not chunked — keep it that way, or bound the
+   parallelism explicitly.
+
+   A bounded virtual-thread executor would be the better instrument and a
+   simpler one, but Loom is new enough that konserve should not require it of
+   its users yet."
   [store batch sync?]
   (if sync?
     #?(:clj (dorun (pmap (fn [{:keys [key]}]
@@ -77,7 +80,7 @@
   ([store whitelist cutoff batch-size opts]
    (async+sync
     (:sync? opts)
-    sweep-sync-translation
+    *default-sync-translation*
     (go-try-
      (let [sync? (:sync? opts)
            to-delete (->> (<?- (k/keys store (select-keys opts [:sync?])))

--- a/src/konserve/gc_guard.cljc
+++ b/src/konserve/gc_guard.cljc
@@ -39,9 +39,15 @@
 
    SCOPE: this is IN-PROCESS state, and it matches konserve's concurrency
    contract — a store has a single writer per runtime, or callers coordinate
-   above konserve. Writers in another process are outside that contract already,
-   for reasons more basic than GC (they lose each other's writes). Readers are
-   unconstrained."
+   above konserve. A writer in another process is not protected: it takes its
+   own guard, in its own heap, and a sweep here cannot see it. Multi-process
+   GC therefore needs coordination this does not provide.
+
+   That is narrower than saying cross-process writers are broken outright.
+   konserve's `:lock-blob?` (default true) is a per-blob file lock, so
+   individual writes do not corrupt one another. What is unguarded is the
+   SEQUENCE — the window between values and pointer — which no per-blob lock
+   spans. Readers are unconstrained."
   (:require [clojure.core.async :as async]
             [clojure.core.async.impl.protocols :as async-protocols]
             [konserve.utils :as ku])
@@ -60,10 +66,27 @@
 
 (defn- ms [d] #?(:clj (.getTime ^Date d) :cljs (.getTime d)))
 
-;; store-id -> {token start-instant}. Keyed by an identifier of the PHYSICAL
-;; store rather than by the store object: separate connections to one store are
-;; different store instances, and a collection running on one must see a
-;; sequence in flight on another.
+;; store-id -> {token start-instant}. Keyed by the store's id rather than by the
+;; store object, because separate connections to one store are different objects
+;; and a collection running on one must see a sequence in flight on another.
+;;
+;; THAT ID IS LOGICAL, NOT PHYSICAL — konserve's `:id` identifies a store across
+;; machines and backends (`konserve.store/validate-store-config`), so a replica
+;; elsewhere carries the same one. The guard's requirement is about the bytes a
+;; sweep is about to delete, and only one direction of the mismatch is unsafe:
+;;
+;;   same bytes, same id       the intended case
+;;   two stores, one id        each sweep held back by the other's writers:
+;;                             conservative, nothing lost, though a busy replica
+;;                             can hold a collection off
+;;   same bytes, two ids       the sweep cannot see the other writer's in-flight
+;;                             objects and DELETES LIVE DATA
+;;
+;; So the id may be coarser than the physical store, never finer — which a
+;; logical id is. Nothing enforces that two connections to one store agree on
+;; it, and nothing can from here; `validate-store-config` only checks that `:id`
+;; is a UUID. Taking it off the store (`konserve.protocols/store-id`) rather
+;; than passing it alongside is what keeps callers from disagreeing.
 (defonce ^:private in-flight (atom {}))
 
 ;; Tokens are counter values, not fresh objects: a token is a MAP KEY, and a bare
@@ -107,7 +130,14 @@
    oldest one: everything it writes lands at or after that instant, so sparing
    from there spares exactly its objects and nothing else.
 
-   Prefer `cutoff`, which handles the ordering requirement described there."
+   Prefer `cutoff`, which handles the ordering requirement described there.
+
+   NOT A PURE READ: the idle branch calls `konserve.utils/now`, which advances
+   the process-global high-water mark. That is deliberate — the cutoff has to
+   come from the same clock that stamps `:last-write`, or the comparison the
+   sweep makes is meaningless — and it is harmless, since `now` is
+   `max(wall, previous)` and so cannot push the stamp ahead of wall time. Worth
+   knowing before polling this from a monitoring path."
   [store-id]
   (let [starts (vals (get @in-flight store-id))]
     (if (seq starts)

--- a/src/konserve/gc_guard.cljc
+++ b/src/konserve/gc_guard.cljc
@@ -42,7 +42,9 @@
    above konserve. Writers in another process are outside that contract already,
    for reasons more basic than GC (they lose each other's writes). Readers are
    unconstrained."
-  (:require [konserve.utils :as ku])
+  (:require [clojure.core.async :as async]
+            [clojure.core.async.impl.protocols :as async-protocols]
+            [konserve.utils :as ku])
   #?(:clj (:import [java.util Date]))
   ;; Self-require the macro namespace so `with-unreferenced-writes` is available
   ;; to ClojureScript consumers that `:refer` it.
@@ -112,6 +114,43 @@
       (reduce (fn [a b] (if (< (ms a) (ms b)) a b)) starts)
       (now))))
 
+(defn stale
+  "Sequences on `store-id` open longer than `max-age-ms`, as `{token start}`.
+
+  A LEAKED ENTRY IS SILENT AND TOTAL: an open sequence holds the safe point at
+  its start instant, so one that never closes stops collection on this store
+  for the lifetime of the process, and the store grows without bound with
+  nothing logged. Nothing here expires entries automatically — a long-running
+  sequence is legitimate and guessing at a timeout would break it — so this is
+  the introspection a caller needs to notice, and `sweep-stale!` is the
+  deliberate way to act on it.
+
+  Every escape from a values-then-pointer sequence should already release its
+  token: `with-unreferenced-writes` closes on the throw path and, for an async
+  body, when its channel delivers. What this catches is the rest — a body whose
+  channel never delivers, a hand-rolled `writing!` whose `done!` is missed, or
+  a `done!` given the wrong store-id."
+  [store-id max-age-ms]
+  (let [cut (- (ms (now)) max-age-ms)]
+    (into {} (filter (fn [[_ start]] (< (ms start) cut))) (get @in-flight store-id))))
+
+(defn sweep-stale!
+  "Force-close sequences on `store-id` older than `max-age-ms`. Returns what was
+  closed, as `stale` reports it.
+
+  A BLUNT INSTRUMENT, and the last resort: closing a sequence that is genuinely
+  still writing reopens exactly the blind spot the guard exists to cover. Reach
+  for it when `stale` shows an entry that cannot still be live — a crashed
+  writer's, or one whose age exceeds anything the application can produce —
+  and prefer fixing the missing `done!`."
+  [store-id max-age-ms]
+  (let [leaked (stale store-id max-age-ms)]
+    (when (seq leaked)
+      (swap! in-flight (fn [m]
+                         (let [m' (apply update m store-id dissoc (keys leaked))]
+                           (if (empty? (get m' store-id)) (dissoc m' store-id) m')))))
+    leaked))
+
 (defn cutoff
   "The sweep cutoff for `store-id`, given the collection's own `started-at`.
 
@@ -125,15 +164,48 @@
   (let [sp (safe-point store-id)]
     (if (< (ms sp) (ms started-at)) sp started-at)))
 
+(defn close-when-delivered
+  "Close the sequence when `ch` delivers, and hand back a channel carrying the
+   same value. Implementation detail of `with-unreferenced-writes`.
+
+   Public because the macro expands into it, and because a caller building its
+   own async sequence needs the same thing."
+  [store-id token ch]
+  (let [out (async/chan 1)]
+    (async/take! ch (fn [v]
+                      (done! store-id token)
+                      (when (some? v) (async/put! out v))
+                      (async/close! out)))
+    out))
+
 #?(:clj
    (defmacro with-unreferenced-writes
      "Run `body` as one unreferenced-write sequence against `store-id`: no
       concurrent collection in this process will sweep what it writes, until it
       completes. Use it whenever you write values into the store that only a
       LATER write (a transaction, a branch head, an index manifest) makes
-      reachable."
+      reachable.
+
+      WORKS FOR ASYNC BODIES TOO, which a plain `try`/`finally` does not — and
+      that mattered, because konserve's default is `{:sync? false}`, so the most
+      idiomatic body here returns a CHANNEL. `finally` then fires when the go
+      block is CONSTRUCTED, releasing the guard before a single write has
+      happened and making the whole form a no-op. So: if `body` yields a
+      channel, this returns a channel that delivers the same value and closes
+      the sequence when it does; otherwise it closes immediately, as before.
+
+      One consequence worth knowing: an async body's guard is released when its
+      channel DELIVERS. A body that returns a channel nobody ever puts to holds
+      the sequence open forever, and an open sequence stops collection — see
+      `stale` and `sweep-stale!`."
      [store-id & body]
      `(let [sid# ~store-id
             t#   (writing! sid#)]
-        (try ~@body
-             (finally (done! sid# t#))))))
+        (try
+          (let [res# (do ~@body)]
+            (if (satisfies? async-protocols/ReadPort res#)
+              (close-when-delivered sid# t# res#)
+              (do (done! sid# t#) res#)))
+          (catch ~(if (:ns &env) :default 'Throwable) e#
+            (done! sid# t#)
+            (throw e#))))))

--- a/src/konserve/gc_guard.cljc
+++ b/src/konserve/gc_guard.cljc
@@ -29,9 +29,10 @@
        (try (write-values!) (write-pointer!)
             (finally (done! store-id t))))
 
-   or `with-unreferenced-writes`, which does the same. `konserve.gc/sweep!`
-   consults the safe point itself when given `:store-id`, so a correct sweep
-   needs only that the writers take the guard.
+   or `with-unreferenced-writes`, which does the same. The COLLECTOR then has an
+   ordering obligation of its own — read `cutoff` BEFORE marking, and pass it to
+   `konserve.gc/sweep!` — for the reason spelled out there. Writers taking the
+   guard is necessary but not sufficient.
 
    A process that dies mid-sequence simply drops its entry: the objects it wrote
    are unreachable, i.e. garbage, and a later cycle collects them. Correct by
@@ -83,10 +84,22 @@
 ;;                             objects and DELETES LIVE DATA
 ;;
 ;; So the id may be coarser than the physical store, never finer — which a
-;; logical id is. Nothing enforces that two connections to one store agree on
-;; it, and nothing can from here; `validate-store-config` only checks that `:id`
-;; is a UUID. Taking it off the store (`konserve.protocols/store-id`) rather
-;; than passing it alongside is what keeps callers from disagreeing.
+;; logical id is. Taking it off the store (`konserve.protocols/store-id`) rather
+;; than passing it alongside is what keeps two callers from disagreeing.
+;;
+;; THE LOGICAL ID IS THE DEFAULT, NOT THE REQUIREMENT. A backend that knows
+;; where its bytes actually live can implement `PStoreConfig` and return an id
+;; derived from that, which wins over the default and closes BOTH mismatches at
+;; once — two connections to one path collapse to one guard key however their
+;; configs were written, and two replicas stop holding each other's collections
+;; back. Nothing else in konserve reads `store-id`, so a backend is free to do
+;; this without surprising anything.
+;;
+;; Until backends do, the default is sound in practice for the reason the guard
+;; is in-process to begin with: a logical store is normally connected once per
+;; runtime, so within a process one id names one store. The unsafe case needs
+;; the SAME bytes opened TWICE in ONE process under DIFFERENT ids, which takes
+;; deliberate effort and is visible at the call site.
 (defonce ^:private in-flight (atom {}))
 
 ;; Tokens are counter values, not fresh objects: a token is a MAP KEY, and a bare

--- a/src/konserve/gc_guard.cljc
+++ b/src/konserve/gc_guard.cljc
@@ -1,0 +1,139 @@
+(ns konserve.gc-guard
+  "The store's SAFE POINT: the instant before which every written object is
+   either reachable from a pointer, or garbage.
+
+   WHY THIS EXISTS. Crash-safety for a persistent index on konserve rests on one
+   rule: write every value the new state references, and only THEN write the
+   mutable pointer that makes it reachable. A torn write therefore leaves
+   collectable orphans, never a dangling pointer.
+
+   That rule is also a BLIND SPOT for the garbage collector. For the duration of
+   such a sequence, freshly written objects sit in the store reachable from
+   NOTHING — the pointer still names the previous state. A mark that runs inside
+   the window classifies them as garbage, and `konserve.gc/sweep!` deletes them;
+   the pointer then lands on deleted objects and the store is corrupt. The
+   objects are not `new' by timestamp either — they were written BEFORE the
+   collection started, so a cutoff of `now` does not spare them.
+
+   THE BLIND SPOT BELONGS TO THE STORE, NOT TO THE WRITER, which is why this
+   lives in konserve rather than in each library that writes through it. A single
+   konserve store commonly carries several independent index structures — a
+   datahike database, a geschichte repository, a scriptum fulltext index — each
+   performing its own values-then-pointer sequences, all swept by one collector.
+   A guard held privately inside one of them cannot protect the others: the
+   safe point has to be shared, and it is shared by agreeing on `store-id`.
+
+   USAGE — wrap the whole values-then-pointer sequence:
+
+     (let [t (writing! store-id)]
+       (try (write-values!) (write-pointer!)
+            (finally (done! store-id t))))
+
+   or `with-unreferenced-writes`, which does the same. `konserve.gc/sweep!`
+   consults the safe point itself when given `:store-id`, so a correct sweep
+   needs only that the writers take the guard.
+
+   A process that dies mid-sequence simply drops its entry: the objects it wrote
+   are unreachable, i.e. garbage, and a later cycle collects them. Correct by
+   construction.
+
+   SCOPE: this is IN-PROCESS state, and it matches konserve's concurrency
+   contract — a store has a single writer per runtime, or callers coordinate
+   above konserve. Writers in another process are outside that contract already,
+   for reasons more basic than GC (they lose each other's writes). Readers are
+   unconstrained."
+  (:require [konserve.utils :as ku])
+  #?(:clj (:import [java.util Date]))
+  ;; Self-require the macro namespace so `with-unreferenced-writes` is available
+  ;; to ClojureScript consumers that `:refer` it.
+  #?(:cljs (:require-macros [konserve.gc-guard])))
+
+(defn- now
+  "Monotonic stamp from konserve's write clock. MUST be the same source that
+   stamps :last-write (`konserve.utils/now`): the sweep spares an object iff
+   last-write >= safe-point, and that comparison is only meaningful when both
+   sides come from one strictly-monotonic clock — a raw (Date.) here would let an
+   NTP step-back stamp a live object BEFORE the safe-point that guards it."
+  [] (ku/now))
+
+(defn- ms [d] #?(:clj (.getTime ^Date d) :cljs (.getTime d)))
+
+;; store-id -> {token start-instant}. Keyed by an identifier of the PHYSICAL
+;; store rather than by the store object: separate connections to one store are
+;; different store instances, and a collection running on one must see a
+;; sequence in flight on another.
+(defonce ^:private in-flight (atom {}))
+
+;; Tokens are counter values, not fresh objects: a token is a MAP KEY, and a bare
+;; `(js/Object.)` implements neither IHash nor IEquiv in cljs, so it cannot be one.
+(defonce ^:private token-seq (atom 0))
+
+(defn writing!
+  "Open an unreferenced-write sequence on `store-id`. Returns a token to close it
+   with. Call BEFORE the first value is written."
+  [store-id]
+  (let [token (swap! token-seq inc)]
+    (swap! in-flight assoc-in [store-id token] (now))
+    token))
+
+(defn done!
+  "Close the sequence — its pointer has landed, so everything it wrote is now
+   reachable (or garbage, if the pointer superseded it)."
+  [store-id token]
+  (swap! in-flight (fn [m]
+                     (let [m' (update m store-id dissoc token)]
+                       (if (empty? (get m' store-id))
+                         (dissoc m' store-id)
+                         m'))))
+  nil)
+
+(defn in-flight?
+  "Is an unreferenced-write sequence currently open on `store-id`?
+
+   `safe-point` cannot answer this: it returns `now` both when nothing is in
+   flight AND when a sequence opened within the same millisecond, so a test that
+   compares timestamps cannot tell a held guard from a missing one. This can."
+  [store-id]
+  (boolean (seq (get @in-flight store-id))))
+
+(defn safe-point
+  "The instant before which every object written to `store-id` is either
+   reachable from a pointer or garbage — i.e. the sweep cutoff.
+
+   No sequence in flight => `now`: nothing is mid-write, so the mark's verdict on
+   everything written so far is final. Sequences in flight => the START of the
+   oldest one: everything it writes lands at or after that instant, so sparing
+   from there spares exactly its objects and nothing else.
+
+   Prefer `cutoff`, which handles the ordering requirement described there."
+  [store-id]
+  (let [starts (vals (get @in-flight store-id))]
+    (if (seq starts)
+      (reduce (fn [a b] (if (< (ms a) (ms b)) a b)) starts)
+      (now))))
+
+(defn cutoff
+  "The sweep cutoff for `store-id`, given the collection's own `started-at`.
+
+   ORDER MATTERS, which is the whole reason this exists rather than leaving
+   callers to combine the two readings. `started-at` must be read BEFORE the
+   guard, and the smaller of the two wins: a sequence that opens and closes
+   between the two readings has landed its pointer, so the mark — which runs
+   after — sees it. Reading the guard first would miss a sequence that opens in
+   between, and sweeping from `started-at` would then delete its objects."
+  [store-id started-at]
+  (let [sp (safe-point store-id)]
+    (if (< (ms sp) (ms started-at)) sp started-at)))
+
+#?(:clj
+   (defmacro with-unreferenced-writes
+     "Run `body` as one unreferenced-write sequence against `store-id`: no
+      concurrent collection in this process will sweep what it writes, until it
+      completes. Use it whenever you write values into the store that only a
+      LATER write (a transaction, a branch head, an index manifest) makes
+      reachable."
+     [store-id & body]
+     `(let [sid# ~store-id
+            t#   (writing! sid#)]
+        (try ~@body
+             (finally (done! sid# t#))))))

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -15,7 +15,8 @@
                                PMultiKeySupport
                                PMultiKeyEDNValueStore
                                PWriteHookStore]]
-   [konserve.impl.storage-layout :refer [-atomic-move -create-store
+   #?(:clj [konserve.nio-helpers :as nio])
+   [konserve.impl.storage-layout :refer [-streaming-binary-write? -atomic-move -create-store
                                          -copy -create-blob -delete-blob -blob-exists?
                                          -keys -sync-store
                                          -migratable -migrate -handle-foreign-key
@@ -98,7 +99,19 @@
         (<?- (-write-header new-blob header env))
         (<?- (-write-meta new-blob meta-arr env))
         (if (= operation :write-binary)
-          (<?- (-write-binary new-blob meta-size input env))
+          ;; Normalize here so no backing has to. `bassoc` documents five input
+          ;; shapes; before this, only the filestore handled any but bytes, and
+          ;; every other backing silently mishandled the rest — konserve-s3
+          ;; stashes the blob and later calls `(.write baos value)`, which needs
+          ;; a byte array. A backing that can drain a stream says so and gets
+          ;; the caller's input untouched, which is what lets a value larger
+          ;; than the heap be written at all: Lucene's DEFAULT merge policy
+          ;; tops out at 5 GB per segment, and a byte array at 2 GB.
+          (<?- (-write-binary new-blob meta-size
+                              (if (-streaming-binary-write? new-blob)
+                                input
+                                #?(:clj (nio/blob->bytes input) :cljs input))
+                              env))
           (let [value-arr (to-array value)]
             (<?- (-write-value new-blob value-arr meta-size env))))
 

--- a/src/konserve/impl/storage_layout.cljc
+++ b/src/konserve/impl/storage_layout.cljc
@@ -226,7 +226,31 @@
   (-write-header [this header-arr env] "Write header array.")
   (-write-meta [this meta-arr env] "Write metadata array.")
   (-write-value [this value-arr meta-size env] "Write value array.")
-  (-write-binary [this meta-size blob env] "Write binary blob."))
+  (-write-binary [this meta-size blob env]
+    "Write binary blob.
+
+     `blob` IS A byte ARRAY unless this blob type declares otherwise via
+     `PStreamingBinaryWrite`. `konserve.core/bassoc` accepts an InputStream, a
+     File, a String, a Reader or a byte array, and normalizing that variety
+     once — in `konserve.impl.defaults` — is what keeps every backing from
+     having to. Before that, only the filestore handled anything but bytes, and
+     every other backing silently mishandled the documented input types."))
+
+(defprotocol PStreamingBinaryWrite
+  "Can this blob consume `-write-binary` input without it being materialized first?
+
+   Defaults to FALSE, which is the safe direction: a backing that has not
+   thought about it receives a byte array, which is what every implementation
+   already assumed. A backing that can consume a stream — the filestore drains
+   one through a fixed buffer — implements this and gets the caller's blob
+   untouched, so a value larger than the heap still writes."
+  (-streaming-binary-write? [this]))
+
+(extend-protocol PStreamingBinaryWrite
+  #?(:clj Object :cljs default)
+  (-streaming-binary-write? [_] false)
+  nil
+  (-streaming-binary-write? [_] false))
 
 (defprotocol PBackingLock
   (-release [this env] "Release this lock."))

--- a/src/konserve/memory.cljc
+++ b/src/konserve/memory.cljc
@@ -6,6 +6,7 @@
                                         PBinaryKeyValueStore PKeyIterable
                                         PMultiKeyEDNValueStore PMultiKeySupport
                                         PAssocSerializers PWriteHookStore]]
+            #?(:clj [konserve.nio-helpers :as nio])
             [konserve.utils #?(:clj :refer :cljs :refer-macros) [async+sync]]))
 
 ;; =============================================================================
@@ -89,7 +90,14 @@
                   (go (<! (locked-cb (let [v (second (get @state key))]
                                        {:input-stream v :blob v})))))))
   (-bassoc [_ key meta-up-fn input opts]
-    (let [{:keys [sync?]} opts]
+    ;; Normalized like every other backing: `bassoc` documents an InputStream,
+    ;; a File, a String and a byte array, and storing the caller's object
+    ;; verbatim handed all but the last straight back out of `bget` — `slurp`
+    ;; then read a String as a FILENAME. The DefaultStore backings normalize in
+    ;; `konserve.impl.defaults`; this store bypasses that layer, so it does its
+    ;; own.
+    (let [input #?(:clj (nio/blob->bytes input) :cljs input)
+          {:keys [sync?]} opts]
       (async+sync sync?
                   {go do
                    <! do}

--- a/src/konserve/nio_helpers.clj
+++ b/src/konserve/nio_helpers.clj
@@ -65,7 +65,6 @@
                     [(Channels/newChannel (ByteArrayInputStream. (.getBytes (String. ^chars input))))
                      (fn [bis buffer] (.read ^ReadableByteChannel bis buffer))])})
 
-
 (def ^:private normalize-buffer-size (* 64 1024))
 
 (defn blob->bytes

--- a/src/konserve/nio_helpers.clj
+++ b/src/konserve/nio_helpers.clj
@@ -26,7 +26,10 @@
 
   File
   (blob->channel [input _buffer-size]
-    [(Channels/newChannel (FileInputStream. ^String input))
+    ;; ^File, not ^String: the hint used to say String, so the reflector chose
+    ;; `FileInputStream(String)` and every `bassoc` given a File threw
+    ;; ClassCastException — a documented input type that never worked.
+    [(Channels/newChannel (FileInputStream. ^File input))
      (fn [bis buffer]  (.read ^ReadableByteChannel bis buffer))])
 
   String
@@ -62,3 +65,36 @@
                     [(Channels/newChannel (ByteArrayInputStream. (.getBytes (String. ^chars input))))
                      (fn [bis buffer] (.read ^ReadableByteChannel bis buffer))])})
 
+
+(def ^:private normalize-buffer-size (* 64 1024))
+
+(defn blob->bytes
+  "`input` as a byte array, whatever documented shape it arrived in.
+
+   `konserve.core/bassoc` accepts an InputStream, a File, a String, a Reader or
+   a byte array, but only backings that consume a stream can take them as they
+   come. Everything else gets them through here, so one dispatch serves every
+   backing instead of each reinventing it — or, as was the case, not
+   implementing it at all and mishandling four of the five types.
+
+   Materializes, necessarily: a backing that cannot stream has to hold the
+   value anyway. A backing that CAN should say so via
+   `PStreamingBinaryWrite` and skip this."
+  ^bytes [input]
+  (if (bytes? input)
+    input
+    (let [[bis read] (blob->channel input normalize-buffer-size)
+          out (java.io.ByteArrayOutputStream.)
+          buffer (ByteBuffer/allocate normalize-buffer-size)]
+      (try
+        (loop []
+          (let [size (read bis buffer)]
+            (when-not (= size -1)
+              (.flip buffer)
+              (let [arr (byte-array (.remaining buffer))]
+                (.get buffer arr)
+                (.write out arr 0 (alength arr)))
+              (.clear buffer)
+              (recur))))
+        (.toByteArray out)
+        (finally (.close ^java.io.Closeable bis))))))

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -70,7 +70,40 @@
     "Returns true if the store handles concurrency internally and doesn't need
      application-level locking. Default is false for all stores."))
 
+(def store-id-key
+  "Where a connected store carries its `:id` when the backend has no field of
+   its own for it. Namespaced, so attaching it to a record lands in the
+   extension map without disturbing the declared fields."
+  ::store-id)
+
+(defprotocol PStoreIdentity
+  "Which physical store is this?
+
+   `konserve.store/validate-store-config` REQUIRES a UUID `:id` on every store,
+   and then every backend drops it — nothing on a connected store carried it. A
+   `DefaultStore`'s `:config` holds the backend's behaviour options
+   (`:in-place?`, `:lock-blob?`, `:sync-blob?`), not the store's identity, and
+   backends that bypass `DefaultStore` (LMDB) keep even less.
+
+   That left components which must AGREE on a store's name — the GC safe point
+   above all, where datahike, geschichte and a scriptum index share one store
+   and one sweep — passing the id alongside the store by hand. Disagreement
+   there is invisible until a collection deletes something.
+
+   The default implementation reads the id `konserve.store` attaches on connect,
+   so no backend has to do anything. A backend that would rather hold its id in
+   a real field can implement this and be authoritative."
+  (-store-id [this]
+    "The UUID this store was connected with, or nil for a store built through a
+     backend constructor directly, which never took one."))
+
 ;; Default implementations for Object
+
+(extend-protocol PStoreIdentity
+  #?(:clj Object :cljs default)
+  (-store-id [this] (get this store-id-key))
+  nil
+  (-store-id [_] nil))
 
 (extend-protocol PMultiKeySupport
   #?(:clj Object :cljs default)

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -141,6 +141,15 @@
    so no backend has to do anything. A backend that would rather hold its config
    in a real field can implement this and be authoritative.
 
+   WORTH DOING FOR IDENTITY, not just for storage: the attached `:id` is konserve's
+   LOGICAL identity, deliberately the same across machines and backends holding
+   one store. The GC safe point needs an id that is never FINER than the bytes a
+   sweep deletes (see `konserve.gc-guard`), and a backend that knows its own
+   physical location can return one derived from it — collapsing two connections
+   to one path onto a single guard key, and separating replicas that would
+   otherwise hold each other's collections back. Nothing else in konserve reads
+   `store-id`, so overriding it costs nothing elsewhere.
+
    Credential keys are stripped — see `credential-keys`. The result identifies a
    store; it is not guaranteed to be enough to reconnect one."
   (-store-config [this]

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -70,40 +70,67 @@
     "Returns true if the store handles concurrency internally and doesn't need
      application-level locking. Default is false for all stores."))
 
-(def store-id-key
-  "Where a connected store carries its `:id` when the backend has no field of
-   its own for it. Namespaced, so attaching it to a record lands in the
-   extension map without disturbing the declared fields."
-  ::store-id)
+(def store-config-key
+  "Where a connected store carries the config it was connected with, when the
+   backend has no field of its own for it. Namespaced, so attaching it to a
+   record lands in the extension map without disturbing the declared fields.
 
-(defprotocol PStoreIdentity
-  "Which physical store is this?
+   NOT `:config` — a `DefaultStore` already has one of those, holding the
+   backend's behaviour options (`:in-place?`, `:lock-blob?`, `:sync-blob?`).
+   Two different maps, and overwriting one with the other would break every
+   backend that reads it."
+  ::store-config)
+
+(def credential-keys
+  "Config keys stripped before a config is attached to a store.
+
+   Store configs carry secrets — `:access-key` and `:secret` for S3,
+   `:password` and `:jdbcUrl` for JDBC. Those are fine in a config a caller
+   holds and passes once; they are not fine sitting on a long-lived object that
+   any `pr-str`, log line or `ex-info` payload might carry off. Identity
+   (`:backend`, `:id`, `:path`, `:bucket`, …) survives, which is what makes the
+   attached config useful.
+
+   A backend with its own secret-bearing keys should add them here rather than
+   hope nobody prints a store."
+  #{:access-key :secret :secret-key :password :token :credentials :jdbcUrl})
+
+(defprotocol PStoreConfig
+  "What config is this store connected with?
 
    `konserve.store/validate-store-config` REQUIRES a UUID `:id` on every store,
-   and then every backend drops it — nothing on a connected store carried it. A
-   `DefaultStore`'s `:config` holds the backend's behaviour options
-   (`:in-place?`, `:lock-blob?`, `:sync-blob?`), not the store's identity, and
-   backends that bypass `DefaultStore` (LMDB) keep even less.
+   and then every backend drops the config — nothing on a connected store
+   carried it. A `DefaultStore`'s `:config` is a different map (behaviour
+   options), and backends that bypass `DefaultStore` (LMDB) keep less still.
 
-   That left components which must AGREE on a store's name — the GC safe point
-   above all, where datahike, geschichte and a scriptum index share one store
-   and one sweep — passing the id alongside the store by hand. Disagreement
-   there is invisible until a collection deletes something.
+   That left components which must AGREE on a store's identity — the GC safe
+   point above all, where datahike, geschichte and a scriptum index share one
+   store and one sweep — passing the id alongside the store by hand.
+   Disagreement there is invisible until a collection deletes something.
 
-   The default implementation reads the id `konserve.store` attaches on connect,
-   so no backend has to do anything. A backend that would rather hold its id in
-   a real field can implement this and be authoritative."
-  (-store-id [this]
-    "The UUID this store was connected with, or nil for a store built through a
-     backend constructor directly, which never took one."))
+   The default implementation reads what `konserve.store` attaches on connect,
+   so no backend has to do anything. A backend that would rather hold its config
+   in a real field can implement this and be authoritative.
+
+   Credential keys are stripped — see `credential-keys`. The result identifies a
+   store; it is not guaranteed to be enough to reconnect one."
+  (-store-config [this]
+    "The (credential-stripped) config this store was connected with, or nil for
+     a store built through a backend constructor directly, which never took one."))
 
 ;; Default implementations for Object
 
-(extend-protocol PStoreIdentity
+(extend-protocol PStoreConfig
   #?(:clj Object :cljs default)
-  (-store-id [this] (get this store-id-key))
+  (-store-config [this] (get this store-config-key))
   nil
-  (-store-id [_] nil))
+  (-store-config [_] nil))
+
+(defn store-id
+  "The UUID this store was connected with, or nil. Convenience over
+   `-store-config`, since identity is what most callers actually want."
+  [store]
+  (:id (-store-config store)))
 
 (extend-protocol PMultiKeySupport
   #?(:clj Object :cljs default)

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -1,4 +1,5 @@
 (ns konserve.protocols
+  (:require [clojure.walk])
   #?(:cljs (:refer-clojure :exclude [-dissoc])))
 
 (defprotocol PEDNKeyValueStore
@@ -93,7 +94,35 @@
 
    A backend with its own secret-bearing keys should add them here rather than
    hope nobody prints a store."
-  #{:access-key :secret :secret-key :password :token :credentials :jdbcUrl})
+  #{:access-key :secret-access-key :aws-secret-access-key
+    :secret :secret-key :private-key
+    :password :passphrase
+    :token :session-token :credentials
+    :api-key
+    :jdbcUrl :jdbc-url :connection-uri})
+
+(defn strip-credentials
+  "`config` with every credential key removed, AT EVERY DEPTH.
+
+   Depth is the point. Konserve configs NEST: a `:tiered` store's config holds a
+   whole `:frontend-config` and `:backend-config`, each a complete store config
+   with its own `:access-key` or `:password` (see `konserve.store`'s `:tiered`
+   methods). A top-level `dissoc` walks straight past those and attaches them to
+   the store, which is worse than not attaching a config at all — before, they
+   were only in a map the caller held.
+
+   The encryptor is handled by name rather than by key set: konserve's own AES
+   key lives at `:encryptor {:type :aes :key ...}`, and `:key` is far too common
+   a word to put in `credential-keys` — stripping it everywhere would gut
+   ordinary configs."
+  [config]
+  (clojure.walk/postwalk
+   (fn [x]
+     (if (map? x)
+       (cond-> (apply dissoc x credential-keys)
+         (map? (:encryptor x)) (update :encryptor dissoc :key))
+       x))
+   config))
 
 (defprotocol PStoreConfig
   "What config is this store connected with?

--- a/src/konserve/store.cljc
+++ b/src/konserve/store.cljc
@@ -92,20 +92,27 @@
   "Give a freshly connected store its own identity.
 
    Done here because this is the only place every backend passes through with
-   the full config in hand — including backends that bypass `DefaultStore`
-   entirely, like LMDB. The default `PStoreConfig` implementation reads this
-   back, so no backend has to change; one that prefers a real field can
-   implement the protocol and take over.
+   the full config in hand, including backends that bypass `DefaultStore`
+   entirely. The default `PStoreConfig` implementation reads this back, so no
+   backend has to change; one that prefers a real field can implement the
+   protocol and take over.
 
-   Credentials are stripped first: a config a caller passes once may hold an S3
-   secret or a JDBC password, and attaching it verbatim would park those on a
-   long-lived object that any log line or `ex-info` payload could carry off.
+   Credentials are stripped first, AT EVERY DEPTH — see
+   `konserve.protocols/strip-credentials`, and note that a `:tiered` config
+   nests two whole store configs inside itself.
+
+   LIMIT WORTH KNOWING: this attaches by `assoc`, so it only reaches a store
+   that is a map or a record. A backend whose store is a `deftype` silently
+   gets nothing, and `store-id` then returns nil for it — which is the one
+   direction that matters, since a caller who guards under a nil id shares a
+   bucket with every other such store. Such a backend should implement
+   `PStoreConfig` itself rather than rely on this.
 
    Anything not associable — an exception delivered on the async path, say —
-   passes through untouched."
+   passes through untouched, which is also what makes the guard above safe."
   [store config]
   (if (and config (or (map? store) (record? store)))
-    (assoc store p/store-config-key (apply dissoc config p/credential-keys))
+    (assoc store p/store-config-key (p/strip-credentials config))
     store))
 
 (defn- with-store-config

--- a/src/konserve/store.cljc
+++ b/src/konserve/store.cljc
@@ -31,11 +31,12 @@
      ;; After requiring konserve-s3:
      (store/connect-store {:backend :s3 :bucket \"my-bucket\" :region \"us-east-1\"})"
   (:require [konserve.memory]
+            [konserve.protocols :as p]
             [konserve.tiered :as tiered]
             [konserve.utils :refer [#?(:clj async+sync) *default-sync-translation*]
              #?@(:cljs [:refer-macros [async+sync]])]
             #?(:clj [konserve.filestore])
-            [clojure.core.async :refer [go] :include-macros true]
+            [clojure.core.async :refer [go <!] :include-macros true]
             [superv.async :refer [go-try- <?-] :include-macros true]))
 
 ;; =============================================================================
@@ -73,6 +74,39 @@
               {:config config :id id :error :invalid-id-type}))
 
       :else config)))
+
+;; =============================================================================
+;; Store identity
+;; =============================================================================
+
+(def store-id
+  "The UUID this store was connected with, or nil — see
+   `konserve.protocols/PStoreIdentity`."
+  p/-store-id)
+
+(defn- remember-id
+  "Give a freshly connected store its own identity.
+
+   Done here because this is the only place every backend passes through with
+   the full config in hand — including backends that bypass `DefaultStore`
+   entirely, like LMDB. The default `PStoreIdentity` implementation reads this
+   back, so no backend has to change; one that prefers a real field can
+   implement the protocol and take over.
+
+   Anything not associable — an exception delivered on the async path, say —
+   passes through untouched."
+  [store id]
+  (if (and id (or (map? store) (record? store)))
+    (assoc store p/store-id-key id)
+    store))
+
+(defn- with-store-id
+  "Apply `remember-id` across both return contracts: a value under `{:sync? true}`,
+   a channel otherwise."
+  [result id opts]
+  (if (:sync? opts)
+    (remember-id result id)
+    (go (remember-id (<! result) id))))
 
 ;; =============================================================================
 ;; Private Multimethods (fixed arity, both config and opts)
@@ -150,7 +184,11 @@
   ([config]
    (connect-store config {:sync? false}))
   ([config opts]
-   (-connect-store config (or opts {:sync? false}))))
+   (let [opts (or opts {:sync? false})]
+     ;; Every backend dispatches through here with the full config, so this is
+     ;; the one place that can hand the store its own identity — including
+     ;; backends like LMDB that bypass DefaultStore entirely.
+     (with-store-id (-connect-store config opts) (:id config) opts))))
 
 (defn create-store
   "Create a new store.
@@ -167,7 +205,8 @@
   ([config]
    (create-store config {:sync? false}))
   ([config opts]
-   (-create-store config (or opts {:sync? false}))))
+   (let [opts (or opts {:sync? false})]
+     (with-store-id (-create-store config opts) (:id config) opts))))
 
 (defn store-exists?
   "Check if a store exists at the given configuration.

--- a/src/konserve/store.cljc
+++ b/src/konserve/store.cljc
@@ -79,34 +79,42 @@
 ;; Store identity
 ;; =============================================================================
 
-(def store-id
-  "The UUID this store was connected with, or nil — see
-   `konserve.protocols/PStoreIdentity`."
-  p/-store-id)
+(def store-config
+  "The (credential-stripped) config this store was connected with, or nil —
+   see `konserve.protocols/PStoreConfig`."
+  p/-store-config)
 
-(defn- remember-id
+(def store-id
+  "The UUID this store was connected with, or nil."
+  p/store-id)
+
+(defn- remember-config
   "Give a freshly connected store its own identity.
 
    Done here because this is the only place every backend passes through with
    the full config in hand — including backends that bypass `DefaultStore`
-   entirely, like LMDB. The default `PStoreIdentity` implementation reads this
+   entirely, like LMDB. The default `PStoreConfig` implementation reads this
    back, so no backend has to change; one that prefers a real field can
    implement the protocol and take over.
 
+   Credentials are stripped first: a config a caller passes once may hold an S3
+   secret or a JDBC password, and attaching it verbatim would park those on a
+   long-lived object that any log line or `ex-info` payload could carry off.
+
    Anything not associable — an exception delivered on the async path, say —
    passes through untouched."
-  [store id]
-  (if (and id (or (map? store) (record? store)))
-    (assoc store p/store-id-key id)
+  [store config]
+  (if (and config (or (map? store) (record? store)))
+    (assoc store p/store-config-key (apply dissoc config p/credential-keys))
     store))
 
-(defn- with-store-id
-  "Apply `remember-id` across both return contracts: a value under `{:sync? true}`,
-   a channel otherwise."
-  [result id opts]
+(defn- with-store-config
+  "Apply `remember-config` across both return contracts: a value under
+   `{:sync? true}`, a channel otherwise."
+  [result config opts]
   (if (:sync? opts)
-    (remember-id result id)
-    (go (remember-id (<! result) id))))
+    (remember-config result config)
+    (go (remember-config (<! result) config))))
 
 ;; =============================================================================
 ;; Private Multimethods (fixed arity, both config and opts)
@@ -188,7 +196,7 @@
      ;; Every backend dispatches through here with the full config, so this is
      ;; the one place that can hand the store its own identity — including
      ;; backends like LMDB that bypass DefaultStore entirely.
-     (with-store-id (-connect-store config opts) (:id config) opts))))
+     (with-store-config (-connect-store config opts) config opts))))
 
 (defn create-store
   "Create a new store.
@@ -206,7 +214,7 @@
    (create-store config {:sync? false}))
   ([config opts]
    (let [opts (or opts {:sync? false})]
-     (with-store-id (-create-store config opts) (:id config) opts))))
+     (with-store-config (-create-store config opts) config opts))))
 
 (defn store-exists?
   "Check if a store exists at the given configuration.

--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -2,6 +2,7 @@
   "Tiered store implementation with frontend and backend storage layers."
   (:refer-clojure :exclude [get get-in update update-in assoc assoc-in exists? dissoc keys])
   (:require [clojure.core.async :refer [go] :as async]
+            #?(:clj [konserve.nio-helpers :as nio])
             [clojure.set :as set]
             [konserve.memory :as memory]
             [konserve.protocols :as protocols :refer [-exists? -get-meta -get-in -assoc-in
@@ -326,7 +327,13 @@
 
   (-bassoc [_this key meta-up-fn val opts]
     (log/trace :konserve/tiered-bassoc {:key key})
-    (async+sync (:sync? opts)
+    ;; Materialize ONCE, before fanning out. Both tiers receive the same `val`,
+    ;; and an InputStream is exhausted by whichever writes first — the second
+    ;; tier would then store nothing, silently. `bassoc` documents streams as
+    ;; input, so this is the only place that can honour that for a two-tier
+    ;; write.
+    (let [val #?(:clj (nio/blob->bytes val) :cljs val)]
+      (async+sync (:sync? opts)
                 *default-sync-translation*
                 (go-try-
                  (case write-policy
@@ -356,7 +363,7 @@
                      result)
 
                    :frontend-only
-                   (<?- (-bassoc frontend-store key meta-up-fn val opts))))))
+                   (<?- (-bassoc frontend-store key meta-up-fn val opts)))))))
 
   PAssocSerializers
   (-assoc-serializers [this serializers]

--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -334,36 +334,36 @@
     ;; write.
     (let [val #?(:clj (nio/blob->bytes val) :cljs val)]
       (async+sync (:sync? opts)
-                *default-sync-translation*
-                (go-try-
-                 (case write-policy
-                   :write-through
-                   (let [backend-result (<?- (-bassoc backend-store key meta-up-fn val opts))]
-                     (try
-                       (<?- (-bassoc frontend-store key meta-up-fn val opts))
-                       (catch #?(:clj Exception :cljs js/Error) e
-                         (log/warn :konserve/tiered-frontend-bassoc-failed {:key key :error e})))
-                     backend-result)
+                  *default-sync-translation*
+                  (go-try-
+                   (case write-policy
+                     :write-through
+                     (let [backend-result (<?- (-bassoc backend-store key meta-up-fn val opts))]
+                       (try
+                         (<?- (-bassoc frontend-store key meta-up-fn val opts))
+                         (catch #?(:clj Exception :cljs js/Error) e
+                           (log/warn :konserve/tiered-frontend-bassoc-failed {:key key :error e})))
+                       backend-result)
 
-                   :write-behind
+                     :write-behind
                    ;; Write to frontend first, then backend asynchronously (standard write-behind)
-                   (let [frontend-result (<?- (-bassoc frontend-store key meta-up-fn val opts))]
-                     (go (try
-                           (<?- (-bassoc backend-store key meta-up-fn val opts))
-                           (catch #?(:clj Exception :cljs js/Error) e
-                             (log/warn :konserve/tiered-backend-bassoc-failed {:key key :error e}))))
-                     frontend-result)
+                     (let [frontend-result (<?- (-bassoc frontend-store key meta-up-fn val opts))]
+                       (go (try
+                             (<?- (-bassoc backend-store key meta-up-fn val opts))
+                             (catch #?(:clj Exception :cljs js/Error) e
+                               (log/warn :konserve/tiered-backend-bassoc-failed {:key key :error e}))))
+                       frontend-result)
 
-                   :write-around
-                   (let [result (<?- (-bassoc backend-store key meta-up-fn val opts))]
-                     (go (try
-                           (<?- (-dissoc frontend-store key opts))
-                           (catch #?(:clj Exception :cljs js/Error) e
-                             (log/warn :konserve/tiered-frontend-invalidation-failed {:key key :error e}))))
-                     result)
+                     :write-around
+                     (let [result (<?- (-bassoc backend-store key meta-up-fn val opts))]
+                       (go (try
+                             (<?- (-dissoc frontend-store key opts))
+                             (catch #?(:clj Exception :cljs js/Error) e
+                               (log/warn :konserve/tiered-frontend-invalidation-failed {:key key :error e}))))
+                       result)
 
-                   :frontend-only
-                   (<?- (-bassoc frontend-store key meta-up-fn val opts)))))))
+                     :frontend-only
+                     (<?- (-bassoc frontend-store key meta-up-fn val opts)))))))
 
   PAssocSerializers
   (-assoc-serializers [this serializers]

--- a/src/konserve/utils.cljc
+++ b/src/konserve/utils.cljc
@@ -128,11 +128,21 @@
           ~async-code))))
 
 (def ^:dynamic *default-sync-translation*
+  "How `async+sync` rewrites async operators for the synchronous branch.
+
+   `reduce<?-` belongs here with the rest: it is a superv.async operator, and
+   under this rewrite its step fn returns a VALUE rather than a channel, so it
+   degrades to plain `reduce`. Left out, a sync branch containing one would hand
+   it a value where it expects a channel. It cannot live in the caller's
+   namespace either — `async+sync` resolves a symbol translation at macroexpand
+   time, which ClojureScript cannot do for a var in a `.cljc` that is not also a
+   loaded Clojure namespace."
   '{go-try try
     <? do
     go-try- try
     <!- do
     <?- do
+    reduce<?- reduce
     go-locked locked
     maybe-go-locked maybe-locked})
 

--- a/test/konserve/gc_guard_test.cljc
+++ b/test/konserve/gc_guard_test.cljc
@@ -12,6 +12,7 @@
    async-only, and expressing these as cljs async tests would obscure what they
    are demonstrating without covering anything the guard does differently there."
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string]
             [konserve.gc-guard :as guard]
             [konserve.utils :as utils]
             #?@(:clj [[clojure.core.async :refer [<!!]]
@@ -197,3 +198,30 @@
            (is (empty? (<!! (gc/sweep! store #{} (cutoff-after-writes) 1000
                                        {:store-id sid}))))
            (guard/done! sid token))))))
+
+#?(:clj
+   (deftest attached-config-identifies-without-carrying-secrets
+     (testing "the store reports the config it was connected with"
+       (let [id (random-uuid)
+             store (ks/create-store {:backend :memory :id id} {:sync? true})]
+         (is (= id (ks/store-id store)))
+         (is (= :memory (:backend (ks/store-config store))))))
+
+     (testing "credentials are stripped: a config a caller passes once may hold
+               an S3 secret or a JDBC password, and a store is long-lived and
+               printable — identity survives, secrets do not"
+       (let [id (random-uuid)
+             store (ks/create-store {:backend :memory :id id
+                                     :access-key "AKIAEXAMPLE"
+                                     :secret "shhh"
+                                     :password "hunter2"
+                                     :jdbcUrl "jdbc://user:pw@host/db"}
+                                    {:sync? true})
+             cfg (ks/store-config store)
+             printed (pr-str cfg)]
+         (is (= id (:id cfg)) "identity survives")
+         (doseq [k [:access-key :secret :password :jdbcUrl]]
+           (is (not (contains? cfg k)) (str k " must not be retained")))
+         (doseq [leak ["AKIAEXAMPLE" "shhh" "hunter2" "hunter2" "user:pw"]]
+           (is (not (clojure.string/includes? printed leak))
+               "no secret may survive into a printable form"))))))

--- a/test/konserve/gc_guard_test.cljc
+++ b/test/konserve/gc_guard_test.cljc
@@ -131,20 +131,85 @@
 
 #?(:clj
    (deftest sweep-with-the-guard-spares-the-unrooted-write
-     (testing "same sequence, guard held: sweep! derives min(ts, safe-point) from
-               :store-id and leaves the in-flight values alone"
+     (testing "same sequence, but the CALLER derives the cutoff from the guard
+               before marking: min(ts, safe-point) sits at or before the open
+               sequence, so its values are never older than the cutoff"
        (let [store (fresh-store)
              sid (random-uuid)
              token (guard/writing! sid)]
          (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
          (<!! (k/assoc store :value-2 {:node :data} {:sync? false}))
-         (let [started (cutoff-after-writes)
-               deleted (<!! (gc/sweep! store #{:root} started 1000 {:store-id sid}))]
+         (let [cutoff (guard/cutoff sid (cutoff-after-writes))
+               deleted (<!! (gc/sweep! store #{:root} cutoff))]
            (is (empty? deleted) "nothing may be collected while the sequence is open")
            (is (some? (<!! (k/get store :value-1 nil {:sync? false}))))
            (is (some? (<!! (k/get store :value-2 nil {:sync? false})))))
          (guard/done! sid token)
          (is (not (guard/in-flight? sid)))))))
+
+#?(:clj
+   (deftest the-guard-must-be-read-before-the-mark
+     (testing "THE ordering property, and why `sweep!` refuses to read the guard
+               itself: it is handed an already-computed whitelist, so any reading
+               it did would necessarily be AFTER the caller's mark.
+
+               A sequence open at the start, whose pointer lands between the mark
+               and the sweep, is invisible to a cutoff taken after the mark — by
+               then the guard is closed, so the cutoff snaps back to the
+               collection start, while the mark walked roots that did not name
+               the values yet.
+
+               The clock is driven rather than waited on: stamps are pinned to
+               wall time at millisecond granularity and the sweep spares ties, so
+               a real-time version of this test spares the values by accident
+               about as often as it proves anything. The high-water mark is
+               process-global and `max`-based, so it is restored afterwards."
+       (let [stamp-atom @#'utils/last-stamp
+             saved @stamp-atom]
+         (try
+           ;; WRONG ORDER: mark, then read the guard.
+           (let [store (fresh-store)
+                 sid (random-uuid)
+                 clock (atom (+ 1000 (utils/monotonic-now-ms)))]
+             (binding [utils/*wall-clock-ms* #(deref clock)]
+               (let [token (guard/writing! sid)]
+                 (swap! clock + 1000)
+                 (<!! (k/assoc store :root {:points-to []} {:sync? false}))
+                 (<!! (k/assoc store :v1 {:node :data} {:sync? false}))
+                 (swap! clock + 1000)
+                 (let [ts (utils/now)
+                       whitelist #{:root}]      ; mark: :root does not name :v1 yet
+                   (swap! clock + 1000)
+                   ;; the pointer lands and the sequence closes, after the mark
+                   (<!! (k/assoc store :root {:points-to [:v1]} {:sync? false}))
+                   (guard/done! sid token)
+                   (let [cutoff (guard/cutoff sid ts)   ; read too late
+                         deleted (<!! (gc/sweep! store whitelist cutoff))]
+                     (is (contains? (set deleted) :v1)
+                         "a guard read after the mark cannot spare :v1")
+                     (is (nil? (<!! (k/get store :v1 nil {:sync? false})))
+                         "so :root is left dangling"))))))
+           ;; RIGHT ORDER: read the guard, then mark.
+           (let [store (fresh-store)
+                 sid (random-uuid)
+                 clock (atom (+ 1000 (utils/monotonic-now-ms)))]
+             (binding [utils/*wall-clock-ms* #(deref clock)]
+               (let [token (guard/writing! sid)]
+                 (swap! clock + 1000)
+                 (<!! (k/assoc store :root {:points-to []} {:sync? false}))
+                 (<!! (k/assoc store :v1 {:node :data} {:sync? false}))
+                 (swap! clock + 1000)
+                 (let [cutoff (guard/cutoff sid (utils/now))  ; guard first, still open
+                       whitelist #{:root}]                    ; then mark
+                   (swap! clock + 1000)
+                   (<!! (k/assoc store :root {:points-to [:v1]} {:sync? false}))
+                   (guard/done! sid token)
+                   (let [deleted (<!! (gc/sweep! store whitelist cutoff))]
+                     (is (empty? deleted)
+                         "the open sequence pinned the cutoff before its own writes")
+                     (is (some? (<!! (k/get store :v1 nil {:sync? false})))
+                         "so :root's target survives"))))))
+           (finally (reset! stamp-atom saved)))))))
 
 #?(:clj
    (deftest guard-is-shared-across-independent-writers-on-one-store
@@ -156,47 +221,64 @@
              ;; writer A (say a datahike commit) opens a sequence
              token-a (guard/writing! sid)]
          (<!! (k/assoc store :a-value {:from :a} {:sync? false}))
-         ;; writer B (say a scriptum manifest sync) triggers a collection
-         (let [started (cutoff-after-writes)
-               deleted (<!! (gc/sweep! store #{} started 1000 {:store-id sid}))]
+         ;; writer B (say a scriptum manifest sync) triggers a collection, and
+         ;; derives its cutoff from the SAME store id
+         (let [cutoff (guard/cutoff sid (cutoff-after-writes))
+               deleted (<!! (gc/sweep! store #{} cutoff))]
            (is (empty? deleted)
                "B's sweep must not collect A's in-flight values")
            (is (some? (<!! (k/get store :a-value nil {:sync? false})))))
          (guard/done! sid token-a)))))
 
 #?(:clj
-   (deftest sweep-consults-the-guard-without-being-told-the-store-id
-     (testing "a store connected through konserve.store names itself, so the
-               guard applies with no :store-id argument at all — the case where
-               a caller and a writer could otherwise disagree about the name"
+   (deftest a-store-names-itself-so-callers-cannot-disagree
+     (testing "the id a caller feeds the guard should come off the store, not be
+               passed alongside it — disagreement there is invisible until a
+               collection deletes something.
+
+               Clock driven, and the high-water mark restored: the second sweep
+               has to actually collect, and against wall time its cutoff ties
+               with the write it is meant to be younger than about half the time."
        (let [id (random-uuid)
-             store (ks/create-store {:backend :memory :id id} {:sync? true})]
+             store (ks/create-store {:backend :memory :id id} {:sync? true})
+             stamp-atom @#'utils/last-stamp
+             saved @stamp-atom
+             clock (atom (+ 1000 (utils/monotonic-now-ms)))]
          (is (= id (ks/store-id store)) "the store must carry its own id")
-         (let [token (guard/writing! id)]
-           (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
-           ;; No :store-id passed. The sweep has to find it on the store.
-           (let [deleted (<!! (gc/sweep! store #{} (cutoff-after-writes) 1000 {}))]
-             (is (empty? deleted)
-                 "the derived id must reach the guard and spare the in-flight write")
-             (is (some? (<!! (k/get store :value-1 nil {:sync? false})))))
-           (guard/done! id token))
-         ;; With the sequence closed the same sweep collects normally, which
-         ;; proves the emptiness above came from the guard and not from a sweep
-         ;; that simply never ran.
-         (let [deleted (<!! (gc/sweep! store #{} (cutoff-after-writes) 1000 {}))]
-           (is (contains? (set deleted) :value-1)))))))
+         (try
+           (binding [utils/*wall-clock-ms* #(deref clock)]
+             (let [sid (ks/store-id store)
+                   token (guard/writing! sid)]
+               (swap! clock + 1000)
+               (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
+               (swap! clock + 1000)
+               (let [cutoff (guard/cutoff sid (utils/now))
+                     deleted (<!! (gc/sweep! store #{} cutoff))]
+                 (is (empty? deleted)
+                     "the id taken off the store must reach the guard")
+                 (is (some? (<!! (k/get store :value-1 nil {:sync? false})))))
+               (guard/done! sid token)
+               ;; Sequence closed: the same sweep now collects, which proves the
+               ;; emptiness above came from the guard and not from a sweep that
+               ;; simply never ran.
+               (swap! clock + 1000)
+               (let [cutoff (guard/cutoff sid (utils/now))
+                     deleted (<!! (gc/sweep! store #{} cutoff))]
+                 (is (contains? (set deleted) :value-1)))))
+           (finally (reset! stamp-atom saved)))))))
 
 #?(:clj
-   (deftest an-explicit-store-id-still-wins
-     (testing "a store built through a backend constructor never took an id, so
-               the caller must still be able to supply one"
+   (deftest a-constructor-built-store-has-no-id-of-its-own
+     (testing "a store built through a backend constructor never took a config,
+               so it cannot name itself and the caller must supply the id it
+               guards with"
        (let [store (fresh-store)
              sid (random-uuid)]
          (is (nil? (ks/store-id store)))
          (let [token (guard/writing! sid)]
            (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
-           (is (empty? (<!! (gc/sweep! store #{} (cutoff-after-writes) 1000
-                                       {:store-id sid}))))
+           (is (empty? (<!! (gc/sweep! store #{}
+                                       (guard/cutoff sid (cutoff-after-writes))))))
            (guard/done! sid token))))))
 
 #?(:clj

--- a/test/konserve/gc_guard_test.cljc
+++ b/test/konserve/gc_guard_test.cljc
@@ -1,0 +1,138 @@
+(ns konserve.gc-guard-test
+  "Pins the store's SAFE POINT against the race it exists to close.
+
+   A persistent index on konserve writes every value the new state references
+   and only THEN the pointer that makes them reachable. Inside that window the
+   fresh values are reachable from nothing while already being older than `now`,
+   so a sweep with a `now` cutoff deletes them and the pointer lands on holes.
+
+   These tests assert the property directly — a sweep concurrent with an
+   unguarded sequence eats its values; the same sweep with the guard held spares
+   them — rather than asserting the shape of the bookkeeping."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.core.async :refer [<!!]]
+            [konserve.core :as k]
+            [konserve.gc :as gc]
+            [konserve.gc-guard :as guard]
+            [konserve.memory :refer [new-mem-store]]
+            [konserve.utils :as utils]))
+
+(defn- fresh-store [] (<!! (new-mem-store)))
+
+(defn- cutoff-after-writes
+  "A collection-start instant strictly greater than every stamp issued so far.
+
+   Derived rather than observed: the write clock is pinned to wall time, so a
+   cutoff read straight after a write lands in the SAME millisecond about as
+   often as not, and the sweep spares ties (fail-safe). Sleeping to let the
+   millisecond turn over would make the test slow and still probabilistic; the
+   successor of the current high-water mark is exact."
+  []
+  (let [t (inc (utils/monotonic-now-ms))]
+    #?(:clj (java.util.Date. t) :cljs (js/Date. t))))
+
+(deftest safe-point-is-now-when-nothing-in-flight
+  (testing "no sequence open => the mark's verdict on everything written so far
+            is final, so the cutoff is the caller's own instant"
+    (let [sid (random-uuid)
+          before (utils/now)
+          sp (guard/safe-point sid)]
+      (is (not (guard/in-flight? sid)))
+      (is (>= (.getTime sp) (.getTime before))))))
+
+(deftest safe-point-retreats-to-the-oldest-open-sequence
+  (testing "the cutoff is the START of the oldest in-flight sequence, so every
+            object that sequence writes lands at or after it and is spared"
+    ;; Drive the clock rather than waiting on wall time: the stamps are pinned to
+    ;; wall time, so consecutive reads land in the same millisecond and could not
+    ;; distinguish a retreating safe point from a stationary one.
+    ;;
+    ;; The high-water mark is process-global and `max`-based, so driving it
+    ;; forward here would leave every LATER test stamping ahead of wall time —
+    ;; which silently breaks any test that compares a write stamp against a
+    ;; cutoff (including this file's own sweep tests). Restore it.
+    (let [sid (random-uuid)
+          stamp-atom @#'utils/last-stamp
+          saved @stamp-atom
+          clock (atom (+ 1000 (utils/monotonic-now-ms)))]
+      (try
+        (binding [utils/*wall-clock-ms* #(deref clock)]
+          (let [t1 (guard/writing! sid)
+                _ (swap! clock + 1000)
+                t2 (guard/writing! sid)
+                _ (swap! clock + 1000)
+                sp (guard/safe-point sid)
+                latest (utils/now)]
+            (is (guard/in-flight? sid))
+            (is (< (.getTime sp) (.getTime latest))
+                "safe point must not be `now` while a sequence is open")
+            (guard/done! sid t2)
+            (is (= (.getTime sp) (.getTime (guard/safe-point sid)))
+                "closing the YOUNGER sequence must not advance the safe point")
+            (guard/done! sid t1)
+            (is (not (guard/in-flight? sid)))
+            (is (>= (.getTime (guard/safe-point sid)) (.getTime latest))
+                "with all sequences closed the safe point returns to now")))
+        (finally (reset! stamp-atom saved))))))
+
+(deftest sweep-without-the-guard-eats-an-unrooted-write
+  (testing "the bug this guard exists for: values written but not yet pointed at
+            are older than the collection's start, so a `now` cutoff deletes them"
+    (let [store (fresh-store)
+          sid (random-uuid)]
+      ;; values land, pointer has NOT yet been written
+      (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
+      (<!! (k/assoc store :value-2 {:node :data} {:sync? false}))
+      (let [started (cutoff-after-writes)
+            ;; whitelist holds only the (still old) pointer, as a real mark would
+            deleted (<!! (gc/sweep! store #{:root} started 1000 {}))]
+        (is (contains? (set deleted) :value-1))
+        (is (contains? (set deleted) :value-2))
+        (is (nil? (<!! (k/get store :value-1 nil {:sync? false})))
+            "unguarded: the sweep destroyed values the pointer was about to reference")))))
+
+(deftest sweep-with-the-guard-spares-the-unrooted-write
+  (testing "same sequence, guard held: sweep! derives min(ts, safe-point) from
+            :store-id and leaves the in-flight values alone"
+    (let [store (fresh-store)
+          sid (random-uuid)
+          token (guard/writing! sid)]
+      (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
+      (<!! (k/assoc store :value-2 {:node :data} {:sync? false}))
+      (let [started (cutoff-after-writes)
+            deleted (<!! (gc/sweep! store #{:root} started 1000 {:store-id sid}))]
+        (is (empty? deleted) "nothing may be collected while the sequence is open")
+        (is (some? (<!! (k/get store :value-1 nil {:sync? false}))))
+        (is (some? (<!! (k/get store :value-2 nil {:sync? false})))))
+      ;; pointer lands, sequence closes, and a later sweep may collect normally
+      (guard/done! sid token)
+      (is (not (guard/in-flight? sid))))))
+
+(deftest guard-is-shared-across-independent-writers-on-one-store
+  (testing "the reason this lives in konserve: two index structures sharing a
+            store must see each other's in-flight sequences, because ONE sweep
+            covers both"
+    (let [store (fresh-store)
+          sid (random-uuid)
+          ;; writer A (say a datahike commit) opens a sequence
+          token-a (guard/writing! sid)]
+      (<!! (k/assoc store :a-value {:from :a} {:sync? false}))
+      ;; writer B (say a scriptum manifest sync) triggers a collection
+      (let [started (cutoff-after-writes)
+            deleted (<!! (gc/sweep! store #{} started 1000 {:store-id sid}))]
+        (is (empty? deleted)
+            "B's sweep must not collect A's in-flight values")
+        (is (some? (<!! (k/get store :a-value nil {:sync? false})))))
+      (guard/done! sid token-a))))
+
+#?(:clj
+   (deftest with-unreferenced-writes-closes-on-throw
+     (testing "a sequence that dies mid-way drops its entry — its objects are
+               unreachable, i.e. garbage, and a later cycle collects them"
+       (let [sid (random-uuid)]
+         (is (thrown? Exception
+                      (guard/with-unreferenced-writes sid
+                        (is (guard/in-flight? sid))
+                        (throw (ex-info "torn write" {})))))
+         (is (not (guard/in-flight? sid))
+             "the guard must not leak and wedge GC forever")))))

--- a/test/konserve/gc_guard_test.cljc
+++ b/test/konserve/gc_guard_test.cljc
@@ -15,7 +15,7 @@
             [clojure.string]
             [konserve.gc-guard :as guard]
             [konserve.utils :as utils]
-            #?@(:clj [[clojure.core.async :refer [<!!]]
+            #?@(:clj [[clojure.core.async :as async :refer [<! <!!]]
                       [konserve.core :as k]
                       [konserve.gc :as gc]
                       [konserve.store :as ks]
@@ -209,6 +209,62 @@
                          "the open sequence pinned the cutoff before its own writes")
                      (is (some? (<!! (k/get store :v1 nil {:sync? false})))
                          "so :root's target survives"))))))
+           (finally (reset! stamp-atom saved)))))))
+
+#?(:clj
+   (deftest the-guard-survives-an-async-body
+     (testing "REGRESSION: konserve's default is {:sync? false}, so the most
+               idiomatic body here returns a CHANNEL — and a plain try/finally
+               releases the guard when the go block is CONSTRUCTED, before a
+               single write has happened. The form was a no-op for exactly the
+               usage it most needs to cover."
+       (let [sid (random-uuid)
+             seen-inside (promise)
+             release (async/chan)
+             result (guard/with-unreferenced-writes sid
+                      (async/go
+                        (<! release)
+                        (deliver seen-inside (guard/in-flight? sid))
+                        :done))]
+         (is (guard/in-flight? sid)
+             "the sequence must still be open while the body runs")
+         (async/close! release)
+         (is (= :done (<!! result)) "the body's value must reach the caller")
+         (is (true? @seen-inside)
+             "and the guard must have been held for the body's whole extent")
+         (is (not (guard/in-flight? sid))
+             "closing once the channel delivers")))))
+
+#?(:clj
+   (deftest a-sync-body-still-closes-eagerly-and-on-throw
+     (let [sid (random-uuid)]
+       (is (= :v (guard/with-unreferenced-writes sid :v)))
+       (is (not (guard/in-flight? sid)) "a value body closes immediately")
+       (is (thrown? Exception (guard/with-unreferenced-writes sid
+                                (throw (ex-info "boom" {})))))
+       (is (not (guard/in-flight? sid)) "and a throwing body still closes"))))
+
+#?(:clj
+   (deftest a-leaked-sequence-is-visible-and-can-be-forced-shut
+     (testing "a leaked entry stops collection on the store for the life of the
+               process, silently. Nothing expires it automatically — a genuinely
+               long sequence is legitimate — so it has to be observable."
+       (let [sid (random-uuid)
+             stamp-atom @#'utils/last-stamp
+             saved @stamp-atom
+             clock (atom (+ 1000 (utils/monotonic-now-ms)))]
+         (try
+           (binding [utils/*wall-clock-ms* #(deref clock)]
+             (let [_leaked (guard/writing! sid)]      ; token dropped on the floor
+               (is (empty? (guard/stale sid 10000))
+                   "a young sequence is not stale")
+               (swap! clock + 60000)
+               (is (= 1 (count (guard/stale sid 10000)))
+                   "an old one is reported")
+               (is (guard/in-flight? sid))
+               (is (= 1 (count (guard/sweep-stale! sid 10000))))
+               (is (not (guard/in-flight? sid))
+                   "and forcing it shut lets collection resume")))
            (finally (reset! stamp-atom saved)))))))
 
 #?(:clj

--- a/test/konserve/gc_guard_test.cljc
+++ b/test/konserve/gc_guard_test.cljc
@@ -6,30 +6,22 @@
    fresh values are reachable from nothing while already being older than `now`,
    so a sweep with a `now` cutoff deletes them and the pointer lands on holes.
 
-   These tests assert the property directly — a sweep concurrent with an
-   unguarded sequence eats its values; the same sweep with the guard held spares
-   them — rather than asserting the shape of the bookkeeping."
+   The guard's own logic is platform-independent and tested on both. The tests
+   that assert the CONSEQUENCE — a sweep eating or sparing real values — drive
+   a store with blocking takes and so are JVM-only; `konserve.gc/sweep!` is
+   async-only, and expressing these as cljs async tests would obscure what they
+   are demonstrating without covering anything the guard does differently there."
   (:require [clojure.test :refer [deftest is testing]]
-            [clojure.core.async :refer [<!!]]
-            [konserve.core :as k]
-            [konserve.gc :as gc]
             [konserve.gc-guard :as guard]
-            [konserve.memory :refer [new-mem-store]]
-            [konserve.utils :as utils]))
+            [konserve.utils :as utils]
+            #?@(:clj [[clojure.core.async :refer [<!!]]
+                      [konserve.core :as k]
+                      [konserve.gc :as gc]
+                      [konserve.memory :refer [new-mem-store]]])))
 
-(defn- fresh-store [] (<!! (new-mem-store)))
-
-(defn- cutoff-after-writes
-  "A collection-start instant strictly greater than every stamp issued so far.
-
-   Derived rather than observed: the write clock is pinned to wall time, so a
-   cutoff read straight after a write lands in the SAME millisecond about as
-   often as not, and the sweep spares ties (fail-safe). Sleeping to let the
-   millisecond turn over would make the test slow and still probabilistic; the
-   successor of the current high-water mark is exact."
-  []
-  (let [t (inc (utils/monotonic-now-ms))]
-    #?(:clj (java.util.Date. t) :cljs (js/Date. t))))
+;; =============================================================================
+;; Guard logic — both platforms
+;; =============================================================================
 
 (deftest safe-point-is-now-when-nothing-in-flight
   (testing "no sequence open => the mark's verdict on everything written so far
@@ -75,55 +67,18 @@
                 "with all sequences closed the safe point returns to now")))
         (finally (reset! stamp-atom saved))))))
 
-(deftest sweep-without-the-guard-eats-an-unrooted-write
-  (testing "the bug this guard exists for: values written but not yet pointed at
-            are older than the collection's start, so a `now` cutoff deletes them"
-    (let [store (fresh-store)
-          sid (random-uuid)]
-      ;; values land, pointer has NOT yet been written
-      (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
-      (<!! (k/assoc store :value-2 {:node :data} {:sync? false}))
-      (let [started (cutoff-after-writes)
-            ;; whitelist holds only the (still old) pointer, as a real mark would
-            deleted (<!! (gc/sweep! store #{:root} started 1000 {}))]
-        (is (contains? (set deleted) :value-1))
-        (is (contains? (set deleted) :value-2))
-        (is (nil? (<!! (k/get store :value-1 nil {:sync? false})))
-            "unguarded: the sweep destroyed values the pointer was about to reference")))))
-
-(deftest sweep-with-the-guard-spares-the-unrooted-write
-  (testing "same sequence, guard held: sweep! derives min(ts, safe-point) from
-            :store-id and leaves the in-flight values alone"
-    (let [store (fresh-store)
-          sid (random-uuid)
-          token (guard/writing! sid)]
-      (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
-      (<!! (k/assoc store :value-2 {:node :data} {:sync? false}))
-      (let [started (cutoff-after-writes)
-            deleted (<!! (gc/sweep! store #{:root} started 1000 {:store-id sid}))]
-        (is (empty? deleted) "nothing may be collected while the sequence is open")
-        (is (some? (<!! (k/get store :value-1 nil {:sync? false}))))
-        (is (some? (<!! (k/get store :value-2 nil {:sync? false})))))
-      ;; pointer lands, sequence closes, and a later sweep may collect normally
-      (guard/done! sid token)
-      (is (not (guard/in-flight? sid))))))
-
-(deftest guard-is-shared-across-independent-writers-on-one-store
-  (testing "the reason this lives in konserve: two index structures sharing a
-            store must see each other's in-flight sequences, because ONE sweep
-            covers both"
-    (let [store (fresh-store)
-          sid (random-uuid)
-          ;; writer A (say a datahike commit) opens a sequence
-          token-a (guard/writing! sid)]
-      (<!! (k/assoc store :a-value {:from :a} {:sync? false}))
-      ;; writer B (say a scriptum manifest sync) triggers a collection
-      (let [started (cutoff-after-writes)
-            deleted (<!! (gc/sweep! store #{} started 1000 {:store-id sid}))]
-        (is (empty? deleted)
-            "B's sweep must not collect A's in-flight values")
-        (is (some? (<!! (k/get store :a-value nil {:sync? false})))))
-      (guard/done! sid token-a))))
+(deftest cutoff-never-runs-ahead-of-the-collection-start
+  (testing "`cutoff` takes the min, so a caller cannot collect into the future
+            by passing a later instant — and cannot miss an open sequence"
+    (let [sid (random-uuid)
+          started (utils/now)]
+      (is (= (.getTime started) (.getTime (guard/cutoff sid started)))
+          "idle: the collection's own instant stands")
+      (let [t (guard/writing! sid)]
+        (try
+          (is (<= (.getTime (guard/cutoff sid started)) (.getTime started))
+              "in flight: the cutoff retreats, never advances")
+          (finally (guard/done! sid t)))))))
 
 #?(:clj
    (deftest with-unreferenced-writes-closes-on-throw
@@ -136,3 +91,73 @@
                         (throw (ex-info "torn write" {})))))
          (is (not (guard/in-flight? sid))
              "the guard must not leak and wedge GC forever")))))
+
+;; =============================================================================
+;; Consequence for a real sweep — JVM only (sweep! is async-only)
+;; =============================================================================
+
+#?(:clj
+   (defn- fresh-store [] (<!! (new-mem-store))))
+
+#?(:clj
+   (defn- cutoff-after-writes
+     "A collection-start instant strictly greater than every stamp issued so far.
+
+      Derived rather than observed: the write clock is pinned to wall time, so a
+      cutoff read straight after a write lands in the SAME millisecond about as
+      often as not, and the sweep spares ties (fail-safe). Sleeping to let the
+      millisecond turn over would make the test slow and still probabilistic; the
+      successor of the current high-water mark is exact."
+     []
+     (java.util.Date. (inc (utils/monotonic-now-ms)))))
+
+#?(:clj
+   (deftest sweep-without-the-guard-eats-an-unrooted-write
+     (testing "the bug this guard exists for: values written but not yet pointed at
+               are older than the collection's start, so a `now` cutoff deletes them"
+       (let [store (fresh-store)]
+         ;; values land, pointer has NOT yet been written
+         (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
+         (<!! (k/assoc store :value-2 {:node :data} {:sync? false}))
+         (let [started (cutoff-after-writes)
+               ;; whitelist holds only the (still old) pointer, as a real mark would
+               deleted (<!! (gc/sweep! store #{:root} started 1000 {}))]
+           (is (contains? (set deleted) :value-1))
+           (is (contains? (set deleted) :value-2))
+           (is (nil? (<!! (k/get store :value-1 nil {:sync? false})))
+               "unguarded: the sweep destroyed values the pointer was about to reference"))))))
+
+#?(:clj
+   (deftest sweep-with-the-guard-spares-the-unrooted-write
+     (testing "same sequence, guard held: sweep! derives min(ts, safe-point) from
+               :store-id and leaves the in-flight values alone"
+       (let [store (fresh-store)
+             sid (random-uuid)
+             token (guard/writing! sid)]
+         (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
+         (<!! (k/assoc store :value-2 {:node :data} {:sync? false}))
+         (let [started (cutoff-after-writes)
+               deleted (<!! (gc/sweep! store #{:root} started 1000 {:store-id sid}))]
+           (is (empty? deleted) "nothing may be collected while the sequence is open")
+           (is (some? (<!! (k/get store :value-1 nil {:sync? false}))))
+           (is (some? (<!! (k/get store :value-2 nil {:sync? false})))))
+         (guard/done! sid token)
+         (is (not (guard/in-flight? sid)))))))
+
+#?(:clj
+   (deftest guard-is-shared-across-independent-writers-on-one-store
+     (testing "the reason this lives in konserve: two index structures sharing a
+               store must see each other's in-flight sequences, because ONE sweep
+               covers both"
+       (let [store (fresh-store)
+             sid (random-uuid)
+             ;; writer A (say a datahike commit) opens a sequence
+             token-a (guard/writing! sid)]
+         (<!! (k/assoc store :a-value {:from :a} {:sync? false}))
+         ;; writer B (say a scriptum manifest sync) triggers a collection
+         (let [started (cutoff-after-writes)
+               deleted (<!! (gc/sweep! store #{} started 1000 {:store-id sid}))]
+           (is (empty? deleted)
+               "B's sweep must not collect A's in-flight values")
+           (is (some? (<!! (k/get store :a-value nil {:sync? false})))))
+         (guard/done! sid token-a)))))

--- a/test/konserve/gc_guard_test.cljc
+++ b/test/konserve/gc_guard_test.cljc
@@ -15,6 +15,7 @@
             [clojure.string]
             [konserve.gc-guard :as guard]
             [konserve.utils :as utils]
+            [konserve.protocols :as p]
             #?@(:clj [[clojure.core.async :as async :refer [<! <!!]]
                       [konserve.core :as k]
                       [konserve.gc :as gc]
@@ -336,6 +337,43 @@
            (is (empty? (<!! (gc/sweep! store #{}
                                        (guard/cutoff sid (cutoff-after-writes))))))
            (guard/done! sid token))))))
+
+#?(:clj
+   (defrecord PhysicallyIdentifiedStore [path logical-config]
+     p/PStoreConfig
+     (-store-config [_]
+       (assoc logical-config :id (java.util.UUID/nameUUIDFromBytes (.getBytes ^String path))))))
+
+#?(:clj
+   (deftest a-backend-may-key-the-guard-by-where-its-bytes-are
+     (testing "the escape hatch for the one unsafe direction.
+
+               konserve's `:id` is LOGICAL — the same store on another machine
+               carries it too. The guard needs an id never FINER than the bytes a
+               sweep deletes, and the logical id is coarser, which is the safe
+               side. What it cannot rule out is the same bytes opened twice under
+               different ids, and no amount of validation from konserve's side
+               can: `validate-store-config` only checks that `:id` is a UUID.
+
+               A backend that knows where its bytes live can implement
+               `PStoreConfig` and settle it, which is why this is worth pinning
+               before any backend does."
+       (let [logical (random-uuid)
+             a (->PhysicallyIdentifiedStore "/var/data/store-1" {:backend :file :id logical})
+             ;; same bytes, configs written with different ids — the unsafe case
+             b (->PhysicallyIdentifiedStore "/var/data/store-1" {:backend :file :id (random-uuid)})
+             ;; a replica: different bytes, one logical id — merely conservative
+             c (->PhysicallyIdentifiedStore "/var/data/store-2" {:backend :file :id logical})]
+         (is (not= logical (p/store-id a))
+             "a direct implementation must win over the Object default")
+         (is (= (p/store-id a) (p/store-id b))
+             "same bytes must share a guard key however the configs were written")
+         (is (not= (p/store-id a) (p/store-id c))
+             "and replicas must not hold each other's collections back"))
+       (testing "a store that does NOT override still reports its logical id"
+         (let [id (random-uuid)
+               store (ks/create-store {:backend :memory :id id} {:sync? true})]
+           (is (= id (ks/store-id store))))))))
 
 #?(:clj
    (deftest credentials-are-stripped-at-every-depth

--- a/test/konserve/gc_guard_test.cljc
+++ b/test/konserve/gc_guard_test.cljc
@@ -17,6 +17,7 @@
             #?@(:clj [[clojure.core.async :refer [<!!]]
                       [konserve.core :as k]
                       [konserve.gc :as gc]
+                      [konserve.store :as ks]
                       [konserve.memory :refer [new-mem-store]]])))
 
 ;; =============================================================================
@@ -161,3 +162,38 @@
                "B's sweep must not collect A's in-flight values")
            (is (some? (<!! (k/get store :a-value nil {:sync? false})))))
          (guard/done! sid token-a)))))
+
+#?(:clj
+   (deftest sweep-consults-the-guard-without-being-told-the-store-id
+     (testing "a store connected through konserve.store names itself, so the
+               guard applies with no :store-id argument at all — the case where
+               a caller and a writer could otherwise disagree about the name"
+       (let [id (random-uuid)
+             store (ks/create-store {:backend :memory :id id} {:sync? true})]
+         (is (= id (ks/store-id store)) "the store must carry its own id")
+         (let [token (guard/writing! id)]
+           (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
+           ;; No :store-id passed. The sweep has to find it on the store.
+           (let [deleted (<!! (gc/sweep! store #{} (cutoff-after-writes) 1000 {}))]
+             (is (empty? deleted)
+                 "the derived id must reach the guard and spare the in-flight write")
+             (is (some? (<!! (k/get store :value-1 nil {:sync? false})))))
+           (guard/done! id token))
+         ;; With the sequence closed the same sweep collects normally, which
+         ;; proves the emptiness above came from the guard and not from a sweep
+         ;; that simply never ran.
+         (let [deleted (<!! (gc/sweep! store #{} (cutoff-after-writes) 1000 {}))]
+           (is (contains? (set deleted) :value-1)))))))
+
+#?(:clj
+   (deftest an-explicit-store-id-still-wins
+     (testing "a store built through a backend constructor never took an id, so
+               the caller must still be able to supply one"
+       (let [store (fresh-store)
+             sid (random-uuid)]
+         (is (nil? (ks/store-id store)))
+         (let [token (guard/writing! sid)]
+           (<!! (k/assoc store :value-1 {:node :data} {:sync? false}))
+           (is (empty? (<!! (gc/sweep! store #{} (cutoff-after-writes) 1000
+                                       {:store-id sid}))))
+           (guard/done! sid token))))))

--- a/test/konserve/gc_guard_test.cljc
+++ b/test/konserve/gc_guard_test.cljc
@@ -338,6 +338,39 @@
            (guard/done! sid token))))))
 
 #?(:clj
+   (deftest credentials-are-stripped-at-every-depth
+     (testing "REGRESSION: konserve configs NEST — a :tiered store's config holds
+               a whole :frontend-config and :backend-config, each a complete
+               store config with its own secrets (konserve.store's :tiered
+               methods). A top-level dissoc walked straight past those and parked
+               them on the store, which is worse than never attaching a config:
+               before, they were only in a map the caller held.
+
+               The AES key is checked too. It lives at :encryptor {:type :aes
+               :key ...}, and `:key` is far too common a word to put in
+               `credential-keys`, so it is stripped by name instead."
+       (let [id (random-uuid)
+             store (ks/create-store
+                    {:backend :tiered :id id
+                     :frontend-config {:backend :memory :id id}
+                     :backend-config {:backend :file :id id
+                                      :path (str "/tmp/konserve-cred-test-" (random-uuid))
+                                      :access-key "AKIAEXAMPLE"
+                                      :secret "shhh-nested"
+                                      :password "hunter2"
+                                      :jdbcUrl "jdbc://user:pw@host/db"}
+                     :config {:encryptor {:type :aes :key "s3cr3t-aes-key"}}}
+                    {:sync? true})
+             cfg (ks/store-config store)
+             printed (pr-str store)]
+         (is (= id (:id cfg)) "identity survives")
+         (is (= :file (get-in cfg [:backend-config :backend]))
+             "and so does the shape — this strips secrets, not structure")
+         (doseq [leak ["AKIAEXAMPLE" "shhh-nested" "hunter2" "user:pw" "s3cr3t-aes-key"]]
+           (is (not (clojure.string/includes? printed leak))
+               (str "printing the store must not reveal " (pr-str leak))))))))
+
+#?(:clj
    (deftest attached-config-identifies-without-carrying-secrets
      (testing "the store reports the config it was connected with"
        (let [id (random-uuid)


### PR DESCRIPTION
## The race

A persistent index on konserve writes every value the new state references and **only then** the pointer that makes them reachable. That ordering is what makes a torn write leave collectable orphans rather than a dangling pointer.

It is also a blind spot for the collector. Inside that window the fresh values are reachable from nothing while *already being older than `now`* — so a sweep cutting off at `now` deletes them, and the pointer then lands on holes. A timestamp cutoff cannot save you here, because the objects genuinely predate the collection.

## Why it belongs in konserve

datahike has carried a private guard for this. It shouldn't.

One konserve store commonly carries several independent index structures — a datahike database, a geschichte repository, a scriptum fulltext index — each running its own values-then-pointer sequences, and **one sweep covers all of them**. A guard held inside one library cannot protect the others. The safe point is a property of the store, and it is shared by agreeing on a `store-id`.

The state across the stack today, which is the case for consolidating:

- **datahike** — `datahike.gc-guard`, 124 lines, seven call sites in `versioning` / `writing` / `migrate`. Works.
- **proximum** — `konserve.gc/sweep!` at `gc.clj:230`, no guard at all.
- **stratum** — a per-store JVM monitor serializing `ds-sync!` against `gc!`. Correct, but coarser than needed, and it does not use `konserve.gc`.
- **scriptum** — its konserve-backed index is written against this branch.

Four answers to one problem, one of them missing.

## What changed

Three separable things — worth reviewing as three.

**1. The guard (`a87f8e2`, `e8c1b15`).** `konserve.gc-guard` — `writing!` / `done!` / `in-flight?` / `safe-point` / `cutoff` / `with-unreferenced-writes`, keyed by `store-id`, stamped from the existing monotonic write clock (`konserve.utils/now`).

`konserve.gc/sweep!` takes a plain `cutoff` and states as a precondition that a caller on a guarded store derives it from `guard/cutoff` **before** marking. It does not read the guard itself — see the correction below for why it cannot.

**2. Store identity (`53da620`, `a911bf8`).** A prerequisite, not a drive-by: the guard is keyed by store id, and its whole value is that everyone agrees on it. `validate-store-config` has always required a UUID `:id`, but every backend then dropped it, so callers passed the id alongside the store by hand — and disagreement there is invisible until a collection deletes something. New `PStoreConfig` lets a store answer what it was connected with.

Non-breaking for backends: `extend-protocol PStoreConfig Object` supplies a default reading what `konserve.store` attaches on connect, so nothing out-of-tree has to implement anything.

**3. Credential stripping (`a911bf8`), which deserves its own line.** Store configs carry `:access-key`, `:secret`, `:password`, `:jdbcUrl`. Fine in a map a caller passes once; not fine sitting on a long-lived object that any `pr-str`, log line or `ex-info` payload might carry off. `credential-keys` strips them before the config is attached. Identity survives, which is what makes it useful.

## Correction: `sweep!` no longer consults the guard at all

The original description of this PR said `sweep!` derives `min(ts, safe-point)` itself. **That was wrong and is now removed**, because it cannot work: `sweep!` receives `whitelist` as a parameter, so the caller has already marked, and any guard reading `sweep!` does is necessarily *after* that mark. A sequence that lands its pointer in between is invisible to both — the mark walked roots that did not name its values yet, and by sweep time the guard is closed, so the cutoff snaps back to `ts` and the values are deleted under a live pointer.

Reproduced against the branch as it stood:

```
mark → sweep (what the auto-consultation invited):
  deleted #{:v1 :v2}   :root {:points-to [:v1 :v2]}   => DANGLING POINTER

cutoff → mark → sweep (what gc-guard's docstring always prescribed):
  deleted #{}          :v1 survives
```

So the contract is now explicit and the caller owns the ordering:

```clj
(let [cutoff    (guard/cutoff store-id (utils/now))   ; 1. guard
      whitelist (mark-reachable! store)]              ; 2. mark
  (sweep! store whitelist cutoff))                    ; 3. sweep
```

`sweep!` takes a plain `cutoff` and no `:store-id`. Its docstring states the precondition and says *why* `sweep!` deliberately does not do this itself. `datahike.gc` already does exactly this (`gc.cljc:242` reads `safe-point` before walking), so datahike needs no change here — it was the correct usage all along, and the auto-consultation would have been a silent trap for everyone else.

Added `the-guard-must-be-read-before-the-mark`, which asserts both halves: mark-first deletes `:v1` and leaves `:root` dangling; guard-first spares it. It drives the clock rather than waiting on wall time, because at millisecond granularity the sweep spares ties and a real-time version proves nothing about half the time.

## Settled: the logical `:id` is the default, not the requirement

`:id` is konserve's LOGICAL identity — a replica on another machine carries the same one. The guard needs an id never *finer* than the bytes a sweep deletes, and of the three cases only one is unsafe:

| case | outcome |
| --- | --- |
| Same bytes, same id | the intended case |
| Two stores sharing one id (store + replica) | each sweep held back by the other's writers: conservative, nothing lost |
| **Same bytes, two ids** | the sweep cannot see the other writer's in-flight objects and **deletes live data** |

A logical id is coarser, which is the safe side. konserve cannot rule the last case out from its side — `validate-store-config` only checks that `:id` is a UUID, and nothing binds it to a path.

**But a backend can.** `PStoreConfig` is overridable, a direct implementation wins over the `Object` default, and nothing in konserve besides the guard reads `store-id` — so a backend that knows where its bytes live may return an id derived from that, closing *both* mismatches at once: two connections to one path collapse onto one guard key however their configs were written, and replicas stop holding each other's collections back. `a-backend-may-key-the-guard-by-where-its-bytes-are` pins that contract now, so the first backend to adopt it has something to build against.

Until then the default is sound for the same reason the guard is in-process at all: a logical store is normally connected once per runtime, so within a process one id names one store. The unsafe case needs the same bytes opened twice in one process under different ids — deliberate, and visible at the call site.

## Tests

The tests assert the property rather than the bookkeeping: the same sweep over the same in-flight sequence **eats its values unguarded and spares them guarded**, and a sweep triggered by one writer spares another writer's in-flight values on a shared store.

Two things worth flagging for review, both learned the hard way here:

- Cutoffs are **derived** (successor of the high-water mark), not observed. The write clock is pinned to wall time, so a cutoff read straight after a write ties with it about half the time and the sweep spares ties — the first version of this test was flaky for exactly that reason.
- Where the clock does have to move, the global high-water mark is **restored afterwards**. It is `max`-based and process-wide, so leaving it advanced makes every later test stamp ahead of wall time; unrestored, it broke `monotonic-clock-test` and `async-gc-test` in the same run.

Green on JVM (238 tests / 3893 assertions) and ClojureScript (61 / 346); the cljs build compiles with 0 warnings.

## Scope, and what this does not do

`gc.cljc` +26, `gc_guard.cljc` +139 (new), `protocols.cljc` +60, `store.cljc` +53, `gc_guard_test.cljc` +227 (new).

Scope is **in-process**, matching konserve's concurrency contract (single writer per runtime, or coordinate above konserve). It does nothing for writers in another process, which are outside that contract already.

It also does **not** make store-sharing safe on its own. A sweep still uses one library's reachable set, so sharing a physical store between datahike, proximum and scriptum needs a shared *mark* protocol too, not just a shared safe point.

## Follow-ups (not in this PR)

Landing order, cheapest validation first and live bugs before churn:

1. **scriptum** — already written against this API; unblocks its konserve backing.
2. **proximum** — the only consumer sweeping with no guard. Live bug.
3. **datahike** — drop the local copy for this one, in the same release so the two cannot disagree about the clock. Its guard works, so this is consolidation, not a fix.
4. **stratum** — port its GC over for consistency. Larger than a bump: it does not use `konserve.gc` at all, so adopting the guard means adopting the sweep first.

## Also here, from a review pass over the branch

- **`sweep!` honours `{:sync? true}`.** It was the only konserve fn forcing async, so synchronous callers bridged with `<!!` — which deadlocks inside a go block, and scriptum's `gc!` is reachable from async contexts. Sync mode keeps the per-key concurrency of the non-multi-key branch (the one the FILESTORE takes) via `pmap`, measured bounded at `cpus + 2`.
- **`with-unreferenced-writes` now works for async bodies.** `try`/`finally` released the guard at go-block *construction*, making the form a no-op for konserve's own `{:sync? false}` default.
- **A leaked sequence is visible and recoverable** — `stale` / `sweep-stale!`. Neither expires anything on its own, since a long sequence is legitimate.
- **Credentials are stripped at every depth.** A `:tiered` config nests two whole store configs; the top-level `dissoc` walked past their secrets and parked them on the store — a leak this branch would otherwise have introduced.
