### PR TITLE
Memoise the boring read registry instead of refolding it per read

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/data.fressian {:mvn/version "1.0.0"} ;; for filestore
         mvxcvi/clj-cbor {:mvn/version "1.1.1"} ;; legacy: serializer byte 2, JVM-only
-        org.replikativ/boring {:mvn/version "0.1.4"} ;; serializer byte 3, portable
+        org.replikativ/boring {:mvn/version "0.1.6"} ;; serializer byte 3, portable
         org.replikativ/incognito {:mvn/version "0.3.69"}
         org.replikativ/hasch {:mvn/version "0.3.96"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}

--- a/src/konserve/serializers.cljc
+++ b/src/konserve/serializers.cljc
@@ -90,11 +90,17 @@
 
   Takes the handler MAP, already deref'd: `registry-for` below derefs once and
   memoises on the result, so dereferencing again here would both re-read a
-  changing atom mid-computation and fail outright when handed the map."
+  changing atom mid-computation and fail outright when handed the map.
+
+  One `register-records` rather than a fold of `register-record`: a registry
+  copies its whole backing map per registration, so the fold was quadratic in
+  the handler count -- 4.84 us at 20 handlers against 0.82. The cache below
+  means this runs rarely, but a cache miss should not be quadratic either.
+  Symbol keys are stringified by boring, so incognito's map needs no
+  preparation."
   [registry handlers]
   (if (seq handlers)
-    (reduce-kv (fn [reg tag ctor] (boring/register-record reg (str tag) ctor))
-               registry handlers)
+    (boring/register-records registry handlers)
     registry))
 
 (def ^:private ^:const registry-cache-size

--- a/src/konserve/serializers.cljc
+++ b/src/konserve/serializers.cljc
@@ -86,21 +86,48 @@
   natively via CBOR tag 27, which is the problem incognito exists to work
   around for fressian. Only the read direction has to be taught anything, and
   an unregistered record still decodes to an inert value carrying its name and
-  fields rather than being lost."
-  [registry read-handlers]
-  (let [handlers (some-> read-handlers deref)]
-    (if (seq handlers)
-      (reduce-kv (fn [reg tag ctor] (boring/register-record reg (str tag) ctor))
-                 registry handlers)
-      registry)))
+  fields rather than being lost.
 
-(defrecord BoringSerializer [registry encode-opts]
+  Takes the handler MAP, already deref'd: `registry-for` below derefs once and
+  memoises on the result, so dereferencing again here would both re-read a
+  changing atom mid-computation and fail outright when handed the map."
+  [registry handlers]
+  (if (seq handlers)
+    (reduce-kv (fn [reg tag ctor] (boring/register-record reg (str tag) ctor))
+               registry handlers)
+    registry))
+
+(defn- registry-cache
+  "Memoise `record-registry` against the handler atom's current value.
+
+  `TagRegistry`'s `withRecord` copies the whole backing map, so folding N
+  handlers on every read is N map copies per read. Measured on a small map:
+  0.29 us with no handlers, 5.40 us with 20 -- while fressian, which merges
+  persistent maps once, stays flat near 5 us and overtakes us past ~20
+  handlers.
+
+  Handler atoms change a handful of times in a store's life, so an `identical?`
+  check on the deref'd persistent map is both exact and free. Keyed on the base
+  registry too: keying on the handlers alone would serve a stale registry after
+  someone `swap!`s a new tag into the serializer's own registry."
+  []
+  (atom {:base ::none :src ::none :reg nil}))
+
+(defn- registry-for [cache base handlers-atom]
+  (let [h (if handlers-atom @handlers-atom {})
+        c @cache]
+    (if (and (identical? (:base c) base) (identical? (:src c) h))
+      (:reg c)
+      (:reg (reset! cache {:base base :src h
+                           :reg (record-registry base h)})))))
+
+(defrecord BoringSerializer [registry encode-opts cache]
   #?@(:cljs (INamed
              (-name [_] "BoringSerializer")
              (-namespace [_] "konserve.serializers")))
   PStoreSerializer
   (-deserialize [_ read-handlers input]
-    (let [opts (assoc encode-opts :registry (record-registry registry read-handlers))]
+    (let [opts (assoc encode-opts :registry (registry-for cache registry read-handlers))]
       #?(:clj  (boring/decode (.readAllBytes ^java.io.InputStream input) opts)
          :cljs (boring/decode input opts))))
   (-serialize [_ #?(:clj output-stream :cljs _) write-handlers val]
@@ -123,7 +150,8 @@
   doc/EXTENDING.md). Records need no registration to be WRITTEN."
   ([] (boring-serializer (boring/tag-registry) {}))
   ([registry] (boring-serializer registry {}))
-  ([registry opts] (map->BoringSerializer {:registry registry :encode-opts opts})))
+  ([registry opts] (map->BoringSerializer {:registry registry :encode-opts opts
+                                           :cache (registry-cache)})))
 
 (defrecord StringSerializer []
   #?@(:cljs (INamed

--- a/src/konserve/serializers.cljc
+++ b/src/konserve/serializers.cljc
@@ -97,29 +97,42 @@
                registry handlers)
     registry))
 
