### PR TITLE
Add konserve.binary/to-bytes; fix sync bget on the node filestore

### DIFF
--- a/src/konserve/binary.cljc
+++ b/src/konserve/binary.cljc
@@ -1,0 +1,187 @@
+(ns konserve.binary
+  "Reading a stored binary back as bytes, on every backend and both platforms.
+
+   `bget` hands its callback a map describing a platform-specific handle, and the
+   callback IS the scope in which that handle is valid — Konserve still owns the
+   backing object, and a streaming view lives only until the callback (or the
+   channel it returns) completes. That contract is right, and it is why the handle
+   is not simply returned.
+
+   What was missing is the ordinary case. Almost every caller wants the bytes, and
+   until now each one re-derived how to get them, because the handle has four
+   different shapes:
+
+     backend                      map
+     ---------------------------- ------------------------------------------
+     filestore (JVM)              {:input-stream <InputStream>}
+     node-filestore, :sync? true  {:blob <js/Buffer>}
+     node-filestore, async        {:input-stream <fs.ReadStream> :size n}
+     indexeddb                    {:input-stream <web ReadableStream>}
+     memory                       {:input-stream <the bytes that were bassoc'd>}
+
+   Only ONE of those differences is inherent to the platform: `fs.ReadStream` and
+   the WHATWG `ReadableStream` really are different APIs. The rest is this
+   library's own inconsistency — the same backend hands back a different KEY
+   depending on `:sync?`, and the memory store calls raw bytes an `:input-stream`,
+   which survives on the JVM only because `clojure.java.io/copy` happens to accept
+   a `byte[]`.
+
+   ## The contract this namespace fixes in place
+
+     `:blob`          bytes, already materialised — nothing to drain
+     `:input-stream`  a streaming handle, valid for the callback's extent
+
+   A backend supplies whichever it has, and may supply both when it has bytes
+   anyway. `to-bytes` accepts any of them. This is additive: the map was always
+   the extension point, so no existing callback that destructures `:input-stream`
+   changes behaviour.
+
+   ## What this does NOT replace
+
+   Streaming. `to-bytes` materialises, so it is the wrong tool for a blob larger
+   than you want in memory — that is what `:streaming? true` and a hand-written
+   callback are for. The raw handle stays available; this is the opt-in for the
+   common case, not a narrowing of the contract.
+
+   ## Why it is a factory
+
+   A `locked-cb` must synchronously return a CHANNEL when called asynchronously
+   and a plain value when called with `{:sync? true}`, and the callback itself
+   cannot tell which. So the mode is supplied up front:
+
+     (k/bget store :k (kb/to-bytes opts) opts)"
+  (:require [clojure.core.async :refer [promise-chan put! close!]])
+  #?(:clj (:import [java.io InputStream ByteArrayOutputStream])))
+
+#?(:cljs
+   (defn- concat-u8
+     "Join a JS array of Uint8Arrays into one.
+
+      Written out rather than using `js/Buffer.concat`: Buffer is a Node global,
+      and this namespace is loaded in browser builds too. Uint8Array is the one
+      byte container both platforms have."
+     [chunks]
+     (let [total (areduce chunks i acc 0 (+ acc (.-length (aget chunks i))))
+           out (js/Uint8Array. total)]
+       (loop [i 0 off 0]
+         (if (< i (alength chunks))
+           (let [c (aget chunks i)]
+             (.set out c off)
+             (recur (inc i) (+ off (.-length c))))
+           out)))))
+
+#?(:cljs
+   (defn- drain-web-stream
+     "Drain a WHATWG ReadableStream into a promise-chan of one Uint8Array."
+     [stream]
+     (let [out (promise-chan)
+           reader (.getReader stream)
+           chunks #js []]
+       (letfn [(step []
+                 (-> (.read reader)
+                     (.then (fn [res]
+                              (if (.-done res)
+                                (do (put! out (concat-u8 chunks)) (close! out))
+                                (do (.push chunks (.-value res)) (step)))))
+                     (.catch (fn [e] (put! out e) (close! out)))))]
+         (step))
+       out)))
+
+#?(:cljs
+   (defn- drain-node-stream
+     "Drain a Node Readable into a promise-chan of one Uint8Array.
+
+      PAUSED mode — `.read()` in a `\"readable\"` loop — and NOT a `\"data\"`
+      handler, which is the obvious version and hangs forever.
+
+      node-filestore calls the `bget` callback from inside its own `\"readable\"`
+      listener (see `afread-binary`). Node's rule is that once a `\"readable\"`
+      listener exists it controls the flow, and `\"data\"` is emitted only when
+      something calls `.read()`. So a `\"data\"` handler registered here never
+      fires, `\"end\"` never arrives, and the channel is never delivered: the
+      caller waits on a read that has already been buffered for it.
+
+      Absorbing that is a large part of why this helper exists.
+
+      The first drain runs immediately rather than waiting for an event, because
+      we are already inside the `\"readable\"` that woke the callback. Note the
+      stream is NOT destroyed — node-filestore opened it on the fd konserve is
+      managing, and destroying it raises."
+     [stream]
+     (let [out (promise-chan)
+           chunks #js []
+           pump (fn pump []
+                  (loop []
+                    (when-let [c (.read stream)]
+                      (.push chunks (js/Uint8Array. c))
+                      (recur))))]
+       (.on stream "readable" pump)
+       (.on stream "error" (fn [e] (put! out e) (close! out)))
+       (.on stream "end" (fn [] (put! out (concat-u8 chunks)) (close! out)))
+       (pump)
+       out)))
+
+#?(:clj
+   (defn- drain-input-stream ^bytes [^InputStream in]
+     (let [bos (ByteArrayOutputStream.)
+           buf (byte-array 65536)]
+       (loop []
+         (let [n (.read in buf)]
+           (when (pos? n)
+             (.write bos buf 0 n)
+             (recur))))
+       (.toByteArray bos))))
+
+(defn- already-bytes?
+  "True when `x` needs no draining — it IS the payload."
+  [x]
+  #?(:clj  (bytes? x)
+     ;; js/Buffer is a Uint8Array subclass, so this covers both.
+     :cljs (instance? js/Uint8Array x)))
+
+(defn to-bytes
+  "Return a `bget` locked-cb that yields the stored bytes — `byte[]` on the JVM,
+   `js/Uint8Array` on ClojureScript.
+
+     (k/bget store :my-key (kb/to-bytes opts) opts)
+
+   Yields `nil` for a key that holds no binary, matching `bget`'s own behaviour,
+   so a missing blob is distinguishable from an empty one only by the caller's
+   own bookkeeping — as it always was.
+
+   With `{:sync? true}` the returned callback produces bytes directly. That is
+   possible on every backend that HAS a sync mode: the JVM drains its
+   `InputStream` in place, and on ClojureScript the sync-capable backends hand
+   back materialised bytes already. A genuine stream in sync mode is a backend
+   contract violation and throws rather than silently returning a handle."
+  ([] (to-bytes {:sync? false}))
+  ([opts]
+   (let [sync? (:sync? opts)]
+     (fn [{:keys [blob input-stream]}]
+       (let [handle (or blob input-stream)]
+         (cond
+           (nil? handle)
+           (if sync? nil (doto (promise-chan) (close!)))
+
+           (already-bytes? handle)
+           (if sync? handle (doto (promise-chan) (put! handle)))
+
+           :else
+           #?(:clj
+              (let [bs (drain-input-stream handle)]
+                (if sync? bs (doto (promise-chan) (put! bs))))
+              :cljs
+              (if sync?
+                (throw (ex-info (str "konserve.binary/to-bytes was called with {:sync? true} "
+                                     "but the backend handed back a stream, which cannot be "
+                                     "drained synchronously in ClojureScript. Use {:sync? false}.")
+                                {:type :konserve/sync-stream-unsupported
+                                 :handle-type (str (type handle))}))
+                (cond
+                  (some? (.-getReader handle)) (drain-web-stream handle)
+                  (some? (.-on handle)) (drain-node-stream handle)
+                  :else (throw (ex-info (str "konserve.binary/to-bytes does not recognise this "
+                                             "binary handle. Expected bytes, a WHATWG "
+                                             "ReadableStream, or a Node Readable.")
+                                        {:type :konserve/unknown-binary-handle
+                                         :handle-type (str (type handle))})))))))))))

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -631,12 +631,26 @@
                     acc))))))
 
 (defn bget
-  "Calls locked-cb with a platform specific binary representation inside
-  the lock, e.g. wrapped InputStream on the JVM and Blob in
-  JavaScript. You need to properly close/dispose the object when you
-  are done!
+  "Calls locked-cb with a platform specific binary representation inside the lock.
+  You need to properly close/dispose the object when you are done!
 
-  You have to do all work in locked-cb, e.g.
+  The callback receives a MAP, and which keys it carries depends on the backend:
+
+    :blob          bytes, already materialised — nothing to drain
+    :input-stream  a streaming handle, valid only for the callback's extent
+
+  Concretely: the JVM filestore passes `:input-stream` (an InputStream);
+  node-filestore passes `:blob` (a js/Buffer) when synchronous and
+  `:input-stream` (an fs.ReadStream, plus `:size`) when asynchronous; indexeddb
+  passes `:input-stream` (a WHATWG ReadableStream); the memory store passes both,
+  since it holds the bytes outright.
+
+  If you just want the bytes — which is most callers — do not write this by hand
+  for each backend. `konserve.binary/to-bytes` is that callback:
+
+    (k/bget store :my-key (konserve.binary/to-bytes opts) opts)
+
+  Write your own when you need to stream rather than materialise, e.g.
 
   (fn [{is :input-stream}]
     (let [tmp-file (io/file \"/tmp/my-private-copy\")]

--- a/src/konserve/memory.cljc
+++ b/src/konserve/memory.cljc
@@ -79,7 +79,15 @@
       (async+sync sync?
                   {go do
                    <! do}
-                  (go (<! (locked-cb {:input-stream (second (get @state key))}))))))
+                  ;; `:blob` because that is what this store has — the bytes that
+                  ;; were `bassoc`'d, with nothing to drain. `:input-stream` stays
+                  ;; alongside it: it was always a misnomer here (it is not a
+                  ;; stream and never was), but callbacks destructure it, and on
+                  ;; the JVM they get away with it only because
+                  ;; `clojure.java.io/copy` accepts a `byte[]`. Removing it would
+                  ;; break them; naming the truth next to it does not.
+                  (go (<! (locked-cb (let [v (second (get @state key))]
+                                       {:input-stream v :blob v})))))))
   (-bassoc [_ key meta-up-fn input opts]
     (let [{:keys [sync?]} opts]
       (async+sync sync?

--- a/src/konserve/node_filestore.cljs
+++ b/src/konserve/node_filestore.cljs
@@ -74,12 +74,19 @@
           bytes-read (iofs/read fd buf {:position pos :length (alength buf)})]
       (verify-read-size value-size bytes-read)
       buf))
