### PR TITLE
boring 0.1.17: encode-indexed for stored values, plus the gcs/README pass

### DIFF
--- a/README.org
+++ b/README.org
@@ -330,10 +330,7 @@ After requiring a backend module, it automatically registers with the multimetho
 - =:lmdb= - LMDB ([[https://github.com/replikativ/konserve-lmdb][konserve-lmdb]])
 - =:rocksdb= - RocksDB ([[https://github.com/replikativ/konserve-rocksdb][konserve-rocksdb]])
 - =:jdbc= - JDBC databases ([[https://github.com/replikativ/konserve-jdbc][konserve-jdbc]])
-
-*** Unofficial Backends
-
-- [[https://github.com/The-Literal-Company/konserve-gcs][konserve-gcs]] - Google Cloud Storage
+- =:gcs= - Google Cloud Storage ([[https://github.com/replikativ/konserve-gcs][konserve-gcs]])
 
 *** Outdated Backends
 
@@ -570,7 +567,7 @@ system by defining multimethod implementations for:
 All backends must implement strict semantics where =create-store= errors if the store
 already exists and =connect-store= errors if the store doesn't exist. See existing
 external backends (konserve-s3, konserve-lmdb, konserve-rocksdb, konserve-redis,
-konserve-dynamodb) for reference implementations.
+konserve-dynamodb, konserve-jdbc, konserve-gcs) for reference implementations.
 
 ** Projects Building on Konserve
    :PROPERTIES:

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/data.fressian {:mvn/version "1.0.0"} ;; for filestore
         mvxcvi/clj-cbor {:mvn/version "1.1.1"} ;; legacy: serializer byte 2, JVM-only
-        org.replikativ/boring {:mvn/version "0.1.13"} ;; serializer byte 3, portable
+        org.replikativ/boring {:mvn/version "0.1.16"} ;; serializer byte 3, portable
         org.replikativ/incognito {:mvn/version "0.3.69"}
         org.replikativ/hasch {:mvn/version "0.3.96"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/data.fressian {:mvn/version "1.0.0"} ;; for filestore
         mvxcvi/clj-cbor {:mvn/version "1.1.1"} ;; legacy: serializer byte 2, JVM-only
-        org.replikativ/boring {:mvn/version "0.1.16"} ;; serializer byte 3, portable
+        org.replikativ/boring {:mvn/version "0.1.17"} ;; serializer byte 3, portable
         org.replikativ/incognito {:mvn/version "0.3.69"}
         org.replikativ/hasch {:mvn/version "0.3.96"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}

--- a/src/konserve/serializers.cljc
+++ b/src/konserve/serializers.cljc
@@ -83,12 +83,6 @@
   meta blobs and small values are untouched."
   16)
 
-(def ^:private ^:const writer-buffer-size
-  "Chunk size for the per-call Writer. The value is staged by the store
-  anyway, so this trades allocation against flush count rather than peak
-  memory."
-  8192)
-
 (defn- indexing?
   "Whether this serializer should seal an offset index onto each value.
 
@@ -97,10 +91,30 @@
 
   Why default on: the index makes a stored value navigable with
   `boring.nav` -- reaching one key without materialising the rest -- and it is
-  close to free where it matters. Measured, datom-shaped content at 200 and
-  5 000 records: +27% and +25% raw, but +3.7% and -0.7% under zstd, because
-  indexing forces `:stringref false` and zstd recovers what stringref was
-  saving. Non-datom shapes cost about 20% under zstd.
+  close to free where it matters. Re-measured against boring 0.1.16, indexed
+  against `{:index 0}` on otherwise identical options:
+
+      datom-shaped,   200 records   10 193 vs 10 108 bytes   +0.8%
+      datom-shaped, 5 000 records  259 595 vs 258 909        +0.3%
+      non-datom map,  500 entries   13 350 vs  12 792        +4.4%
+
+  An indexed value keeps its stringref namespace, so the frame is all it
+  costs.
+
+  SMALL VALUES PAY NOTHING, which is why this is affordable as a default.
+  Where no container clears the placement rule and no string is referenced,
+  the frame would describe nothing and boring emits neither it nor the
+  stringref envelope -- the result is byte-for-byte a plain encode. Measured
+  through this serializer: `{:a 1}` is 7 bytes, `{}` is 1, `[1 2 3]` is 4,
+  `{:id 1 :name \"alice\"}` is 22.
+
+  A value large enough to earn a frame DOES open a stringref namespace -- it
+  begins `d9 01 00`, tag 256 -- and such a document is navigable only through
+  its index, since the pointer table that resolves a reference lives in the
+  frame. So `{:trust-index :ignore}`, boring's recipe for navigating bytes you
+  do not trust, is refused on those with `:boring/stringref-not-navigable`.
+  For untrusted input use `boring/decode`, which builds the table by decoding
+  in order and reads no frame at all.
 
   It is also FORWARD-COMPATIBLE, which is what makes it safe to switch on for
   existing deployments: an indexed value is a two-item CBOR sequence, and
@@ -243,15 +257,25 @@
     ;; is precisely why it was unusable.
     (let [opts (assoc encode-opts :registry registry)]
       (if (indexing? opts)
-        ;; `write-indexed!` on the JVM rather than `encode-indexed`, even though
-        ;; the store stages into a ByteArrayOutputStream either way:
-        ;; `encode-indexed` builds the whole array and then WALKS it to derive
-        ;; the index -- two passes and two copies -- while this captures the
-        ;; nodes as the writer emits them. A fresh Writer per call because a
-        ;; Writer is not thread-safe and this serializer is shared; that costs
-        ;; ~600 bytes since boring 0.1.11 made the index scaffolding lazy.
-        #?(:clj  (boring/write-indexed! (boring/writer writer-buffer-size)
-                                        val output-stream opts)
+        ;; `encode-indexed` ON BOTH PLATFORMS, which used to be `write-indexed!`
+        ;; on the JVM. The reason given for that -- "`encode-indexed` builds the
+        ;; whole array and then WALKS it to derive the index, two passes and two
+        ;; copies" -- has not been true since boring consolidated its builders:
+        ;; `encode-indexed` IS `write-indexed!` into a ByteArrayOutputStream,
+        ;; and it captures nodes from the writer exactly the same way. There was
+        ;; no second pass left to avoid, and this store stages into a
+        ;; ByteArrayOutputStream regardless, so nothing was being streamed.
+        ;;
+        ;; What the buffered entry point can do that the streaming one cannot is
+        ;; DECLINE AN INDEX FRAME THAT DESCRIBES NOTHING. An indexed write seals
+        ;; a frame whenever it opens a stringref namespace, even with no
+        ;; container worth a node, because "namespace with no pointer table" has
+        ;; to keep meaning one thing for `boring.nav`. On a large value that is
+        ;; noise; on the small values a KV store is mostly made of it is the
+        ;; whole file -- `{:a 1}` came out at 50 bytes here against 7. Measured
+        ;; over 20 konserve-shaped values, 3195 bytes against 2514, 21% smaller.
+        #?(:clj  (.write ^java.io.OutputStream output-stream
+                         ^bytes (boring/encode-indexed val opts))
            :cljs (boring/encode-indexed val opts))
         #?(:clj  (.write ^java.io.OutputStream output-stream ^bytes (boring/encode val opts))
            :cljs (boring/encode val opts))))))

--- a/src/konserve/store.cljc
+++ b/src/konserve/store.cljc
@@ -339,31 +339,38 @@
 ;; Default Error Handling
 ;; =============================================================================
 
+(def ^:private known-backends
+  "The backends a user can reach, for the unsupported-backend error.
+
+  ONE string, FOUR call sites. It was four copies, and they had already
+  drifted: `:jdbc` and `:gcs` were missing from all of them while both are
+  listed in the README as available. An error message that names an incomplete
+  set sends someone looking for a backend that exists."
+  (str "\n\nBuilt-in backends: :memory (all platforms), :file (JVM only), :tiered"
+       "\nExternal backends: :file (Node.js - konserve.node-filestore),"
+       " :indexeddb (browser), :s3, :dynamodb, :redis, :lmdb, :rocksdb, :jdbc,"
+       " :gcs"
+       "\nMake sure the corresponding backend module is required before use."))
+
 (defmethod -connect-store :default
   [{:keys [backend] :as config} _opts]
   (throw (ex-info
           (str "Unsupported store backend: " backend
-               "\n\nBuilt-in backends: :memory (all platforms), :file (JVM only), :tiered"
-               "\nExternal backends: :file (Node.js - konserve.node-filestore), :indexeddb (browser), :s3, :dynamodb, :redis, :lmdb, :rocksdb"
-               "\nMake sure the corresponding backend module is required before use.")
+               known-backends)
           {:backend backend :config config})))
 
 (defmethod -create-store :default
   [{:keys [backend] :as config} _opts]
   (throw (ex-info
           (str "Unsupported store backend: " backend
-               "\n\nBuilt-in backends: :memory (all platforms), :file (JVM only), :tiered"
-               "\nExternal backends: :file (Node.js - konserve.node-filestore), :indexeddb (browser), :s3, :dynamodb, :redis, :lmdb, :rocksdb"
-               "\nMake sure the corresponding backend module is required before use.")
+               known-backends)
           {:backend backend :config config})))
 
 (defmethod -store-exists? :default
   [{:keys [backend] :as config} _opts]
   (throw (ex-info
           (str "Unsupported store backend: " backend
-               "\n\nBuilt-in backends: :memory (all platforms), :file (JVM only), :tiered"
-               "\nExternal backends: :file (Node.js - konserve.node-filestore), :indexeddb (browser), :s3, :dynamodb, :redis, :lmdb, :rocksdb"
-               "\nMake sure the corresponding backend module is required before use.")
+               known-backends)
           {:backend backend :config config})))
 
 ;; ===== :tiered Backend (built-in) =====
@@ -483,9 +490,7 @@
   [{:keys [backend] :as config} _opts]
   (throw (ex-info
           (str "Unsupported store backend: " backend
-               "\n\nBuilt-in backends: :memory (all platforms), :file (JVM only), :tiered"
-               "\nExternal backends: :file (Node.js - konserve.node-filestore), :indexeddb (browser), :s3, :dynamodb, :redis, :lmdb, :rocksdb"
-               "\nMake sure the corresponding backend module is required before use.")
+               known-backends)
           {:backend backend :config config})))
 
 (defmethod -release-store :default

--- a/test/konserve/boring_serializer_test.cljc
+++ b/test/konserve/boring_serializer_test.cljc
@@ -203,7 +203,8 @@
            (is (= big (round-trip big))))
          (testing "and boring.nav can reach one key through the index"
            (is (= "name-137"
-                  (nav/value (get-in (nav/source bs) ["customer-137" "name"])))))
+                  (nav/value (get-in (nav/root (nav/source bs))
+                                     ["customer-137" "name"])))))
          (testing "a small value gets no frame, so it costs nothing"
            (is (= (seq (boring/encode {:a 1} {:stringref false}))
                   (seq (->b ser {:a 1})))))


