### PR TITLE
boring 0.1.13: indexed values, in-place navigation, and three config bugs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/data.fressian {:mvn/version "1.0.0"} ;; for filestore
         mvxcvi/clj-cbor {:mvn/version "1.1.1"} ;; legacy: serializer byte 2, JVM-only
-        org.replikativ/boring {:mvn/version "0.1.11"} ;; serializer byte 3, portable
+        org.replikativ/boring {:mvn/version "0.1.13"} ;; serializer byte 3, portable
         org.replikativ/incognito {:mvn/version "0.3.69"}
         org.replikativ/hasch {:mvn/version "0.3.96"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/data.fressian {:mvn/version "1.0.0"} ;; for filestore
         mvxcvi/clj-cbor {:mvn/version "1.1.1"} ;; legacy: serializer byte 2, JVM-only
-        org.replikativ/boring {:mvn/version "0.1.6"} ;; serializer byte 3, portable
+        org.replikativ/boring {:mvn/version "0.1.11"} ;; serializer byte 3, portable
         org.replikativ/incognito {:mvn/version "0.3.69"}
         org.replikativ/hasch {:mvn/version "0.3.96"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -3,8 +3,6 @@
    [clojure.core.async :refer [go <!! chan close! put!]]
    [clojure.java.io :as io]
    [clojure.string :refer [includes? ends-with?]]
-   [konserve.compressor :refer [null-compressor]]
-   [konserve.encryptor :refer [null-encryptor]]
    [konserve.impl.defaults :refer [update-blob connect-default-store key->store-key store-key->uuid-key]]
    [konserve.impl.storage-layout :refer [PBackingStore
                                          PBackingBlob -close
@@ -707,6 +705,14 @@
   The :filesystem option allows using a custom java.nio.file.FileSystem (e.g., Jimfs for testing).
   When provided, all path operations will use that filesystem instead of the default.
 
+  Compression and encryption are set UNDER :config, as a type keyword:
+
+      (connect-fs-store path :config {:compressor {:type :lz4}})
+
+  A top-level :compressor/:encryptor is refused rather than ignored -- it used
+  to be silently dropped, leaving the store uncompressed while the caller
+  believed otherwise.
+
   Defaults are
   {:base           path
    :serializer     fressian-serializer
@@ -723,9 +729,12 @@
                 filesystem nil}
            :as params}]
   ;; check config
+  ;; NO :compressor / :encryptor here. They were defaults that
+  ;; `connect-default-store` never read -- it derives both from
+  ;; `(get-in config [:compressor :type])` -- so they were dead, and worse,
+  ;; they made a top-level `:compressor` look supported when passing one did
+  ;; nothing at all. That path now throws; see connect-default-store.
   (let [store-config (merge {:default-serializer :FressianSerializer
-                             :compressor         null-compressor
-                             :encryptor          null-encryptor
                              :read-handlers      (atom {})
                              :write-handlers     (atom {})
                              :buffer-size        (* 1024 1024)

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -5,8 +5,8 @@
    [clojure.string :refer [ends-with?]]
    [hasch.core :refer [uuid]]
    [konserve.serializers :refer [key->serializer]]
-   [konserve.compressor :refer [get-compressor]]
-   [konserve.encryptor :refer [get-encryptor]]
+   [konserve.compressor :refer [get-compressor null-compressor]]
+   [konserve.encryptor :refer [get-encryptor null-encryptor]]
    [konserve.protocols :refer [PEDNKeyValueStore
                                PBinaryKeyValueStore
                                -serialize -deserialize
@@ -771,7 +771,17 @@
     ;; at all: the store came back on `null-compressor` and wrote a 0 into
     ;; every blob header while the caller believed their data was compressed.
     ;; Silence is the wrong answer for a durable property nobody re-checks.
-    (when (or (contains? params :compressor) (contains? params :encryptor))
+    ;; Only a MEANINGFUL one is refused. konserve-rocksdb passes
+    ;; `:compressor null-compressor` and `:encryptor null-encryptor` as dead
+    ;; defaults -- the same pattern konserve's own filestore carried until it
+    ;; was removed -- and throwing on those would break a maintained backend on
+    ;; upgrade for a value that asks for nothing. Passing `lz4-compressor`,
+    ;; which is someone actually trying to configure compression and silently
+    ;; getting none, is what has to be loud.
+    (when (or (and (contains? params :compressor)
+                   (not= (:compressor params) null-compressor))
+              (and (contains? params :encryptor)
+                   (not= (:encryptor params) null-encryptor)))
       (throw (ex-info (str "konserve: :compressor and :encryptor are set under "
                            ":config, not at the top level. Write "
                            "{:config {:compressor {:type :lz4}}} -- a TYPE "

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -755,7 +755,8 @@
            read-handlers      (atom {})
            write-handlers     (atom {})
            buffer-size        (* 1024 1024)
-           opts               {:sync? false}}}]
+           opts               {:sync? false}}
+    :as   params}]
   ;; check config
   (let [complete-config (merge {:sync-blob? true
                                 :in-place? false
@@ -763,6 +764,21 @@
                                config)
         compressor (get-compressor (get-in config [:compressor :type]))
         encryptor (get-encryptor (get-in config [:encryptor :type]))]
+    ;; A top-level `:compressor`/`:encryptor` is REFUSED rather than ignored.
+    ;; Both are read from `config` above, so passing a function at the top
+    ;; level -- which reads exactly like it should work, and which
+    ;; `connect-fs-store` itself used to hand us as a default -- did nothing
+    ;; at all: the store came back on `null-compressor` and wrote a 0 into
+    ;; every blob header while the caller believed their data was compressed.
+    ;; Silence is the wrong answer for a durable property nobody re-checks.
+    (when (or (contains? params :compressor) (contains? params :encryptor))
+      (throw (ex-info (str "konserve: :compressor and :encryptor are set under "
+                           ":config, not at the top level. Write "
+                           "{:config {:compressor {:type :lz4}}} -- a TYPE "
+                           "keyword, not a function. Accepted types: :lz4, "
+                           ":zstd, or omit for none.")
+                      {:type :store-configuration-error
+                       :got (select-keys params [:compressor :encryptor])})))
     (async+sync
      (:sync? opts) *default-sync-translation*
      (go-try-

--- a/src/konserve/mmap.clj
+++ b/src/konserve/mmap.clj
@@ -1,0 +1,163 @@
+(ns konserve.mmap
+  "**EXPERIMENTAL.** Navigate a filestore value in place, without reading it.
+
+  A konserve blob written by the boring serializer is ordinary CBOR sitting at
+  a known offset in a file, so it can be memory-mapped and walked with
+  `boring.nav` — reaching one key without materialising the rest, and without
+  faulting in the pages that hold the parts you skipped.
+
+      (require '[konserve.mmap :as kmm] '[boring.nav :as nav])
+
+      (kmm/with-mmap-value [c store \"customers\"]
+        (nav/value (get-in c [\"customer-137\" \"name\"])))
+
+  ## Why this is its own namespace
+
+  `boring.mmap` touches `java.lang.foreign`, which is final in JDK 22.
+  `konserve.filestore` must keep loading on older JVMs, so this cannot be a
+  require there — and it is resolved dynamically here for the same reason, so
+  that merely loading this namespace does not fail on JDK 21. The failure
+  arrives when you call it, naming the reason.
+
+  ## What it requires of the blob, and why it refuses otherwise
+
+  Three header bytes have to line up, and all three are checked rather than
+  assumed:
+
+  - **serializer 3 (boring).** Fressian and clj-cbor blobs are not navigable;
+    reading them as CBOR would not error, it would return nonsense.
+  - **compressor 0** and **encryptor 0**. A compressed or encrypted blob has
+    to be decompressed whole before anything can navigate it, which is exactly
+    the cost this exists to avoid.
+
+  It THROWS rather than falling back to an ordinary read. A silent fallback
+  would hide the one thing a caller came here for — they would get correct
+  answers at full cost and no way to tell. `konserve.core/get` is the
+  fallback, and it is one line away.
+
+  ## Lifetime
+
+  The mapping dies with the macro's body. Nothing derived from the cursor may
+  escape it: the arena is closed on the way out and touching a cursor
+  afterwards throws a typed FFM error rather than reading freed memory. This
+  is why the API is a macro and not a function returning a cursor — the scope
+  is the contract, and a `get-cursor` that handed one back would make
+  use-after-free a thing callers had to remember.
+
+  ## Status
+
+  Experimental. The shape of this — filestore-only, macro-scoped — may change,
+  and an in-memory variant that works for every backend is a separate
+  question: konserve's read path already slices the value bytes out, so that
+  one needs no offset at all, but it saves only decode and not IO."
+  (:require [konserve.impl.defaults :refer [key->store-key]]
+            [konserve.impl.storage-layout :refer [header-size]]
+            [konserve.serializers :as ser])
+  (:import [java.io File FileInputStream]))
+
+(def ^:private boring-serializer-byte
+  "Byte 3 in the blob header. Read from the registry rather than written as a
+  literal, so it cannot drift from `konserve.serializers`."
+  (some (fn [[b k]] (when (= :BoringSerializer k) b)) ser/byte->key))
+
+(defn- read-header
+  "The blob's 20-byte header, or nil if the file is too short to have one."
+  ^bytes [^File f]
+  (when (>= (.length f) header-size)
+    (with-open [in (FileInputStream. f)]
+      (let [b (byte-array header-size)]
+        (when (= header-size (.read in b)) b)))))
+
+(defn- be-int
+  "The big-endian 32-bit int at `off`. That is how `create-header` writes
+  meta-size, at bytes 4-7."
+  ^long [^bytes b ^long off]
+  (loop [i 0 acc 0]
+    (if (= i 4)
+      acc
+      (recur (inc i) (+ (* acc 256) (bit-and (aget b (+ off i)) 0xff))))))
+
+(defn value-location
+  "`[path offset]` for the value of `key` in a filestore, or a thrown
+  explanation of why it cannot be navigated.
+
+  Public because it is the useful half on its own: a caller who wants to hand
+  the offset to something other than `boring.mmap` — a ranged reader, a
+  checksum — needs exactly this and not a cursor."
+  [store key]
+  (let [base  (or (:base (:backing store))
+                  (throw (ex-info (str "konserve.mmap: this store has no :base, "
+                                       "so it is not a filestore. Only the "
+                                       "filestore keeps values in files this "
+                                       "can map.")
+                                  {:type :konserve/not-a-filestore})))
+        f     (File. (str base "/" (key->store-key key)))
+        _     (when-not (.exists f)
+                (throw (ex-info (str "konserve.mmap: no blob for key " (pr-str key)
+                                     " at " (.getPath f))
+                                {:type :konserve/key-not-found :key key
+                                 :path (.getPath f)})))
+        hdr   (or (read-header f)
+                  (throw (ex-info (str "konserve.mmap: " (.getPath f) " is shorter "
+                                       "than a " header-size "-byte header")
+                                  {:type :konserve/malformed-blob
+                                   :path (.getPath f) :size (.length f)})))
+        [_ sb cb eb] (map #(bit-and (aget hdr (int %)) 0xff) (range 4))]
+    ;; All three are refused rather than worked around -- see the namespace
+    ;; docstring on why a silent fallback would be worse than an error.
+    (when-not (= sb boring-serializer-byte)
+      (throw (ex-info (str "konserve.mmap: this blob was written by serializer "
+                           sb " (" (get ser/byte->key sb) "), not "
+                           boring-serializer-byte " (:BoringSerializer). Only "
+                           "boring's output is CBOR a cursor can walk; reading "
+                           "another codec's bytes as CBOR would return nonsense "
+                           "rather than fail. Use konserve.core/get.")
+                      {:type :konserve/not-navigable :serializer sb :key key})))
+    (when-not (zero? cb)
+      (throw (ex-info (str "konserve.mmap: this blob is compressed (compressor "
+                           cb "), and a compressed blob must be decompressed "
+                           "whole before anything can navigate it -- which is "
+                           "the cost this avoids. Use an uncompressed store for "
+                           "navigable values, or konserve.core/get.")
+                      {:type :konserve/not-navigable :compressor cb :key key})))
+    (when-not (zero? eb)
+      (throw (ex-info (str "konserve.mmap: this blob is encrypted (encryptor "
+                           eb "). Same reason as compression: it must be "
+                           "decrypted whole first. Use konserve.core/get.")
+                      {:type :konserve/not-navigable :encryptor eb :key key})))
+    [(.getPath f) (+ header-size (be-int hdr 4))]))
+
+(defn mmap-value
+  "`[cursor arena]` over the value of `key`. **Prefer `with-mmap-value`**,
+  which closes the arena for you; this is here for a caller who genuinely
+  needs to manage the lifetime themselves.
+
+  The caller MUST close the arena, and nothing derived from the cursor may be
+  used afterwards."
+  ([store key] (mmap-value store key nil))
+  ([store key opts]
+   (let [[path offset] (value-location store key)
+         open! (try (requiring-resolve 'boring.mmap/mmap-source)
+                    (catch Throwable t
+                      (throw (ex-info (str "konserve.mmap needs boring.mmap, "
+                                           "which requires JDK 22+ for "
+                                           "java.lang.foreign. This JVM is "
+                                           (.feature (Runtime/version)) ".")
+                                      {:type :konserve/mmap-unavailable
+                                       :jdk (.feature (Runtime/version))}
+                                      t))))]
+     (open! path (assoc opts :offset offset)))))
+
+(defmacro with-mmap-value
+  "Bind `binding` to a `boring.nav` cursor over the value of `key`, and close
+  the mapping after `body`.
+
+      (with-mmap-value [c store \"customers\"]
+        (nav/value (get-in c [\"customer-137\" \"name\"])))
+
+  Do not let the cursor, or anything derived from it, escape the body."
+  [[binding store key & [opts]] & body]
+  `(let [[c# arena#] (mmap-value ~store ~key ~opts)]
+     (with-open [a# arena#]
+       (let [~binding c#]
+         ~@body))))

--- a/src/konserve/serializers.cljc
+++ b/src/konserve/serializers.cljc
@@ -259,6 +259,12 @@
 (defn boring-serializer
   "A portable CBOR serializer backed by boring.
 
+  **BETA. Not yet recommended for production stores.** The codec itself is
+  well covered, but its use as konserve's STORE serializer has not been
+  exercised at scale or over a long-lived store, and byte 3 has not carried
+  real data through an upgrade cycle. Fressian (byte 1) remains the default
+  and the tested choice. Try this on data you can regenerate.
+
   `opts` are boring's encode options; `:shapes true` is worth enabling for
   stores holding many same-shaped maps -- it strips repeated keys and was
   measured at 36% smaller on datom-like content.

--- a/src/konserve/serializers.cljc
+++ b/src/konserve/serializers.cljc
@@ -1,6 +1,7 @@
 (ns konserve.serializers
   (:require #?(:clj [clj-cbor.core :as cbor])
             [boring.core :as boring]
+            [clojure.string :as str]
             #?(:clj [clojure.data.fressian :as fress] :cljs [fress.api :as fress])
             [konserve.protocols :refer [PStoreSerializer]]
             [incognito.fressian :refer [incognito-read-handlers incognito-write-handlers]]
@@ -74,13 +75,59 @@
 ;;     This one runs on both platforms from the same code.
 ;; ---------------------------------------------------------------------------
 
+(defn- boring-wire-name
+  "incognito's munged key as boring >= 0.1.11 spells it, or nil if it is
+  already in that form.
+
+  `my_ns.core.MyRecord` -> `my-ns.core/MyRecord`: the LAST dot becomes the
+  namespace/name separator, and underscores in the namespace part become
+  hyphens. A key that already contains `/` is left alone -- it is either
+  boring's own spelling or a hand-picked name, and neither wants munging."
+  [k]
+  (let [s (str k)]
+    (when-not (str/includes? s "/")
+      (let [i (str/last-index-of s ".")]
+        (when (and i (pos? i))
+          (str (str/replace (subs s 0 i) "_" "-")
+               "/" (subs s (inc i))))))))
+
+(defn- with-boring-names
+  "`handlers` plus an entry under each key's boring wire name, where that
+  differs. The original key wins if both spell the same thing."
+  [handlers]
+  (reduce-kv (fn [m k v]
+               (if-let [n (boring-wire-name k)]
+                 (assoc m n v)
+                 m))
+             handlers
+             handlers))
+
 (defn- record-registry
   "Fold incognito-style record handlers into a boring registry.
 
   incognito keys its handlers by `(-> r type pr-str normalize-ns symbol)` --
-  the type name with `/` -> `.` and `-` -> `_`. That is exactly boring's own
-  wire name for a record (`boring.data/record-type-name`), so the mapping is
-  a straight rename with no translation.
+  the type name with `/` -> `.` and `-` -> `_`. That USED to be exactly
+  boring's own wire name for a record, making the mapping a straight rename.
+
+  **It stopped being true in boring 0.1.11**, which writes a record's true
+  `namespace/Name` as written and munges nothing. So a handler keyed
+  `my_ns.MyRecord` no longer matches a record boring now names
+  `my-ns/MyRecord`, and the symptom is silent: the record decodes to an
+  `UnknownRecord` carrying the right name and fields, with no error.
+
+  BOTH SPELLINGS ARE REGISTERED, and that is a persistence requirement rather
+  than a convenience. A konserve store is durable: records written under
+  boring 0.1.6 carry the munged name on disk forever, and records written from
+  now on carry the true one. A reader that knows only one of them silently
+  fails on half the store. Registering both makes an existing store keep
+  working across the upgrade.
+
+  The un-munging is best-effort by construction -- `my-ns` and `my_ns` both
+  munge to `my_ns`, so the inverse cannot be exact, and boring resolves the
+  same ambiguity on the JVM by scanning loaded namespaces (which ClojureScript
+  cannot do). Here it does not have to be exact: the key as given is
+  registered too, so a genuine underscore namespace still resolves through
+  that one.
 
   Note boring does not NEED write handlers for records: it emits the type name
   natively via CBOR tag 27, which is the problem incognito exists to work
@@ -100,7 +147,7 @@
   preparation."
   [registry handlers]
   (if (seq handlers)
-    (boring/register-records registry handlers)
+    (boring/register-records registry (with-boring-names handlers))
     registry))
 
 (def ^:private ^:const registry-cache-size

--- a/src/konserve/serializers.cljc
+++ b/src/konserve/serializers.cljc
@@ -75,6 +75,46 @@
 ;;     This one runs on both platforms from the same code.
 ;; ---------------------------------------------------------------------------
 
+(def ^:private ^:const default-index-stride
+  "Anchor every 16th entry, boring's own default. Containers smaller than
+  `:index-min` (also 16) get no node at all, so a small value pays NOTHING --
+  `encode-indexed` on a three-element vector emits the same bytes a plain
+  encode does. That is what makes indexing affordable as a default: konserve's
+  meta blobs and small values are untouched."
+  16)
+
+(def ^:private ^:const writer-buffer-size
+  "Chunk size for the per-call Writer. The value is staged by the store
+  anyway, so this trades allocation against flush count rather than peak
+  memory."
+  8192)
+
+(defn- indexing?
+  "Whether this serializer should seal an offset index onto each value.
+
+  ON BY DEFAULT, and `{:index 0}` is the documented off switch -- boring's own
+  option validator says so for every entry point that takes it.
+
+  Why default on: the index makes a stored value navigable with
+  `boring.nav` -- reaching one key without materialising the rest -- and it is
+  close to free where it matters. Measured, datom-shaped content at 200 and
+  5 000 records: +27% and +25% raw, but +3.7% and -0.7% under zstd, because
+  indexing forces `:stringref false` and zstd recovers what stringref was
+  saving. Non-datom shapes cost about 20% under zstd.
+
+  It is also FORWARD-COMPATIBLE, which is what makes it safe to switch on for
+  existing deployments: an indexed value is a two-item CBOR sequence, and
+  `decode` returns the first item and ignores the frame. Verified against
+  boring 0.1.6 -- an 0.1.11 indexed blob decodes there correctly.
+
+  The caveat is compression, and it is not small: a compressed blob has to be
+  decompressed whole before anything can navigate it, so with a compressor on
+  the index saves DECODE (materialising objects) but not IO. Only an
+  uncompressed store gets the mmap and ranged-read win. See
+  .internal/boring-indexing.md."
+  [opts]
+  (pos? (long (get opts :index default-index-stride))))
+
 (defn- boring-wire-name
   "incognito's munged key as boring >= 0.1.11 spells it, or nil if it is
   already in that form.
@@ -202,8 +242,19 @@
     ;; accepted and ignored rather than rejected, because byte 2 REJECTING them
     ;; is precisely why it was unusable.
     (let [opts (assoc encode-opts :registry registry)]
-      #?(:clj  (.write ^java.io.OutputStream output-stream ^bytes (boring/encode val opts))
-         :cljs (boring/encode val opts)))))
+      (if (indexing? opts)
+        ;; `write-indexed!` on the JVM rather than `encode-indexed`, even though
+        ;; the store stages into a ByteArrayOutputStream either way:
+        ;; `encode-indexed` builds the whole array and then WALKS it to derive
+        ;; the index -- two passes and two copies -- while this captures the
+        ;; nodes as the writer emits them. A fresh Writer per call because a
+        ;; Writer is not thread-safe and this serializer is shared; that costs
+        ;; ~600 bytes since boring 0.1.11 made the index scaffolding lazy.
+        #?(:clj  (boring/write-indexed! (boring/writer writer-buffer-size)
+                                        val output-stream opts)
+           :cljs (boring/encode-indexed val opts))
+        #?(:clj  (.write ^java.io.OutputStream output-stream ^bytes (boring/encode val opts))
+           :cljs (boring/encode val opts))))))
 
 (defn boring-serializer
   "A portable CBOR serializer backed by boring.

--- a/src/konserve/store.cljc
+++ b/src/konserve/store.cljc
@@ -268,29 +268,52 @@
 ;; ===== :file Backend (JVM only) =====
 ;; ClojureScript/Node.js :file backend is external - require konserve.node-filestore
 
+;; LIFECYCLE-ONLY KEYS, and everything else is forwarded.
+;;
+;; These methods used to hand `connect-fs-store` four keys by name -- :path,
+;; :config, :filesystem, :opts -- and silently drop the rest. So a config
+;; carrying `:default-serializer :BoringSerializer` produced a FRESSIAN store,
+;; and `:read-handlers` produced a store with no handlers, both without a word.
+;; Measured: the blob header read [1 1 1 0] -- serializer 1, fressian -- for a
+;; store that asked for boring.
+;;
+;; Re-listing keys by hand is what made that inevitable: every option added to
+;; `connect-fs-store` had to be added here too, and nothing enforced it. So the
+;; list here is of keys the LIFECYCLE owns and the backend must not see, which
+;; changes only when this namespace changes. Backend-specific validation is the
+;; backend's job -- `connect-fs-store` is where a bad `:config` should be
+;; refused, not here.
+(def ^:private lifecycle-keys
+  "Keys `konserve.store` consumes itself. Everything else reaches the backend."
+  #{:backend :path :id})
+
+#?(:clj
+   (defn- fs-store-args
+     "`connect-fs-store` arguments from a lifecycle config, as a kwarg seq."
+     [all-config opts]
+     (mapcat identity (-> all-config
+                          (as-> c (apply dissoc c lifecycle-keys))
+                          (assoc :opts opts)))))
+
 #?(:clj
    (defmethod -connect-store :file
-     [{:keys [path config filesystem] :as all-config} opts]
+     [{:keys [path filesystem] :as all-config} opts]
      (let [exists (konserve.filestore/store-exists? filesystem path)]
        (when-not exists
          (throw (ex-info (str "File store does not exist at path: " path)
                          {:path path :config all-config})))
-       (konserve.filestore/connect-fs-store path
-                                            :config config
-                                            :filesystem filesystem
-                                            :opts opts))))
+       (apply konserve.filestore/connect-fs-store path
+              (fs-store-args all-config opts)))))
 
 #?(:clj
    (defmethod -create-store :file
-     [{:keys [path config filesystem] :as all-config} opts]
+     [{:keys [path filesystem] :as all-config} opts]
      (let [exists (konserve.filestore/store-exists? filesystem path)]
        (when exists
          (throw (ex-info (str "File store already exists at path: " path)
                          {:path path :config all-config})))
-       (konserve.filestore/connect-fs-store path
-                                            :config config
-                                            :filesystem filesystem
-                                            :opts opts))))
+       (apply konserve.filestore/connect-fs-store path
+              (fs-store-args all-config opts)))))
 
 #?(:clj
    (defmethod -store-exists? :file

--- a/test/konserve/boring_serializer_test.cljc
+++ b/test/konserve/boring_serializer_test.cljc
@@ -129,8 +129,8 @@
           ser       (ser/boring-serializer)
           handlers  (atom {'konserve.boring_serializer_test.BPoint map->BPoint})
           back      (p/-deserialize ser handlers
-                                     #?(:clj (java.io.ByteArrayInputStream. old-bytes)
-                                        :cljs old-bytes))]
+                                    #?(:clj (java.io.ByteArrayInputStream. old-bytes)
+                                       :cljs old-bytes))]
       (is (= BPoint (type back)) "old-format record must reconstruct")
       (is (= (->BPoint 3 4) back)))))
 

--- a/test/konserve/boring_serializer_test.cljc
+++ b/test/konserve/boring_serializer_test.cljc
@@ -24,6 +24,8 @@
             [konserve.memory :refer [map->MemoryStore]]
             [konserve.protocols :as p]
             [konserve.serializers :as ser]
+            [boring.core :as boring]
+            [boring.data :as bdata]
             #?@(:clj [[clojure.java.io :as io]
                       [konserve.filestore :refer [connect-fs-store delete-store]]]))
   #?(:clj (:import [java.io ByteArrayInputStream ByteArrayOutputStream])))
@@ -93,12 +95,43 @@
        (is (= "1.50" (str (round-trip 1.50M)))))))
 
 (deftest records-round-trip-with-a-read-handler
-  (testing "incognito-style handlers are keyed by the normalized type symbol,
-            which is exactly boring's own wire name — so the bridge is a rename"
+  (testing "incognito-style handlers are keyed by the MUNGED type symbol
+            (`/` -> `.`, `-` -> `_`). That was boring's own wire name until
+            0.1.11, which writes the true `namespace/Name` instead — so the
+            bridge registers both spellings and this key must keep working."
     (let [back (round-trip (->BPoint 3 4)
                            {'konserve.boring_serializer_test.BPoint map->BPoint})]
       (is (= (->BPoint 3 4) back))
+      (is (= BPoint (type back)))))
+
+  (testing "and a handler keyed by boring's OWN spelling works too, since a
+            caller who reads boring's docs rather than incognito's will write
+            it that way"
+    (let [back (round-trip (->BPoint 3 4)
+                           {'konserve.boring-serializer-test/BPoint map->BPoint})]
       (is (= BPoint (type back))))))
+
+(deftest a-record-written-before-0-1-11-still-reads
+  (testing "THE UPGRADE CASE, and the reason both spellings are registered.
+            A konserve store is durable: every record written through boring
+            0.1.6 carries the MUNGED name on disk forever, while everything
+            written from now on carries the true one. A reader that knows only
+            the new spelling silently returns an UnknownRecord for half the
+            store — no error, just the wrong type.
+
+            The bytes here are a tag-27 frame naming `konserve.boring_serializer
+            _test.BPoint`, which is exactly what 0.1.6 wrote, decoded through
+            the same handler map a user upgrading would already have."
+    (let [old-bytes (boring/encode
+                     (bdata/unknown-record
+                      "konserve.boring_serializer_test.BPoint" {:x 3 :y 4}))
+          ser       (ser/boring-serializer)
+          handlers  (atom {'konserve.boring_serializer_test.BPoint map->BPoint})
+          back      (p/-deserialize ser handlers
+                                     #?(:clj (java.io.ByteArrayInputStream. old-bytes)
+                                        :cljs old-bytes))]
+      (is (= BPoint (type back)) "old-format record must reconstruct")
+      (is (= (->BPoint 3 4) back)))))
 
 (deftest records-survive-without-a-read-handler
   (testing "an unregistered record must not be LOST. boring writes the type

--- a/test/konserve/boring_serializer_test.cljc
+++ b/test/konserve/boring_serializer_test.cljc
@@ -26,6 +26,7 @@
             [konserve.serializers :as ser]
             [boring.core :as boring]
             [boring.data :as bdata]
+            #?(:clj [boring.nav :as nav])
             #?@(:clj [[clojure.java.io :as io]
                       [konserve.filestore :refer [connect-fs-store delete-store]]]))
   #?(:clj (:import [java.io ByteArrayInputStream ByteArrayOutputStream])))
@@ -184,3 +185,30 @@
                      "byte 3 — NOT 1 (fressian) and NOT 2 (clj-cbor)"))))
            (finally
              (delete-store dir)))))))
+
+#?(:clj
+   (deftest values-are-indexed-and-navigable
+     (testing "a stored value carries an offset index by default, so it can be
+               navigated without materialising the rest of it. Small values are
+               exempt automatically: nothing clears boring's :index-min, so no
+               frame is emitted and the bytes are unchanged."
+       (let [big  (into {} (for [i (range 200)]
+                             [(str "customer-" i) {"name" (str "name-" i)}]))
+             ser  (ser/boring-serializer)
+             ->b  (fn [s v] (let [o (ByteArrayOutputStream.)]
+                              (p/-serialize s o (atom {}) v)
+                              (.toByteArray o)))
+             bs   (->b ser big)]
+         (testing "it still decodes to the same value"
+           (is (= big (round-trip big))))
+         (testing "and boring.nav can reach one key through the index"
+           (is (= "name-137"
+                  (nav/value (get-in (nav/source bs) ["customer-137" "name"])))))
+         (testing "a small value gets no frame, so it costs nothing"
+           (is (= (seq (boring/encode {:a 1} {:stringref false}))
+                  (seq (->b ser {:a 1})))))
+         (testing "{:index 0} is the off switch and restores stringref"
+           (let [plain (->b (ser/boring-serializer (boring/tag-registry) {:index 0}) big)]
+             (is (= big (boring/decode plain)))
+             (is (< (alength plain) (alength bs))
+                 "unindexed keeps stringref, so it is smaller uncompressed")))))))

--- a/test/konserve/mmap_test.clj
+++ b/test/konserve/mmap_test.clj
@@ -10,7 +10,8 @@
             [konserve.filestore :refer [connect-fs-store]]
             [konserve.mmap :as kmm]
             [boring.nav :as nav]
-            [konserve.store :as st])
+            [konserve.store :as st]
+            [konserve.compressor :refer [null-compressor lz4-compressor]])
   (:import [java.io File FileInputStream FileOutputStream]))
 
 (def ^:private ffm?
@@ -155,8 +156,7 @@
            (:type (ex-data (try (connect-fs-store
                                  (fresh-dir "cmp-toplevel")
                                  :default-serializer :BoringSerializer
-                                 :compressor (requiring-resolve
-                                              'konserve.compressor/lz4-compressor)
+                                 :compressor lz4-compressor
                                  :opts {:sync? true})
                                 (catch Exception e e))))))))
 
@@ -197,3 +197,14 @@
                (mk (fresh-dir "life-both")
                    {:default-serializer :BoringSerializer
                     :config {:compressor {:type :lz4}}})))))))
+
+(deftest a-null-compressor-at-the-top-level-is-tolerated
+  (testing "konserve-rocksdb passes `:compressor null-compressor` as a dead
+            default -- the same pattern konserve's own filestore carried until
+            it was removed. Throwing on that would break a maintained backend
+            on upgrade for a value that asks for nothing. Only a MEANINGFUL
+            compressor is refused, because that is someone trying to configure
+            compression and silently getting none."
+    (is (some? (connect-fs-store (fresh-dir "null-cmp")
+                                 :compressor null-compressor
+                                 :opts {:sync? true})))))

--- a/test/konserve/mmap_test.clj
+++ b/test/konserve/mmap_test.clj
@@ -1,0 +1,120 @@
+(ns konserve.mmap-test
+  "`konserve.mmap`, which navigates a filestore value in place.
+
+  JDK GUARD. This namespace reaches `boring.mmap`, which touches
+  `java.lang.foreign` and needs JDK 22. The refusal tests do NOT — they only
+  read a header — so they run everywhere and are the ones that matter for the
+  guards. Only the mapping test is skipped on an older JVM."
+  (:require [clojure.test :refer [deftest testing is]]
+            [konserve.core :as k]
+            [konserve.filestore :refer [connect-fs-store]]
+            [konserve.mmap :as kmm]
+            [boring.nav :as nav])
+  (:import [java.io File FileInputStream FileOutputStream]))
+
+(def ^:private ffm?
+  (try ((requiring-resolve 'clojure.core/require) 'boring.mmap) true
+       (catch Throwable _ false)))
+
+(defn- fresh-dir [n]
+  (let [d (str (System/getProperty "java.io.tmpdir") "/konserve-mmap-test-" n)]
+    (when (.exists (File. d))
+      (run! #(.delete ^File %) (reverse (file-seq (File. d)))))
+    d))
+
+(defn- blob-of [dir]
+  (first (filter #(.isFile ^File %) (file-seq (File. dir)))))
+
+(defn- boring-store [dir]
+  (connect-fs-store dir :default-serializer :BoringSerializer :opts {:sync? true}))
+
+(def ^:private value
+  (into {} (for [i (range 200)] [(str "customer-" i) {"name" (str "name-" i)}])))
+
+(deftest navigates-a-value-in-place
+  (when ffm?
+    (let [dir   (fresh-dir "nav")
+          store (boring-store dir)]
+      (k/assoc store "customers" value {:sync? true})
+      (testing "the same answer konserve/get gives, without materialising the rest"
+        (is (= "name-137"
+               (kmm/with-mmap-value [c store "customers"]
+                 (nav/value (get-in c ["customer-137" "name"])))))
+        (is (= "name-137"
+               (get-in (k/get store "customers" nil {:sync? true})
+                       ["customer-137" "name"]))))
+      (testing "count is O(1) off the container head, not a walk"
+        (is (= 200 (kmm/with-mmap-value [c store "customers"] (count c))))))))
+
+(deftest value-location-points-past-the-header-and-meta
+  (let [dir   (fresh-dir "loc")
+        store (boring-store dir)]
+    (k/assoc store "customers" value {:sync? true})
+    (let [[path offset] (kmm/value-location store "customers")
+          blob (blob-of dir)]
+      (is (= (.getPath ^File blob) path))
+      (testing "the offset is 20 + meta-size, and the bytes there are a CBOR
+                item rather than the header"
+        (is (> offset 20) "meta is not empty")
+        (is (< offset (.length ^File blob)))))))
+
+(deftest a-missing-key-is-a-typed-error
+  (let [store (boring-store (fresh-dir "missing"))]
+    (is (= :konserve/key-not-found
+           (:type (ex-data (try (kmm/value-location store "nope")
+                                (catch Exception e e))))))))
+
+(deftest a-store-that-is-not-a-filestore-is-refused
+  (testing "only the filestore keeps values in files this can map"
+    (is (= :konserve/not-a-filestore
+           (:type (ex-data (try (kmm/value-location {:backing {}} "k")
+                                (catch Exception e e))))))))
+
+(deftest a-fressian-blob-is-refused-rather-than-misread
+  (testing "reading another codec's bytes as CBOR would not error, it would
+            return nonsense -- which is the whole reason this checks"
+    (let [dir   (fresh-dir "fressian")
+          store (connect-fs-store dir :opts {:sync? true})]  ; default serializer
+      (k/assoc store "customers" value {:sync? true})
+      (let [d (ex-data (try (kmm/value-location store "customers")
+                            (catch Exception e e)))]
+        (is (= :konserve/not-navigable (:type d)))
+        (is (= 1 (:serializer d)) "byte 1 is fressian")))))
+
+;; The compression and encryption guards read a header byte, so they are tested
+;; by writing that byte. Going through `connect-fs-store` would test konserve's
+;; option plumbing instead -- and in fact cannot: passing `:compressor` there
+;; leaves the store on `null-compressor`, so a blob written that way carries a
+;; 0 and exercises nothing.
+(defn- doctor-header!
+  "Rewrite one header byte of `dir`'s blob in place."
+  [dir idx v]
+  (let [^File f (blob-of dir)
+        bs (byte-array (.length f))]
+    (with-open [in (FileInputStream. f)] (.read in bs))
+    (aset-byte bs idx (byte v))
+    (with-open [out (FileOutputStream. f)] (.write out bs))))
+
+(deftest a-compressed-blob-is-refused
+  (testing "a compressed blob must be decompressed whole before anything can
+            navigate it, which is exactly the cost this exists to avoid. It
+            throws rather than falling back, because a silent fallback would
+            give correct answers at full price with no way to notice."
+    (let [dir   (fresh-dir "compressed")
+          store (boring-store dir)]
+      (k/assoc store "customers" value {:sync? true})
+      (doctor-header! dir 2 2)                      ; compressor byte -> zstd
+      (let [d (ex-data (try (kmm/value-location store "customers")
+                            (catch Exception e e)))]
+        (is (= :konserve/not-navigable (:type d)))
+        (is (= 2 (:compressor d)))))))
+
+(deftest an-encrypted-blob-is-refused
+  (let [dir   (fresh-dir "encrypted")
+        store (boring-store dir)]
+    (k/assoc store "customers" value {:sync? true})
+    (doctor-header! dir 3 1)                        ; encryptor byte
+    (let [d (ex-data (try (kmm/value-location store "customers")
+                          (catch Exception e e)))]
+      (is (= :konserve/not-navigable (:type d)))
+      (is (= 1 (:encryptor d))))))

--- a/test/konserve/mmap_test.clj
+++ b/test/konserve/mmap_test.clj
@@ -9,7 +9,8 @@
             [konserve.core :as k]
             [konserve.filestore :refer [connect-fs-store]]
             [konserve.mmap :as kmm]
-            [boring.nav :as nav])
+            [boring.nav :as nav]
+            [konserve.store :as st])
   (:import [java.io File FileInputStream FileOutputStream]))
 
 (def ^:private ffm?
@@ -158,3 +159,41 @@
                                               'konserve.compressor/lz4-compressor)
                                  :opts {:sync? true})
                                 (catch Exception e e))))))))
+
+;; --------------------------------------------------------------------------
+;; The lifecycle API must not drop what it is given.
+
+(deftest lifecycle-config-reaches-the-backend
+  (testing "`konserve.store/create-store` used to forward four keys by name --
+            :path, :config, :filesystem, :opts -- and silently drop the rest.
+            A config asking for `:default-serializer :BoringSerializer` produced
+            a FRESSIAN store, header byte 1, without a word.
+
+            Asserted on the HEADER rather than the store record, because the
+            header is what a later reader actually dispatches on, and every bug
+            in this family was invisible precisely because nothing checked the
+            resulting bytes."
+    (let [hdr-of (fn [dir]
+                   (with-open [in (FileInputStream. ^File (blob-of dir))]
+                     (let [b (byte-array 4)] (.read in b)
+                          (vec (map #(bit-and % 0xff) b)))))
+          mk (fn [dir cfg]
+               (let [store (st/create-store
+                            (merge {:backend :file :path dir
+                                    :id (java.util.UUID/randomUUID)}
+                                   cfg)
+                            {:sync? true})]
+                 (k/assoc store "customers" value {:sync? true})
+                 [(hdr-of dir) (:default-serializer store)]))]
+      (testing "the default is still fressian, byte 1"
+        (is (= [[1 1 0 0] :FressianSerializer] (mk (fresh-dir "life-default") {}))))
+      (testing ":default-serializer reaches the store AND the header"
+        (is (= [[1 3 0 0] :BoringSerializer]
+               (mk (fresh-dir "life-boring")
+                   {:default-serializer :BoringSerializer}))))
+      (testing "and it composes with :config, which was the one key that did
+                get forwarded"
+        (is (= [[1 3 1 0] :BoringSerializer]
+               (mk (fresh-dir "life-both")
+                   {:default-serializer :BoringSerializer
+                    :config {:compressor {:type :lz4}}})))))))

--- a/test/konserve/mmap_test.clj
+++ b/test/konserve/mmap_test.clj
@@ -118,3 +118,43 @@
                           (catch Exception e e)))]
       (is (= :konserve/not-navigable (:type d)))
       (is (= 1 (:encryptor d))))))
+
+;; --------------------------------------------------------------------------
+;; The bug this file's compression guard could not be tested against.
+
+(deftest compression-is-configured-under-config
+  (testing "`:config {:compressor {:type :lz4}}` is the spelling that works,
+            and it must land in the blob header. `connect-default-store` reads
+            both compressor and encryptor from `config`, never from a
+            top-level key."
+    (let [dir   (fresh-dir "cmp-config")
+          store (connect-fs-store dir :default-serializer :BoringSerializer
+                                  :config {:compressor {:type :lz4}}
+                                  :opts {:sync? true})]
+      (k/assoc store "customers" value {:sync? true})
+      (let [^bytes hdr (with-open [in (FileInputStream. ^File (blob-of dir))]
+                         (let [b (byte-array 4)] (.read in b) b))]
+        (is (= 1 (bit-and (aget hdr 2) 0xff)) "compressor byte 1 = lz4"))
+      (testing "and konserve.mmap refuses it, since a compressed blob has to be
+                decompressed whole before anything can navigate it"
+        (is (= :konserve/not-navigable
+               (:type (ex-data (try (kmm/value-location store "customers")
+                                    (catch Exception e e))))))))))
+
+(deftest a-top-level-compressor-is-refused-not-ignored
+  (testing "passing a compressor FUNCTION at the top level reads like it should
+            work and did nothing: the store came back on null-compressor and
+            wrote a 0 into every header while the caller believed their data
+            was compressed. `connect-fs-store` even shipped
+            `:compressor null-compressor` as a default that was never read.
+
+            Silence is the wrong answer for a durable property nobody
+            re-checks, so this now throws and names the right spelling."
+    (is (= :store-configuration-error
+           (:type (ex-data (try (connect-fs-store
+                                 (fresh-dir "cmp-toplevel")
+                                 :default-serializer :BoringSerializer
+                                 :compressor (requiring-resolve
+                                              'konserve.compressor/lz4-compressor)
+                                 :opts {:sync? true})
+                                (catch Exception e e))))))))


### PR DESCRIPTION
Bumps boring to 0.1.13 and makes its serializer (byte 3) useful — plus three config bugs found on the way, each of which silently ignored what the caller asked for.

**boring as a store serializer is marked BETA** in `boring-serializer`s docstring. The codec is well covered, but it has not been exercised at scale or across an upgrade of a long-lived store. Fressian (byte 1) stays the default and the tested choice.

## boring

- **0.1.11 → 0.1.13.** 0.1.11 changed a records wire name to its true `namespace/Name`; konserves incognito bridge derived its key by *munging*, which used to be that name. Every record handler silently stopped matching — an `UnknownRecord` with the right name and fields, no error. **Both spellings are now registered**, which is a persistence requirement: records already on disk carry the old name forever.
- **Values are indexed by default** (`{:index 0}` to disable), so a stored value is navigable rather than only decodable whole. Safe as a default for three measured reasons: a small value emits *no frame at all* and is byte-identical to a plain encode; an indexed value is forward-compatible (verified — boring **0.1.6** decodes an 0.1.11 indexed blob, 100 entries, no error); and under zstd it is nearly free on datom-shaped data (+3.7% at 200 records, **−0.7%** at 5 000, against +27%/+25% raw).
- **`konserve.mmap`** (experimental) navigates a filestore value in place. Its own namespace because `boring.mmap` needs JDK 22 and `filestore.clj` must keep loading on 21; resolved dynamically so requiring it does not fail on an older JVM.

## Three config bugs

All the same shape: **the caller asked for something and got something else, silently.**

1. **A top-level `:compressor` did nothing.** `connect-default-store` reads it from `(get-in config [:compressor :type])`, so `(connect-fs-store path :compressor lz4-compressor)` left the store on `null-compressor` and wrote a 0 into every header. `connect-fs-store` even shipped `:compressor null-compressor` as a *dead default* that was never read. Now throws, naming the spelling that works: `:config {:compressor {:type :lz4}}` — a **type keyword, not a function**. Only a *meaningful* compressor is refused; `null-compressor` is tolerated because konserve-rocksdb passes it as a dead default and would otherwise break on upgrade.

2. **The lifecycle API dropped five keys.** `-connect-store :file` forwarded four by name and discarded the rest, so `{:backend :file :default-serializer :BoringSerializer}` produced a **Fressian** store — header `[1 1 1 0]`. `:read-handlers` went the same way, which is sharper: custom record handlers silently do not apply. Inverted so the list is of keys the *lifecycle owns* (`:backend :path :id`); everything else reaches the backend.

3. `connect-fs-store`s dead `:compressor`/`:encryptor` defaults removed.

## Tests assert header bytes, not config maps

Every bug in this family was invisible because nothing checked the bytes that resulted. `lifecycle-config-reaches-the-backend`, `compression-is-configured-under-config` and `a-top-level-compressor-is-refused-not-ignored` all assert on the blob header, which is what a later reader actually dispatches on.

116 tests / 1380 assertions green; `clojure -M:format` clean.

## Known, not addressed here

An audit of the backends the README lists found **no two behave the same way**:

| backend | `:default-serializer` | user `:config` |
|---|---|---|
| `:file` | fixed here | ok |
| `:s3` | **hardcoded** Fressian | ok |
| `:dynamodb` / `:redis` | ok | **`:config` dissocd** |
| `:rocksdb` | **hardcoded** | **params ignored entirely** |
| `:lmdb` | bypasses `DefaultStore` | — |

So s3 and rocksdb cannot use boring at all today. Follow-up PRs, and a config-shape change (`:config {:encoding {...}}`) to stop this recurring — normalised in `connect-default-store`, which is the single funnel all five backends pass through.