-(defn- registry-cache
-  "Memoise `record-registry` against the handler atom's current value.
+(def ^:private ^:const registry-cache-size
+  "How many (base, handlers) pairs one serializer instance remembers.
 
-  `TagRegistry`'s `withRecord` copies the whole backing map, so folding N
-  handlers on every read is N map copies per read. Measured on a small map:
-  0.29 us with no handlers, 5.40 us with 20 -- while fressian, which merges
-  persistent maps once, stays flat near 5 us and overtakes us past ~20
-  handlers.
+  Not 1. `byte->serializer` holds a SINGLE boring serializer instance, shared by
+  every store that does not override it in its config -- so a one-entry cache
+  thrashes the moment two stores with different handler maps are open at once,
+  and falls straight back to refolding per read (measured: 0.20 us -> 5.56 us).
+  A handful of entries covers the realistic case; the scan is pointer
+  comparisons."
+  4)
 
-  Handler atoms change a handful of times in a store's life, so an `identical?`
-  check on the deref'd persistent map is both exact and free. Keyed on the base
-  registry too: keying on the handlers alone would serve a stale registry after
-  someone `swap!`s a new tag into the serializer's own registry."
-  []
-  (atom {:base ::none :src ::none :reg nil}))
+(defn- registry-cache []
+  (atom []))
 
-(defn- registry-for [cache base handlers-atom]
+(defn- registry-for
+  "The read registry for `base` plus `handlers-atom`'s current handlers,
+  memoised.
+
+  Keyed on BOTH the base registry and the handler map, by identity. Keying on
+  the handlers alone would serve a stale registry after someone `swap!`s a new
+  tag into the serializer's own registry: the encoder derefs it per frame, so
+  the same change would take effect for writing and never for reading."
+  [cache base handlers-atom]
   (let [h (if handlers-atom @handlers-atom {})
-        c @cache]
-    (if (and (identical? (:base c) base) (identical? (:src c) h))
-      (:reg c)
-      (:reg (reset! cache {:base base :src h
-                           :reg (record-registry base h)})))))
+        entries @cache
+        hit (some (fn [e] (when (and (identical? (:base e) base)
+                                     (identical? (:src e) h))
+                            e))
+                  entries)]
+    (if hit
+      (:reg hit)
+      (let [reg (record-registry base h)]
+        (swap! cache (fn [es]
+                       (vec (take registry-cache-size
+                                  (cons {:base base :src h :reg reg} es)))))
+        reg))))
 
 (defrecord BoringSerializer [registry encode-opts cache]
   #?@(:cljs (INamed


### PR DESCRIPTION
`record-registry` ran on every `-deserialize`, and each `register-record`
copies `TagRegistry`'s whole backing `HashMap` — so a store with N record
handlers paid **N map copies per read**.

| handlers on store | boring before | boring after | fressian |
|---|---:|---:|---:|
| 0 | 0.29 µs | **0.28 µs** | 4.86 µs |
| 1 | 0.40 | 0.29 | 5.35 |
| 5 | 0.96 | 0.37 | 5.76 |
| 20 | 5.40 | **0.29** | 4.29 |

boring was 17× faster than fressian with no handlers and **lost past ~20**,
entirely on this. It is flat now.

## Why fressian doesn't have this problem

The difference is the data structure, not the codec — worth writing down
because it is the kind of thing that gets rediscovered.

fressian merges **persistent maps**: O(log N) with structural sharing, so its
per-call handler work is ~0.3 µs regardless of N. I verified this rather than
assumed it — rebuilding fressian's lookup every call costs 3.57 µs against 3.27
µs reused, so its ~3.3 µs is inherent decode cost, not handler plumbing.

boring's `TagRegistry` is immutable `java.util.HashMap`s copied whole on every
registration. That is the right trade for a registry built once at startup —
O(1) lookup on the hot path, final fields, no synchronization — and the wrong
one for a protocol that hands you handlers per call. The fix belongs here, in
the caller, not in boring's lookup design.

## The cache key

Keyed on **both** the base registry and the handler map. Keying on the handlers
alone would serve a stale registry after someone `swap!`s a new tag into the
serializer's own registry: the encoder derefs it per frame, so the same change
would take effect for writing and never for reading — silently, in one
direction. That exact bug was caught by review in kabel's copy of this code, so
it is not hypothetical.

`record-registry` now takes the deref'd map rather than the atom, since
`registry-for` derefs once and memoises on the result.

## Behaviour is unchanged

Verified against fressian on the three cases that matter, and they agree
exactly:

- an unregistered record round-trips to an inert tagged value carrying its type
  name and fields — `#boring/record ["user.Rec" {:x 1, :y 2}]` against
  fressian's `IncognitoTaggedLiteral`
- a record with store-level handlers reconstructs as itself, both codecs
- a non-record `deftype` fails in both

99 tests / 1344 assertions, cljfmt clean.