### PR TITLE
Whole-batch metadata (:meta-all), and refuse a meta map that names no key

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/data.fressian {:mvn/version "1.0.0"} ;; for filestore
         mvxcvi/clj-cbor {:mvn/version "1.1.1"} ;; legacy: serializer byte 2, JVM-only
-        org.replikativ/boring {:mvn/version "0.1.17"} ;; serializer byte 3, portable
+        org.replikativ/boring {:mvn/version "0.1.21"} ;; serializer byte 3, portable
         org.replikativ/incognito {:mvn/version "0.3.69"}
         org.replikativ/hasch {:mvn/version "0.3.96"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -6,7 +6,7 @@
                                                       -update-in -dissoc -bget -bassoc
                                                       -keys -multi-get -multi-assoc -multi-dissoc
                                                       -assoc-serializers -get-write-hooks -lock-free?]]
-            [konserve.utils :refer [meta-update multi-key-capable? invoke-write-hooks! #?(:clj async+sync) *default-sync-translation*]
+            [konserve.utils :refer [meta-update multi-key-capable? kv-keys invoke-write-hooks! #?(:clj async+sync) *default-sync-translation*]
              #?@(:cljs [:refer-macros [async+sync]])]
             [konserve.impl.storage-layout :as storage-layout]
             [konserve.impl.defaults :as defaults]
@@ -421,7 +421,22 @@
    `(multi-assoc store nodes (uniform-meta nodes {:immutable? true}) opts)`.
    `kvs` may be a kv-map, an ordered seq of [k v] pairs, or a plain seq of keys.
    Note the result is a plain lookup map — per-key meta is unordered by nature;
-   ordering lives in `kvs` (see `multi-assoc`)."
+   ordering lives in `kvs` (see `multi-assoc`).
+
+   PREFER `{:meta-all m}` IN `opts` FOR A WHOLE-BATCH ANNOTATION, which needs no
+   keys at all and therefore cannot get them wrong.
+
+   THE SHAPE TEST BELOW IS A GUESS AND CANNOT BE MADE SOUND. A key that is
+   itself a 2-element vector is indistinguishable from a `[k v]` pair: `[[:a 1]]`
+   is both a valid one-key seq and a valid one-pair seq, and no inspection of
+   the data separates them. So `(uniform-meta (keys {[:a 1] v}) ..)` returns
+   `{:a ..}` — the annotation lands on a key nobody wrote.
+
+   Narrowing the test was tried and rejected: keying off `MapEntry` fixes the
+   `(keys m)` case and breaks the hand-built pair-vector instead, which only
+   moves the failure onto a different caller. What IS fixed is the SILENCE —
+   `multi-assoc` refuses a `meta` map whose keys are disjoint from `kvs`, so a
+   misread shape raises at the call site instead of dropping metadata."
   [kvs meta]
   (let [ks (cond
              (map? kvs)                      (clojure.core/keys kvs)
@@ -485,10 +500,51 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-try-
-                (let [mfn    (if meta
+                (let [meta-all (:meta-all opts)
+                      _ (when (and meta meta-all)
+                          (throw (#?(:clj ex-info :cljs js/Error.)
+                                  "Pass either a per-key `meta` or `:meta-all`, not both"
+                                  {:type :konserve/ambiguous-meta})))
+                      ;; UNIFORM ANNOTATION NEEDS NO KEYS, and that is the whole
+                      ;; point of `:meta-all`. `uniform-meta` existed to turn one
+                      ;; annotation into a per-key map, which meant DERIVING THE
+                      ;; KEYS from `kvs` -- and a key that is itself a 2-element
+                      ;; vector is indistinguishable from a `[k v]` pair, so
+                      ;; `(uniform-meta (keys m) ..)` on `{[:a 1] v}` produced
+                      ;; `{:a ..}` and the annotation was silently dropped.
+                      ;; Naming the two intents removes the guess entirely.
+                      mfn    (cond
+                               meta-all
+                               (fn [key type old] (clojure.core/merge meta-all (meta-update key type old)))
+                               meta
                                ;; per-key meta map: `(get meta key)` (nil ⇒ just the built meta)
                                (fn [key type old] (clojure.core/merge (clojure.core/get meta key) (meta-update key type old)))
-                               meta-update)
+                               :else meta-update)
+                      ;; A `meta` MAP THAT NAMES NO KEY OF THIS BATCH IS ALWAYS A
+                      ;; MISTAKE, and it used to be a silent one: the write
+                      ;; succeeded and the annotation vanished. `uniform-meta`
+                      ;; produces exactly that when it misreads its input shape
+                      ;; -- a 2-element vector key is indistinguishable from a
+                      ;; [k v] pair, so `(uniform-meta (keys {[:a 1] v}) ..)`
+                      ;; keys the map by `:a`. A hand-built map with a typo does
+                      ;; the same. Checked here because this is the only place
+                      ;; holding both halves.
+                      ;;
+                      ;; DISJOINT THROWS, PARTIAL DOES NOT: annotating a SUBSET
+                      ;; is the documented mixed-batch case -- immutable nodes
+                      ;; plus the mutable pointer that makes them reachable --
+                      ;; so a single overlapping key is enough to be intentional.
+                      _ (when (seq meta)
+                          (let [ks (set (kv-keys kvs))]
+                            (when-not (some ks (clojure.core/keys meta))
+                              (throw (#?(:clj ex-info :cljs js/Error.)
+                                      (str "multi-assoc: none of `meta`'s keys appear in `kvs`, "
+                                           "so no value would receive it. If this came from "
+                                           "`uniform-meta`, pass the kv-map itself, name the keys, "
+                                           "or use {:meta-all m} in opts.")
+                                      {:type :konserve/meta-keys-disjoint
+                                       :meta-keys (vec (clojure.core/keys meta))
+                                       :kvs-keys (vec ks)})))))
                       result (try
                                (<?- (-multi-assoc store kvs mfn opts))
                                (catch #?(:clj Exception :cljs js/Error) e
@@ -503,9 +559,20 @@
                                                        :reason (:reason (ex-data e))}))
                                       (throw e))
                                     :cljs (throw e))))]
+                  ;; HOOKS ALWAYS SEE A PER-KEY MAP, whichever way the caller
+                  ;; expressed it. `:meta-all` is expanded here and never escapes
+                  ;; this namespace, so a consumer like konserve-sync keeps its
+                  ;; `(get m k)` and needs no change -- teaching every consumer a
+                  ;; second spelling would recreate the dropped-annotation bug one
+                  ;; layer out, in any consumer that was not updated.
+                  ;;
+                  ;; Expanded ONLY when a hook is registered, so the write path
+                  ;; still avoids building an N-entry map to say one thing.
                   (invoke-write-hooks! store (cond-> {:api-op :multi-assoc :kvs kvs}
-                                               ;; per-key meta map forwarded verbatim (pure data)
-                                               meta (clojure.core/assoc :meta meta)))
+                                               meta     (clojure.core/assoc :meta meta)
+                                               meta-all (clojure.core/assoc
+                                                         :meta (zipmap (kv-keys kvs)
+                                                                       (clojure.core/repeat meta-all)))))
                   result)))))
 
 (defn dissoc


### PR DESCRIPTION
## The bug

```clojure
(k/multi-assoc store kvs (k/uniform-meta (keys kvs) {:immutable? true}) opts)
```

silently dropped the annotation whenever the keys were **2-element vectors** — `[:a 1]`, `["user" 7]`, `[:db :root]`.

`uniform-meta` has to *derive* the keys from its argument, and it separates "seq of `[k v]` pairs" from "seq of keys" by asking whether the first element is sequential with count 2 — which such a key also is. So it returned `{:a …}`, `(get meta [:a 1])` was nil, and every value was written without the metadata. No error.

Found while investigating why konserve-lmdb could not exploit `:immutable?` to skip its metadata read.

## The heuristic cannot be fixed, and this PR does not try

`[[:a 1]]` is both a valid one-key seq and a valid one-pair seq — the same data. Narrowing the test to `MapEntry` was implemented and reverted: it fixes `(keys m)` and breaks the hand-built pair-vector instead, which only moves the failure onto a different caller. The compliance suite has one (4 failures).

So the *need* to guess is removed, and the guess is made non-silent.

## Changes

**`{:meta-all m}` in opts** annotates the whole batch. It carries no keys, so it cannot misread them, and it is the majority case — bulk content-addressed writes. Passing both `meta` and `:meta-all` throws.

**`multi-assoc` refuses a per-key `meta` disjoint from `kvs`** (`:konserve/meta-keys-disjoint`). That is always a mistake and is the exact signature of a misread shape, or a typo in a hand-built map. Partial overlap stays legal — annotating a *subset* is the documented mixed-batch case (immutable nodes plus the mutable pointer that makes them reachable).

**Hooks see one shape.** `:meta-all` is expanded into the per-key map at the write-hook boundary and never escapes `konserve.core`, so **konserve-sync needs no change** — it keeps its `(get m k)`. Teaching every consumer a second spelling would recreate the dropped-annotation bug one layer out. Expansion happens only when a hook is registered, so the write path still avoids building an N-entry map to say one thing.

**`uniform-meta` is unchanged**, with its docstring now stating that its shape test is a guess that cannot be made sound, and pointing at `:meta-all`.

## Why it matters

konserve-lmdb uses `:meta-all {:immutable? true}` to skip the metadata read-modify-write that konserve's contract otherwise requires — a content-addressed value is written once, so there is no prior metadata worth merging:

| | µs/key | batch put |
|---|---|---|
| ordinary batch | 52.6 | 91.8K ops/s |
| `:meta-all {:immutable? true}` | **27.0** | **163K ops/s** (1.78x) |

That is datahike's node-storage shape.

## Verification

123 tests, 1399 assertions, 0 failures. Behaviour verified end to end against konserve-lmdb, which is multi-key capable where the memory store is not (`Store does not support multi-key operations`, so the guard is unreachable there):

- disjoint `meta` raises `:konserve/meta-keys-disjoint`
- `:meta-all` round-trips to `get-meta`
- subset annotation still allowed

## Scope note

This branch also carries three pre-existing local commits that were not on `origin/main`: `ada3aa6` (boring 0.1.17), `57edebd` (serializers: encode-indexed), `1c5c9e8` (README backends). Happy to rebase them out if you would rather they land separately.