### PR DESCRIPTION
Two independent topics on this branch — it started as the README/gcs pass (`1c5c9e8`) and picked up the boring serializer work. Happy to split if you'd rather review them separately.

## 1. Serializer: `encode-indexed` instead of `write-indexed!`

The boring serializer used `write-indexed!` on the JVM, on the grounds that *"`encode-indexed` builds the whole array and then WALKS it to derive the index — two passes and two copies"*. That stopped being true when boring consolidated its index builders: `encode-indexed` **is** `write-indexed!` into a `ByteArrayOutputStream` and captures nodes from the writer the same way. There was no second pass left to avoid, and this store stages into a `ByteArrayOutputStream` regardless, so nothing was being streamed either.

What the buffered entry point can do that the streaming one cannot is **decline an index frame that describes nothing**. An indexed write seals a frame whenever it opens a stringref namespace, even with no container worth a node, because "namespace with no pointer table" has to keep meaning one thing for `boring.nav`. On a large value that is noise; on the small values a KV store is mostly made of it is the whole file.

Through this serializer:

| value | before | after |
|---|---:|---:|
| `{:a 1}` | 50 bytes | **7** |
| `{}` | 44 | **1** |
| `{:id 1 :name "alice"}` | 65 | **22** |
| 20 konserve-shaped values | 3195 | **2514** (−21%) |

