### PR TITLE
mmap: add navigable?, and judge the blob rather than the store

### DIFF
--- a/src/konserve/mmap.clj
+++ b/src/konserve/mmap.clj
@@ -117,8 +117,10 @@
       (throw (ex-info (str "konserve.mmap: this blob is compressed (compressor "
                            cb "), and a compressed blob must be decompressed "
                            "whole before anything can navigate it -- which is "
-                           "the cost this avoids. Use an uncompressed store for "
-                           "navigable values, or konserve.core/get.")
+                           "the cost this avoids. Encoding is per BLOB, not per "
+                           "store, so values written while no compressor was "
+                           "configured stay navigable; this one was not. Use "
+                           "konserve.core/get for it.")
                       {:type :konserve/not-navigable :compressor cb :key key})))
     (when-not (zero? eb)
       (throw (ex-info (str "konserve.mmap: this blob is encrypted (encryptor "
@@ -126,6 +128,27 @@
                            "decrypted whole first. Use konserve.core/get.")
                       {:type :konserve/not-navigable :encryptor eb :key key})))
     [(.getPath f) (+ header-size (be-int hdr 4))]))
+
+(defn navigable?
+  "Whether `key`'s blob can be navigated in place, without throwing.
+
+  ENCODING IS PER BLOB, not per store. A store's serializer and compressor are
+  applied to what it writes NEXT; blobs already on disk keep the encoding they
+  were written with, and every read dispatches on that blob's own header. So a
+  store that switches to boring holds a mix, indefinitely and by design --
+  nothing needs migrating.
+
+  Which makes a mixed store the normal case rather than an error, and asking
+  cheaper than catching:
+
+      (if (navigable? store k)
+        (with-mmap-value [c store k] (nav/value (get-in c path)))
+        (get-in (k/get store k nil {:sync? true}) path))
+
+  Reads only the 20-byte header."
+  [store key]
+  (try (boolean (value-location store key))
+       (catch Exception _ false)))
 
 (defn mmap-value
   "`[cursor arena]` over the value of `key`. **Prefer `with-mmap-value`**,

--- a/test/konserve/mmap_test.clj
+++ b/test/konserve/mmap_test.clj
@@ -208,3 +208,35 @@
     (is (some? (connect-fs-store (fresh-dir "null-cmp")
                                  :compressor null-compressor
                                  :opts {:sync? true})))))
+
+(deftest encoding-is-per-blob-not-per-store
+  (testing "a store's serializer applies to what it writes NEXT. Blobs already
+            on disk keep the encoding they were written with, and every read
+            dispatches on that blob's own header -- so switching a store's
+            default needs no migration and leaves a mix, by design.
+
+            konserve.mmap must therefore judge the BLOB, never the store: a
+            boring-configured store still holds fressian blobs it cannot
+            navigate, and that is correct rather than a failure."
+    (let [dir (fresh-dir "mixed")
+          fressian-store (connect-fs-store dir :opts {:sync? true})
+          _ (k/assoc fressian-store "old" {:a 1} {:sync? true})
+          boring-store (connect-fs-store
+                        dir :default-serializer :BoringSerializer
+                        :opts {:sync? true})
+          _ (k/assoc boring-store "new" value {:sync? true})]
+      (testing "both blobs read correctly through EITHER store"
+        (is (= {:a 1} (k/get boring-store "old" nil {:sync? true})))
+        (is (some? (k/get fressian-store "new" nil {:sync? true}))))
+      (testing "the boring blob is navigable"
+        (is (true? (kmm/navigable? boring-store "new")))
+        (when ffm?
+          (is (= "name-137" (kmm/with-mmap-value [c boring-store "new"]
+                              (nav/value (get-in c ["customer-137" "name"])))))))
+      (testing "and the fressian one is not -- judged by its own header, not by
+                the store that happens to be asking"
+        (is (false? (kmm/navigable? boring-store "old")))
+        (is (= 1 (:serializer (ex-data (try (kmm/value-location boring-store "old")
+                                            (catch Exception e e)))))))
+      (testing "a missing key is not navigable rather than throwing"
+        (is (false? (kmm/navigable? boring-store "absent")))))))


### PR DESCRIPTION
Follow-up to the per-blob encoding semantics.

Encoding is per **blob**, not per store: a stores serializer and compressor apply to what it writes *next*, blobs already on disk keep the encoding they were written with, and every read dispatches on that blobs own header. So swapping a stores default needs no migration and leaves a mix indefinitely, by design — which is how the default moves to boring once it has earned it.

## `konserve.mmap` was already consistent

It reads each blobs own header and never the store config. Verified with a fressian blob and a boring blob in one directory:

| | |
|---|---|
| fressian blob read via **boring**-configured store | ✓ |
| boring blob read via **fressian**-configured store | ✓ |
| mmap on the boring blob | ✓ |
| mmap on the fressian blob | `:konserve/not-navigable`, serializer 1 — correct |

## Two things that consistency did not extend to

**The compression error gave store-level advice** — "use an uncompressed store" — which is wrong under per-blob semantics. Values written while no compressor was configured stay navigable whatever the store is set to now. Reworded.

**No way to ask without catching.** In a mixed store — the normal state during a default swap, not an error — catching is the wrong shape:

```clojure
(if (navigable? store k)
  (with-mmap-value [c store k] (nav/value (get-in c path)))
  (get-in (k/get store k nil {:sync? true}) path))
```

`navigable?` reads only the 20-byte header, and answers `false` for a missing key rather than throwing, so it works as a plain predicate.

117 tests / 1387 assertions green; `clojure -M:format` clean.

Independent of #164 — different files, and the new test uses the `:default-serializer` spelling that works on main today.