-  (-read-binary [this meta-size locked-cb _env]
+  (-read-binary [_this meta-size locked-cb _env]
+    ;; `iofs/read`'s positional arity is (fd buffer BUFFER-offset length
+    ;; FILE-position). This passed the file offset as the buffer offset and read
+    ;; from position 0 — both arguments in the wrong place. Since the header
+    ;; guarantees offset > 0, buffer-offset + length always exceeded the buffer,
+    ;; so every sync bget raised ERR_OUT_OF_RANGE; no test caught it because the
+    ;; existing coverage goes through the async path. Uses the options-map arity
+    ;; now, like -read-value directly above, where the two cannot be confused.
     (let [blob-size ^number (.-size (fs.fstatSync fd))
           offset (+ meta-size storage-layout/header-size)
           value-len (- blob-size offset)
-          blob (js/Buffer. value-len)
-          bytes-read (iofs/read (.-fd this) blob offset value-len 0)]
+          blob (js/Buffer.alloc value-len)
+          bytes-read (iofs/read fd blob {:position offset :length value-len})]
       (verify-read-size value-len bytes-read)
       (locked-cb {:blob blob})))
   (-write-header [_this header _env]

--- a/test/konserve/binary_test.cljc
+++ b/test/konserve/binary_test.cljc
@@ -1,0 +1,104 @@
+(ns konserve.binary-test
+  "`to-bytes` exists because `bget`'s handle has four shapes across backends and
+   platforms, so a test that covers one backend on one platform proves nothing.
+
+   This runs against the memory store on BOTH platforms, the JVM filestore (a
+   real `InputStream`, so the draining path rather than the already-bytes
+   shortcut). The node filestore — the backend that changes its map KEY depending
+   on `:sync?`, and therefore the one that motivated the helper — is covered in
+   `konserve.node-filestore-binary-test`, for the build reason noted below."
+  (:require #?(:clj [clojure.test :refer [deftest testing is]]
+               :cljs [cljs.test :refer [deftest testing is async]])
+            [clojure.core.async :refer [go #?(:clj <!!) <!]]
+            [konserve.core :as k]
+            [konserve.binary :as kb]
+            [konserve.memory :refer [new-mem-store]]
+            #?(:clj [clojure.java.io :as io])))
+
+(defn- bytes->vec
+  "Payloads as vectors of unsigned ints, so a JVM `byte[]` (signed) and a
+   `js/Uint8Array` (unsigned) compare against the same literal."
+  [bs]
+  (mapv #(bit-and % 0xff)
+        #?(:clj (seq bs) :cljs (array-seq bs))))
+
+(def ^:private payload
+  "0-255, so the top half is negative as JVM bytes and positive as JS ones —
+   which is where a sign-extension mistake in the conversion would show."
+  (vec (range 256)))
+
+(defn- ->binary [xs]
+  #?(:clj (byte-array (map unchecked-byte xs))
+     :cljs (js/Uint8Array.from (into-array xs))))
+
+;; ---------------------------------------------------------------------------
+;; JVM
+
+#?(:clj
+   (deftest to-bytes-round-trips-on-the-memory-store-both-modes
+     (testing "sync yields bytes directly, async yields a channel of them — the
+               distinction the factory arity exists to carry, since a locked-cb
+               cannot discover its own mode."
+       (doseq [opts [{:sync? true} {:sync? false}]]
+         (let [take* (if (:sync? opts) identity <!!)
+               store (take* (new-mem-store (atom {}) opts))]
+           (take* (k/bassoc store :bin (->binary payload) opts))
+           (is (= payload (bytes->vec (take* (k/bget store :bin (kb/to-bytes opts) opts))))
+               (str "mode " opts)))))))
+
+#?(:clj
+   (deftest missing-binary-yields-nil-not-an-error
+     (testing "a key holding no binary comes back nil rather than throwing — the
+               behaviour bget always had, and a caller distinguishes absent from
+               empty with its own bookkeeping."
+       (let [opts {:sync? true}
+             store (new-mem-store (atom {}) opts)]
+         (is (nil? (k/bget store :nope (kb/to-bytes opts) opts)))))))
+
+#?(:clj
+   (deftest empty-binary-is-not-confused-with-a-missing-one
+     (testing "zero bytes stored is zero bytes read, and is distinct from nil."
+       (let [opts {:sync? true}
+             store (new-mem-store (atom {}) opts)]
+         (k/bassoc store :empty (->binary []) opts)
+         (let [r (k/bget store :empty (kb/to-bytes opts) opts)]
+           (is (some? r) "an empty binary is present")
+           (is (= [] (bytes->vec r))))))))
+
+#?(:clj
+   (deftest drains-a-real-input-stream-from-the-filestore
+     (testing "the filestore passes an actual InputStream, so this exercises the
+               draining branch. The memory store cannot: it hands back bytes and
+               takes the shortcut."
+       (doseq [opts [{:sync? true} {:sync? false}]]
+         (let [take* (if (:sync? opts) identity <!!)
+               dir (str (System/getProperty "java.io.tmpdir") "/konserve-bin-test-"
+                        (System/nanoTime))
+               connect (requiring-resolve 'konserve.filestore/connect-fs-store)
+               store (take* (connect dir :opts opts))]
+           (try
+             (take* (k/bassoc store :bin (->binary payload) opts))
+             (is (= payload (bytes->vec (take* (k/bget store :bin (kb/to-bytes opts) opts))))
+                 (str "mode " opts))
+             (finally
+               (doseq [f (reverse (file-seq (io/file dir)))]
+                 (io/delete-file f true)))))))))
+
+;; ---------------------------------------------------------------------------
+;; ClojureScript
+;;
+;; The node-filestore cases live in `konserve.node-filestore-binary-test`, not
+;; here: the browser and karma builds select namespaces with a negative lookahead
+;; on `konserve.node-filestore`, so a require of it from THIS namespace would drag
+;; node-only code into a browser build that deliberately excludes it.
+
+#?(:cljs
+   (deftest to-bytes-round-trips-on-the-memory-store-cljs
+     (async done
+            (go
+              (let [opts {:sync? false}
+                    store (<! (new-mem-store (atom {}) opts))]
+                (<! (k/bassoc store :bin (->binary payload) opts))
+                (is (= payload
+                       (bytes->vec (<! (k/bget store :bin (kb/to-bytes opts) opts)))))
+                (done))))))

--- a/test/konserve/node_filestore_binary_test.cljs
+++ b/test/konserve/node_filestore_binary_test.cljs
@@ -1,0 +1,70 @@
+(ns konserve.node-filestore-binary-test
+  "`konserve.binary/to-bytes` against the node filestore — the backend that
+   motivated it.
+
+   It is the one that hands back a DIFFERENT map key depending on `:sync?`:
+   `{:blob <js/Buffer>}` synchronously and `{:input-stream <fs.ReadStream>}`
+   asynchronously. Both shapes are exercised here, because a helper that only
+   handled one of them would still leave every caller writing the branch.
+
+   Named `konserve.node-filestore-…` deliberately: the browser and karma builds
+   select namespaces with a negative lookahead on `konserve.node-filestore`, so
+   this name is excluded from them along with the backend itself."
+  (:require [clojure.core.async :refer [go <!]]
+            [cljs.test :refer-macros [deftest is testing async]]
+            [cljs-node-io.fs :as fs]
+            [konserve.core :as k]
+            [konserve.binary :as kb]
+            [konserve.node-filestore :refer [connect-fs-store]]))
+
+(def ^:private payload
+  "0-255, so the top half is negative as JVM bytes and positive as JS ones —
+   where a sign-extension mistake in the conversion would show."
+  (vec (range 256)))
+
+(defn- ->binary [xs] (js/Uint8Array.from (into-array xs)))
+
+(defn- bytes->vec [bs] (mapv #(bit-and % 0xff) (array-seq bs)))
+
+(deftest to-bytes-drains-an-fs-read-stream
+  (testing "the async path hands back an fs.ReadStream. This is the ONE
+            difference among the backends that is genuine JavaScript
+            fragmentation — a Node Readable and a WHATWG ReadableStream really
+            are different APIs — rather than konserve inconsistency.
+
+            Note the stream is drained, not destroyed: node-filestore opens it on
+            the fd konserve is managing, and destroying it raises."
+    (async done
+           (go
+             (let [dir "/tmp/konserve-binary-async-test"
+                   opts {:sync? false}]
+               (fs/rm-rf dir)
+               (let [store (<! (connect-fs-store dir :opts opts))]
+                 (<! (k/bassoc store :bin (->binary payload) opts))
+                 (is (= payload
+                        (bytes->vec (<! (k/bget store :bin (kb/to-bytes opts) opts)))))
+                 (done)))))))
+
+(deftest to-bytes-takes-the-blob-in-sync-mode
+  (testing "the SAME backend passes `:blob` — a js/Buffer, already materialised —
+            when synchronous. A Buffer is a Uint8Array subclass, so it needs no
+            draining at all, and `to-bytes` returns it directly rather than
+            through a channel."
+    (let [dir "/tmp/konserve-binary-sync-test"
+          opts {:sync? true}]
+      (fs/rm-rf dir)
+      (let [store (connect-fs-store dir :opts opts)]
+        (k/bassoc store :bin (->binary payload) opts)
+        (is (= payload
+               (bytes->vec (k/bget store :bin (kb/to-bytes opts) opts))))))))
+
+(deftest a-stream-in-sync-mode-is-refused-loudly
+  (testing "there is no way to drain a stream synchronously in ClojureScript, so
+            a backend handing one back under `{:sync? true}` gets a named error
+            rather than the raw handle. Returning the handle would look like it
+            worked and fail later, somewhere else."
+    (let [cb (kb/to-bytes {:sync? true})
+          fake-stream #js {:getReader (fn [] nil)}]
+      (is (thrown-with-msg?
+           js/Error #"cannot be drained synchronously"
+           (cb {:input-stream fake-stream}))))))


### PR DESCRIPTION
## Why

`bget` hands its callback a map describing a platform-specific handle, and that contract is right — konserve owns the backing object, and a streaming view is valid only for the callback's extent.

What was missing is the *ordinary* case. Almost every caller just wants the bytes, and each one has had to re-derive how, because the map has four shapes:

| backend | map |
|---|---|
| filestore (JVM) | `{:input-stream <InputStream>}` |
| node-filestore, `:sync? true` | `{:blob <js/Buffer>}` |
| node-filestore, async | `{:input-stream <fs.ReadStream> :size n}` |
| indexeddb | `{:input-stream <web ReadableStream>}` |
| memory | `{:input-stream <the bytes that were bassoc'd>}` |

Only **one** of those differences is inherent to the platform: `fs.ReadStream` and the WHATWG `ReadableStream` really are different APIs. The rest is our own inconsistency — the same backend hands back a different *key* depending on `:sync?`, and the memory store calls raw bytes an `:input-stream`, which survives on the JVM only because `clojure.java.io/copy` happens to accept a `byte[]`.

konserve ships a helper for exactly one of the shapes (`indexeddb/read-web-stream`), so downstream keeps rewriting the rest. datahike has an acknowledged stub in `migrate/blobs.cljc` that only survives because import had not yet run on cljs.

## What

States the contract — **`:blob` = materialised bytes, `:input-stream` = a streaming handle** — and adds a callback that accepts any of them:

```clojure
(k/bget store :my-key (konserve.binary/to-bytes opts) opts)
```

**Purely additive.** The map was always the extension point, so no existing callback that destructures `:input-stream` changes behaviour; the memory store now passes `:blob` *alongside* it rather than instead of it.

It is a factory rather than a bare function because a `locked-cb` must return a channel when async and a value when sync, and cannot discover its own mode.

This does not replace streaming. `to-bytes` materialises, so it is the wrong tool for a blob larger than you want in memory — `:streaming? true` and a hand-written callback still are. The raw handle stays available.

## Two bugs found while writing it

**Draining a Node Readable with a `"data"` handler hangs forever.** That is the obvious implementation, and the node suite stalled on it. node-filestore calls the callback from inside *its own* `"readable"` listener (`afread-binary`), and Node's rule is that once a `"readable"` listener exists it controls the flow — `"data"` fires only when something calls `.read()`. So the callback waits forever on bytes already buffered for it. `to-bytes` drains in paused mode, starting immediately since it is already inside a `"readable"`.

**Sync `bget` on the node filestore has never worked.** `-read-binary` passed `iofs/read` the file offset as the **buffer** offset and read from file position **0** — both arguments in the wrong slot. The header guarantees `offset > 0`, so `buffer-offset + length` always exceeded the buffer and every call raised `ERR_OUT_OF_RANGE` (the new test hit `must be <= 180. Received 256`, 180 being 256 minus the 76-byte header+meta). No test caught it because all existing binary coverage goes through the async path. Now uses the options-map arity that `-read-value` directly above already uses, where the two cannot be confused, and `js/Buffer.alloc` instead of the deprecated `js/Buffer.` constructor.

## Tests

New coverage runs against the memory store on **both** platforms, the JVM filestore (a real `InputStream`, so the draining branch rather than the already-bytes shortcut), and the node filestore in **both** modes — the sync one being the regression test for the bug above. Payload is 0-255, so the top half is negative as JVM bytes and positive as JS ones, which is where a sign-extension mistake would show.

- JVM: 103 tests, 1351 assertions, 0 failures
- node: 57 tests, 339 assertions, 0 failures

## Downstream

datahike's portable dump export/import needs this to read chunk binaries back on node; it currently pins konserve 0.9.365.