### PR TITLE
README: gcs is supported, and name every backend in one place

### DIFF
--- a/README.org
+++ b/README.org
@@ -330,10 +330,7 @@ After requiring a backend module, it automatically registers with the multimetho
 - =:lmdb= - LMDB ([[https://github.com/replikativ/konserve-lmdb][konserve-lmdb]])
 - =:rocksdb= - RocksDB ([[https://github.com/replikativ/konserve-rocksdb][konserve-rocksdb]])
 - =:jdbc= - JDBC databases ([[https://github.com/replikativ/konserve-jdbc][konserve-jdbc]])
-
-*** Unofficial Backends
-
-- [[https://github.com/The-Literal-Company/konserve-gcs][konserve-gcs]] - Google Cloud Storage
+- =:gcs= - Google Cloud Storage ([[https://github.com/replikativ/konserve-gcs][konserve-gcs]])
 
 *** Outdated Backends
 
@@ -570,7 +567,7 @@ system by defining multimethod implementations for:
 All backends must implement strict semantics where =create-store= errors if the store
 already exists and =connect-store= errors if the store doesn't exist. See existing
 external backends (konserve-s3, konserve-lmdb, konserve-rocksdb, konserve-redis,
-konserve-dynamodb) for reference implementations.
+konserve-dynamodb, konserve-jdbc, konserve-gcs) for reference implementations.
 
 ** Projects Building on Konserve
    :PROPERTIES:

--- a/src/konserve/store.cljc
+++ b/src/konserve/store.cljc
@@ -339,31 +339,38 @@
 ;; Default Error Handling
 ;; =============================================================================
 
+(def ^:private known-backends
+  "The backends a user can reach, for the unsupported-backend error.
+
+  ONE string, FOUR call sites. It was four copies, and they had already
+  drifted: `:jdbc` and `:gcs` were missing from all of them while both are
+  listed in the README as available. An error message that names an incomplete
+  set sends someone looking for a backend that exists."
+  (str "\n\nBuilt-in backends: :memory (all platforms), :file (JVM only), :tiered"
+       "\nExternal backends: :file (Node.js - konserve.node-filestore),"
+       " :indexeddb (browser), :s3, :dynamodb, :redis, :lmdb, :rocksdb, :jdbc,"
+       " :gcs"
+       "\nMake sure the corresponding backend module is required before use."))
+
 (defmethod -connect-store :default
   [{:keys [backend] :as config} _opts]
   (throw (ex-info
           (str "Unsupported store backend: " backend
-               "\n\nBuilt-in backends: :memory (all platforms), :file (JVM only), :tiered"
-               "\nExternal backends: :file (Node.js - konserve.node-filestore), :indexeddb (browser), :s3, :dynamodb, :redis, :lmdb, :rocksdb"
-               "\nMake sure the corresponding backend module is required before use.")
+               known-backends)
           {:backend backend :config config})))
 
 (defmethod -create-store :default
   [{:keys [backend] :as config} _opts]
   (throw (ex-info
           (str "Unsupported store backend: " backend
-               "\n\nBuilt-in backends: :memory (all platforms), :file (JVM only), :tiered"
-               "\nExternal backends: :file (Node.js - konserve.node-filestore), :indexeddb (browser), :s3, :dynamodb, :redis, :lmdb, :rocksdb"
-               "\nMake sure the corresponding backend module is required before use.")
+               known-backends)
           {:backend backend :config config})))
 
 (defmethod -store-exists? :default
   [{:keys [backend] :as config} _opts]
   (throw (ex-info
           (str "Unsupported store backend: " backend
-               "\n\nBuilt-in backends: :memory (all platforms), :file (JVM only), :tiered"
-               "\nExternal backends: :file (Node.js - konserve.node-filestore), :indexeddb (browser), :s3, :dynamodb, :redis, :lmdb, :rocksdb"
-               "\nMake sure the corresponding backend module is required before use.")
+               known-backends)
           {:backend backend :config config})))
 
 ;; ===== :tiered Backend (built-in) =====
@@ -483,9 +490,7 @@
   [{:keys [backend] :as config} _opts]
   (throw (ex-info
           (str "Unsupported store backend: " backend
-               "\n\nBuilt-in backends: :memory (all platforms), :file (JVM only), :tiered"
-               "\nExternal backends: :file (Node.js - konserve.node-filestore), :indexeddb (browser), :s3, :dynamodb, :redis, :lmdb, :rocksdb"
-               "\nMake sure the corresponding backend module is required before use.")
+               known-backends)
           {:backend backend :config config})))
 
 (defmethod -release-store :default


### PR DESCRIPTION
konserve-gcs sat under **Unofficial Backends**, pointing at `The-Literal-Company/konserve-gcs`, while the repository it is developed in is `replikativ/konserve-gcs`. Moved to the supported list with the right URL, and added to the reference-implementations sentence alongside konserve-jdbc, which was also missing from it.

## Four drifted copies of the backend list

The unsupported-backend error names the available backends — in **four copies**, one per `:default` multimethod — and all four had already drifted: neither `:jdbc` nor `:gcs` appeared in any of them, while both are listed in the README as available. An error message that names an incomplete set sends someone looking for a backend that exists.

One `known-backends` string now, four call sites.

## How this was found

An audit of "the backends the README lists" missed konserve-gcs entirely — it *was* in the README, just in a section that read as unmaintained. Worth knowing that the list had two homes that disagreed.

123 tests / 1398 assertions green; format clean.