### PR TITLE
Config: :config :encoding, with old spellings still working

### DIFF
--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -3,7 +3,7 @@
    [clojure.core.async :refer [go <!! chan close! put!]]
    [clojure.java.io :as io]
    [clojure.string :refer [includes? ends-with?]]
-   [konserve.impl.defaults :refer [update-blob connect-default-store key->store-key store-key->uuid-key]]
+   [konserve.impl.defaults :refer [update-blob connect-default-store key->store-key store-key->uuid-key normalize-store-config]]
    [konserve.impl.storage-layout :refer [PBackingStore
                                          PBackingBlob -close
                                          PBackingLock header-size]]
@@ -734,16 +734,32 @@
   ;; `(get-in config [:compressor :type])` -- so they were dead, and worse,
   ;; they made a top-level `:compressor` look supported when passing one did
   ;; nothing at all. That path now throws; see connect-default-store.
-  (let [store-config (merge {:default-serializer :FressianSerializer
-                             :read-handlers      (atom {})
-                             :write-handlers     (atom {})
-                             :buffer-size        (* 1024 1024)
-                             :opts               {:sync? false}
-                             :config             (merge {:sync-blob? true
-                                                         :in-place? false
-                                                         :lock-blob? true}
-                                                        config)}
-                            (dissoc params :config :filesystem))
+  ;; CANONICAL SHAPE. The codec group lives under `:config :encoding` -- see
+  ;; `konserve.impl.defaults/normalize-store-config`. Emitting it here rather
+  ;; than the old spellings is what makes the deprecation warnings mean
+  ;; something: konserve's own defaults would otherwise trip them on every
+  ;; connect, for every caller, whatever they wrote.
+  (let [;; NORMALISE THE CALLER FIRST, then fill defaults into the gaps.
+        ;; Order matters and got this wrong once: applying our own
+        ;; `:encoding {:serializer :FressianSerializer}` default before
+        ;; normalising meant a caller's older `:default-serializer
+        ;; :BoringSerializer` found the slot already taken and was dropped --
+        ;; reintroducing the exact silent-override bug this shape exists to
+        ;; end. Caught by the old-spelling test asserting header byte 3.
+        store-config (-> (dissoc params :filesystem)
+                         (assoc :config (or config {}))
+                         normalize-store-config
+                         (update :config #(merge {:sync-blob? true
+                                                  :in-place? false
+                                                  :lock-blob? true}
+                                                 %))
+                         (update-in [:config :encoding]
+                                    #(merge {:serializer     :FressianSerializer
+                                             :read-handlers  (atom {})
+                                             :write-handlers (atom {})}
+                                            %))
+                         (update :buffer-size #(or % (* 1024 1024)))
+                         (update :opts #(or % {:sync? false})))
         detect-old-blob (when detect-old-file-schema?
                           (atom (detect-old-file-schema filesystem path)))
         _                  (when detect-old-file-schema?

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -745,6 +745,111 @@
   (-set-write-hooks! [this hooks-atom]
     (assoc this :write-hooks hooks-atom)))
 
+(def ^:const encoding-keys
+  "What `:config :encoding` may contain.
+
+  The first three ARE the blob header -- serializer, compressor and encryptor
+  are bytes 1, 2 and 3 of every blob, and a later reader dispatches on them.
+  That is what makes this group real rather than a tidy-up: get one wrong and
+  the bytes on disk mean something else.
+
+  The handlers and the serializer registry are not in the header. They are
+  here because they are about turning a value into bytes, and because keeping
+  them next to `:serializer` is what makes \"your handlers must match what was
+  written\" legible -- separating them is how a record wire-name change went
+  unnoticed until a test asserted equality with the input."
+  #{:serializer :compressor :encryptor :serializers :read-handlers :write-handlers})
+
+(defn- deprecated!
+  [from to]
+  (log/warn :konserve/deprecated-config
+            {:msg (str "konserve: " from " is deprecated; use " to
+                       ". Both work for now.")
+             :from from :to to}))
+
+(defn normalize-store-config
+  "A store config in canonical shape: everything about value-to-bytes under
+  `:config :encoding`.
+
+      {:backend :file :path \"...\" :id #uuid \"...\"      ; which store
+       :config {:encoding {:serializer :BoringSerializer  ; header byte 1
+                           :compressor {:type :zstd}      ; header byte 2
+                           :encryptor  {:type :aes}}      ; header byte 3
+                :sync-blob? true                          ; local policy
+                :in-place?  false}}
+
+  Three levels, three rules: the top says WHICH store, `:encoding` says how a
+  value becomes bytes and is durable, the rest of `:config` is local policy you
+  can change between runs without anything on disk caring.
+
+  OLD SPELLINGS STILL WORK and warn. `:default-serializer` and the handler maps
+  used to sit at the top level while `:compressor` sat inside `:config`, with
+  no rule saying why -- which is how five backends each guessed differently and
+  three of them silently ignored what they were handed.
+
+  Canonical wins if both are present, so a caller migrating one key at a time
+  never gets a surprise from the leftover."
+  [params]
+  (let [enc (get-in params [:config :encoding] {})
+        ;; Old top-level spellings. These DID work through `connect-fs-store`,
+        ;; so they are the real deprecation surface; the same keys through the
+        ;; lifecycle API were dropped and cannot have been relied on.
+        enc (reduce (fn [e [old new]]
+                      (if (and (contains? params old) (not (contains? e new)))
+                        (do (deprecated! old (str ":config :encoding " new))
+                            (assoc e new (get params old)))
+                        e))
+                    enc
+                    [[:default-serializer :serializer]
+                     [:serializers :serializers]
+                     [:read-handlers :read-handlers]
+                     [:write-handlers :write-handlers]])
+        ;; And the old `:config` spellings, which are what works today.
+        enc (reduce (fn [e k]
+                      (if (and (contains? (:config params) k) (not (contains? e k)))
+                        (do (deprecated! (str ":config " k) (str ":config :encoding " k))
+                            (assoc e k (get-in params [:config k])))
+                        e))
+                    enc
+                    [:compressor :encryptor])
+        bad (remove encoding-keys (keys enc))]
+    (when (seq bad)
+      (throw (ex-info (str "konserve: unknown key(s) in :config :encoding: "
+                           (pr-str (vec bad)) ". Accepted: "
+                           (pr-str (vec (sort encoding-keys))) ".")
+                      {:type :store-configuration-error :unknown (vec bad)})))
+    (-> params
+        (dissoc :default-serializer :serializers :read-handlers :write-handlers)
+        (update :config #(-> (or % {}) (dissoc :compressor :encryptor)
+                             (assoc :encoding enc))))))
+
+(defn assert-encoding-supported!
+  "Throw unless the config's encoding is one `backend-name` can honour.
+
+  `supported` is `{:serializers #{...} :compressors #{...} :encryptors #{...}}`
+  of ACCEPTED values; `nil` for a slot means anything goes. Compressor and
+  encryptor are named by `:type` keyword, with `:none` standing for absent.
+
+  For backends that cannot honour an arbitrary encoding -- konserve-lmdb uses
+  its own buffer format, and others hardcoded a serializer for years -- so that
+  they REFUSE rather than accept and quietly write something else. Every config
+  bug this shape has produced was a backend accepting a setting it then
+  ignored; a shared helper means the refusal reads the same everywhere instead
+  of being spelled five ways or not at all."
+  [backend-name config {:keys [serializers compressors encryptors]}]
+  (let [enc (get-in config [:config :encoding] {})
+        chk (fn [allowed got what]
+              (when (and allowed (not (contains? allowed got)))
+                (throw (ex-info (str "konserve: " backend-name " does not support "
+                                     what " " (pr-str got) ". Supported: "
+                                     (pr-str (vec (sort-by str allowed))) ".")
+                                {:type :store-configuration-error
+                                 :backend backend-name what got}))))]
+    (chk serializers (or (:serializer enc) :FressianSerializer) :serializer)
+    (chk compressors (or (get-in enc [:compressor :type]) :none) :compressor)
+    (chk encryptors  (or (get-in enc [:encryptor :type]) :none) :encryptor))
+  config)
+
 (defn connect-default-store
   "Create general store in given base of backing store."
   [backing
@@ -757,13 +862,29 @@
            buffer-size        (* 1024 1024)
            opts               {:sync? false}}
     :as   params}]
-  ;; check config
-  (let [complete-config (merge {:sync-blob? true
+  ;; NORMALISED FIRST, so everything below reads one shape. `params` is what
+  ;; the caller wrote, in any accepted spelling; `p` is canonical.
+  (let [p (normalize-store-config params)
+        config (:config p)
+        enc (:encoding config)
+        default-serializer (or (:serializer enc) default-serializer)
+        serializers (or (:serializers enc) serializers)
+        read-handlers (or (:read-handlers enc) read-handlers)
+        write-handlers (or (:write-handlers enc) write-handlers)
+        ;; `:compressor`/`:encryptor` are ALSO left at `:config` level, because
+        ;; the use sites read them there: `update-blob` applies the encryptor
+        ;; to `(:encryptor config)`, which is where its KEY lives, not just its
+        ;; type. Moving them under `:encoding` and stopping there silently
+        ;; stripped the encryption key -- 34 tests in the compressor/encryptor
+        ;; matrix caught it. `:encoding` is where a caller CONFIGURES them;
+        ;; this keeps the existing readers working until they are migrated too.
+        complete-config (merge {:sync-blob? true
                                 :in-place? false
                                 :lock-blob? true}
-                               config)
-        compressor (get-compressor (get-in config [:compressor :type]))
-        encryptor (get-encryptor (get-in config [:encryptor :type]))]
+                               config
+                               (select-keys enc [:compressor :encryptor]))
+        compressor (get-compressor (get-in enc [:compressor :type]))
+        encryptor (get-encryptor (get-in enc [:encryptor :type]))]
     ;; A top-level `:compressor`/`:encryptor` is REFUSED rather than ignored.
     ;; Both are read from `config` above, so passing a function at the top
     ;; level -- which reads exactly like it should work, and which

--- a/test/konserve/encoding_config_test.clj
+++ b/test/konserve/encoding_config_test.clj
@@ -1,0 +1,107 @@
+(ns konserve.encoding-config-test
+  "`:config :encoding` — the canonical home for everything about turning a
+  value into bytes, and the old spellings that must keep working.
+
+  Every assertion here is on the BLOB HEADER rather than the config map,
+  because the header is what a later reader dispatches on. Every bug in this
+  family was invisible precisely because nothing checked the resulting bytes."
+  (:require [clojure.test :refer [deftest testing is]]
+            [konserve.core :as k]
+            [konserve.store :as st]
+            [konserve.filestore :refer [connect-fs-store]]
+            [konserve.impl.defaults :refer [normalize-store-config
+                                            assert-encoding-supported!]])
+  (:import [java.io File FileInputStream]))
+
+(defn- fresh-dir [n]
+  (let [d (str (System/getProperty "java.io.tmpdir") "/konserve-enc-" n)]
+    (when (.exists (File. d))
+      (run! #(.delete ^File %) (reverse (file-seq (File. d)))))
+    d))
+
+(defn- header-of
+  "[version serializer compressor encryptor] of the store's only blob."
+  [dir]
+  (let [^File f (first (filter #(.isFile ^File %) (file-seq (File. dir))))]
+    (with-open [in (FileInputStream. f)]
+      (let [b (byte-array 4)] (.read in b)
+           (vec (map #(bit-and % 0xff) b))))))
+
+(defn- write! [dir cfg]
+  (let [store (st/create-store (merge {:backend :file :path dir
+                                       :id (java.util.UUID/randomUUID)}
+                                      cfg)
+                               {:sync? true})]
+    (k/assoc store "k" {:a (vec (range 100))} {:sync? true})
+    (header-of dir)))
+
+(deftest encoding-drives-the-header
+  (testing "the canonical shape reaches all three header bytes"
+    (is (= [1 1 0 0] (write! (fresh-dir "default") {})))
+    (is (= [1 3 0 0] (write! (fresh-dir "boring")
+                             {:config {:encoding {:serializer :BoringSerializer}}})))
+    (is (= [1 3 1 0] (write! (fresh-dir "both")
+                             {:config {:encoding {:serializer :BoringSerializer
+                                                  :compressor {:type :lz4}}}})))))
+
+(deftest old-spellings-still-work
+  (testing "`:default-serializer` at the top level and `:compressor` directly
+            under `:config` are the pre-:encoding spellings. They must keep
+            producing the same bytes -- konserve is pre-1.0 but silently
+            changing what a caller's config means is the failure this whole
+            shape exists to prevent."
+    (is (= [1 3 1 0] (write! (fresh-dir "old")
+                             {:default-serializer :BoringSerializer
+                              :config {:compressor {:type :lz4}}})))))
+
+(deftest canonical-wins-over-the-old-spelling
+  (testing "so a caller migrating one key at a time never gets a surprise from
+            the leftover"
+    (is (= [1 3 0 0] (write! (fresh-dir "both-spellings")
+                             {:default-serializer :FressianSerializer
+                              :config {:encoding {:serializer :BoringSerializer}}})))))
+
+(deftest an-unknown-encoding-key-is-refused
+  (testing "this is what stops the family recurring: a typo or a wrong-shaped
+            value fails loudly instead of being silently ignored, which is how
+            every bug here started"
+    (is (= :store-configuration-error
+           (:type (ex-data (try (normalize-store-config
+                                 {:config {:encoding {:compresor {:type :lz4}}}})
+                                (catch Exception e e))))))))
+
+(deftest normalize-is-idempotent
+  (testing "a config that is already canonical must pass through unchanged --
+            otherwise normalising twice, which the filestore and
+            connect-default-store both do, would drift"
+    (let [c {:config {:encoding {:serializer :BoringSerializer}
+                      :sync-blob? true}}]
+      (is (= (normalize-store-config c)
+             (normalize-store-config (normalize-store-config c)))))))
+
+(deftest backends-can-refuse-an-encoding-they-cannot-honour
+  (testing "konserve-lmdb uses its own buffer format and cannot honour an
+            arbitrary serializer; others hardcoded one for years. A shared
+            helper makes the refusal read the same everywhere, instead of
+            being spelled five ways -- or, as it was, not at all."
+    (let [cfg {:config {:encoding {:serializer :BoringSerializer}}}]
+      (testing "an unsupported serializer is refused, naming what is supported"
+        (is (= :store-configuration-error
+               (:type (ex-data (try (assert-encoding-supported!
+                                     "konserve-lmdb" cfg
+                                     {:serializers #{:FressianSerializer}})
+                                    (catch Exception e e)))))))
+      (testing "a supported one passes through"
+        (is (= cfg (assert-encoding-supported!
+                    "konserve-x" cfg
+                    {:serializers #{:BoringSerializer :FressianSerializer}}))))
+      (testing "nil means the backend does not care"
+        (is (= cfg (assert-encoding-supported! "konserve-x" cfg {}))))
+      (testing "compression is named by :type, with :none for absent"
+        (is (= :store-configuration-error
+               (:type (ex-data (try (assert-encoding-supported!
+                                     "konserve-y"
+                                     {:config {:encoding {:compressor {:type :lz4}}}}
+                                     {:compressors #{:none}})
+                                    (catch Exception e e))))))
+        (is (some? (assert-encoding-supported! "konserve-y" {} {:compressors #{:none}})))))))


### PR DESCRIPTION
S1 from the plan: the normaliser and the shared helper. Backends are untouched and migrate at their own pace.

## The shape

```clojure
{:backend :file :path "..." :id #uuid "..."        ; which store
 :config {:encoding {:serializer :BoringSerializer ; header byte 1
                     :compressor {:type :zstd}     ; header byte 2
                     :encryptor  {:type :aes}}     ; header byte 3
          :sync-blob? true                         ; local policy
          :in-place?  false}}
```

Three levels, three rules a reviewer can apply without asking:

1. **top** — which store, where. Backend-specific.
2. **`:config :encoding`** — how a value becomes bytes. **Durable**; change it and old data may not read.
3. **rest of `:config`** — local policy. Change freely; nothing on disk cares.

`opts` (`{:sync? true}`) is unchanged — per-call execution, not store identity.

The first three keys are not a tidy-up: **they are the blob header**, and a later reader dispatches on them. Before this, `:default-serializer` sat at the top level while `:compressor` sat under `:config` with no rule saying why — which is how five backends each guessed differently and three silently ignored what they were handed.

## Backwards compatibility

Old spellings work and warn. `konserve.filestore` emits the canonical shape so the warnings mean something — its own defaults would otherwise trip them on every connect, for every caller, whatever they wrote.

The blast radius was checked rather than assumed: **datahike, konserve-sync, persistent-sorted-set and the datahike-* backends pass none of these keys**. kabels four hits are its own peer API. The only real deprecation surface is direct `connect-fs-store` callers.

## Normalised at the funnel

`connect-default-store` — filestore, s3, dynamodb, redis and rocksdb all call it. The shape lands for all of them **without touching any**.

## Two things this got wrong first, both caught by tests

- **Defaults must fill AFTER normalising.** Applying our own `:encoding {:serializer :FressianSerializer}` first meant a callers older `:default-serializer :BoringSerializer` found the slot taken and was dropped — reintroducing the exact silent override this shape exists to end.
- **`:compressor`/`:encryptor` must stay readable at `:config` level too.** The use sites read `(:encryptor config)` for its **key**, not just its type; moving them under `:encoding` and stopping there stripped the encryption key. 34 tests in the compressor/encryptor matrix caught it.

## `assert-encoding-supported!`

For backends that cannot honour an arbitrary encoding — konserve-lmdb uses its own buffer format, others hardcoded a serializer for years. They **refuse** rather than accept and quietly write something else, in one wording rather than five.

```clojure
(assert-encoding-supported! "konserve-lmdb" config {:serializers #{}})
```

Unknown keys under `:encoding` are refused too, which is what stops this family recurring: `:compresor` now fails loudly instead of being ignored.

## Tests

All assertions are on **blob header bytes**, not config maps — every bug in this family was invisible because nothing checked the bytes that resulted. Also covers idempotence, since both the filestore and `connect-default-store` normalise.

122 tests / 1392 assertions green; `clojure -M:format` clean.

Next: backends emit the new shape and adopt the helper (warnings go quiet, signalling the old spelling can be dropped) — combined with the s3/rocksdb/dynamodb/redis fixes they need anyway.