Large values are untouched — they have containers, so the frame was always earning its bytes. The `+0.8% / +0.3% / +4.4%` figures in `indexing?` re-measure identically.

## 2. `deps.edn`: boring 0.1.16 → 0.1.17

0.1.17 carries reader-side fixes made since:

- **stringref binary search.** A key repeated inside a document is written as a *reference*, while the lookup probe is built as a *literal* — so the binary search compared across two encodings, walked the wrong way, and reported a miss. Every present key was then rescued by a full container rescan. konserve's default blobs are exactly this shape, so every `nav` lookup on them was paying it.
- the degenerate index frame dropped by both writers, byte-identically
- registered tag readers, record constructors, tag writers and `:encode-fallback` now fail **typed** instead of letting `ClassCastException` / `IllegalArgumentException` escape `decode`

## Test fix

One assertion needed updating for boring's `source`/`root` split: `(nav/source bs)` returns a source now, and a source is deliberately not a cursor.

Worth noting the *small-value* assertion needed no change — it asserted the plain encoding all along, and the implementation had drifted away from it. Restoring `encode-indexed` made it pass again rather than the other way round.

## Docs

`indexing?`'s docstring re-measured against 0.1.17, and it now states two things it did not: that small values pay nothing (byte-for-byte a plain encode), and that a value large enough to earn a frame opens a stringref namespace — so `{:trust-index :ignore}` is refused on those with `:boring/stringref-not-navigable`, and untrusted input wants `boring/decode`.

## Testing

123 tests, 1398 assertions, 0 failures against boring 0.1.17.