### PR TITLE
Add an internal simulation harness for the storage layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ All notable, user-visible changes to konserve are documented here.
   runs replay exactly), a crash simulator that tracks sync points and discards
   unsynced state at each of the six steps of the `DefaultStore` write path, and
   an in-memory backing store for tests that should not touch a filesystem. Comes
-  with 95 tests / 2409 assertions covering error propagation, atomicity,
+  with 99 tests / 2427 assertions covering error propagation, atomicity,
   durability across reopen, orphaned `.new`/`.backup` handling, GC under crash,
-  and concurrency and resource-exhaustion stress. Folded in from an out-of-tree
-  repository so the backing implementations track the protocols they wrap. See
+  and concurrency and resource-exhaustion stress. Two properties carry most of
+  the weight: corruption is never silently absorbed (a read returns exactly what
+  was written or fails), and acknowledged writes are durable under chaos, swept
+  across seeds. The suite is mutation-tested — removing fault injection, crash
+  injection, resource limits, deletes or konserve's per-key lock each produces
+  failures. Folded in from an out-of-tree repository so the backing
+  implementations track the protocols they wrap. See
   [doc/simulation-testing.md](doc/simulation-testing.md).
 
   These namespaces are marked `^:no-doc` and are **internal**: they ship in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable, user-visible changes to konserve are documented here.
 ## Unreleased
 
 ### Added
+- **Simulation testing harness** (`konserve.simulation.backing`, `.crash`,
+  `.memory`). A fault-injecting wrapper around any `PBackingStore` (19
+  per-operation error and corruption rates, seeded from a `SplittableRandom` so
+  runs replay exactly), a crash simulator that tracks sync points and discards
+  unsynced state at each of the six steps of the `DefaultStore` write path, and
+  an in-memory backing store for tests that should not touch a filesystem. Comes
+  with 95 tests / 2409 assertions covering error propagation, atomicity,
+  durability across reopen, orphaned `.new`/`.backup` handling, GC under crash,
+  and concurrency and resource-exhaustion stress. Folded in from an out-of-tree
+  repository so the backing implementations track the protocols they wrap. See
+  [doc/simulation-testing.md](doc/simulation-testing.md).
+
+  These namespaces are marked `^:no-doc` and are **internal**: they ship in the
+  jar so backends and downstream projects can test against them, but they carry
+  no compatibility guarantee and may change or move in any release.
 - **Monotonic write stamps** — `:last-write` metadata is now issued by a
   process-global monotone clock (`utils/now` = `max(wall-clock,
   previous-stamp)`): stamps never go backwards under wall-clock retreat

--- a/doc/simulation-testing.md
+++ b/doc/simulation-testing.md
@@ -1,0 +1,155 @@
+# Simulation testing
+
+konserve ships a simulation harness for testing the storage layer under
+conditions that are hard to reach with ordinary tests: I/O errors at arbitrary
+points, byte-level corruption, resource exhaustion, and process crashes at each
+step of the write path.
+
+The harness lives in three namespaces under `konserve.simulation`. They are
+marked `^:no-doc` and are **internal**: they ship in the jar so that backend
+implementations and downstream projects can test against them, but they carry
+no compatibility guarantee and may change or move in any release.
+
+| namespace | what it is |
+|---|---|
+| `konserve.simulation.backing` | fault-injecting wrapper around any `PBackingStore` |
+| `konserve.simulation.crash` | crash simulation with sync-point tracking |
+| `konserve.simulation.memory` | in-memory `PBackingStore`, no filesystem I/O |
+
+All three implement or wrap `konserve.impl.storage-layout` protocols, so they
+compose with `connect-default-store` exactly like a real backing store:
+
+```
+[k/assoc] → [DefaultStore] → [SimulatedBackingStore] → [MemoryBackingStore | BackingFilestore]
+```
+
+## Fault injection
+
+`konserve.simulation.backing/wrap-backing-store` intercepts every
+`PBackingStore` and `PBackingBlob` method and decides, per call, whether to
+inject a fault. The configuration is a map of per-operation probabilities — 19
+knobs in total: 16 error-injection rates (`:create-blob-fault-rate`,
+`:atomic-move-fault-rate`, `:write-value-fault-rate`, `:get-lock-fault-rate`, …),
+3 corruption rates that flip bits in returned byte arrays rather than throwing,
+plus three crash probabilities.
+
+Three presets are provided: `no-faults-config`, `default-fault-config` (1% per
+operation) and `chaos-fault-config`.
+
+Decisions are drawn from a caller-supplied `java.util.SplittableRandom`, so a
+seed reproduces a run exactly:
+
+```clojure
+(require '[konserve.simulation.backing :as sim]
+         '[konserve.impl.defaults :refer [connect-default-store]])
+
+(let [history (atom [])
+      backing (sim/wrap-backing-store real-backing
+                                      sim/chaos-fault-config
+                                      (sim/rng 42)
+                                      history)]
+  (connect-default-store backing {...})
+  ;; ... exercise the store ...
+  (sim/count-faults @history))
+```
+
+Every intercepted operation is appended to the history atom, so a failing run
+can be replayed and inspected.
+
+## Crash simulation
+
+`konserve.simulation.crash` models a crash as *loss of everything not yet
+synced*. It tracks pending versus synced blob state, promotes pending to synced
+on `-sync`/`-sync-store`, and on crash discards the pending set and restores the
+synced snapshot — including pending `.new` files, pending atomic moves, and
+pending backup deletions.
+
+Crash points are chosen explicitly, not at random; there is no RNG in this
+namespace, so a scenario is deterministic by construction. The six points
+correspond to the steps of the `DefaultStore` write path:
+
+| point | crash between |
+|---|---|
+| `:after-write-header` | `-write-header` and `-write-meta` |
+| `:after-write-meta` | `-write-meta` and `-write-value` |
+| `:after-write-value` | `-write-value` and `-sync` |
+| `:after-sync` | `-sync` and `-atomic-move` |
+| `:after-atomic-move` | `-atomic-move` and `-sync-store` |
+| `:after-sync-store` | `-sync-store` and `-delete-blob` |
+
+The choice to enumerate sync points rather than sample random interruptions
+follows the crash-consistency literature (SQLite, RocksDB, CrashMonkey): crash
+bugs cluster immediately after fsync-like calls, and most reproduce in a
+handful of operations.
+
+The harness also enforces resource limits (`max-total-bytes`, `max-keys`) so
+exhaustion paths can be exercised without filling a disk.
+
+## What is covered
+
+95 tests, 2,409 assertions.
+
+**`simulation_backing_test`** (23) — error propagation from each `PBackingStore`
+method up to the public API, in both sync and async modes; atomicity (a failed
+write leaves no trace, a failed atomic move does not corrupt the previous
+value); durability across store reopen; that orphaned `.new` and `.backup`
+files left by a failed write neither break subsequent operations nor appear in
+`keys`; history recording; chaos-mode survival.
+
+**`simulation_crash_test`** (20) — a crash at each of the six points, with
+recovery checked afterwards; repeated crash/recovery cycles; the no-partial-data
+and atomicity invariants; crashes concurrent with other writers; empty values,
+large values, and first writes to a new key.
+
+**`simulation_gc_test`** (14) — `konserve.gc/sweep!` with whitelist and
+timestamp cutoffs; a crash during sweep deletion; that recovery leaves GC
+idempotent; writes and reads concurrent with a sweep; nested data; repeated
+cycles.
+
+**`simulation_stress_test`** (38) — storage and key limits and reclamation;
+concurrent writers to one key and to many; read/write contention; 1000+
+operation stability runs; binary blobs to 100 KB and mixed with EDN; 200-cycle
+rapid delete/recreate on one key, including concurrently; `update-in`
+atomicity; store close/reopen, including after a crash; `keys` enumeration
+during concurrent modification; delete racing against read and update;
+`append` ordering, concurrency and crash behaviour.
+
+## Limits of the harness
+
+Worth stating plainly, so results are not read as stronger than they are:
+
+- **Single process, JVM only.** These namespaces are `.clj`, use
+  `SplittableRandom` and `java.io`, and model one process crashing. Multi-node
+  and multi-process failure modes are out of scope.
+- **No linearizability checker.** The recorded history is deliberately
+  Elle-shaped (`:invoke`/`:ok`/`:fail` with process ids), but no checker is run
+  against it. The consistency claims here rest on hand-written invariants, not
+  on a model checker.
+- **Two tests are characterizations, not assertions.**
+  `update-in-concurrent-test` runs 5 threads × 20 `update-in`s and only asserts
+  the result is positive, printing any lost updates rather than failing. No
+  lost updates are observed on the current implementation, so this could be
+  tightened to an equality assertion — it has not been, so it would not catch a
+  regression. `delete-during-update-test` similarly asserts only that no errors
+  occur while delete races update, deliberately accepting either winner.
+- **Crash simulation models sync semantics, not the filesystem.** It reproduces
+  what konserve's write path promises about sync points; it does not model
+  reordering within a physical device or partial sector writes.
+
+## Why it lives here
+
+This harness was developed out-of-tree, in a separate repository used to
+validate konserve during early 2026, and was folded in so that the
+backing-store implementations track the protocols they depend on. The
+out-of-tree copy silently broke when `BackingFilestore` gained a `:filesystem`
+argument for jimfs support, and that went unnoticed for months. In this
+repository it runs in CI on every commit, and a change to
+`konserve.impl.storage-layout` updates its wrappers in the same commit.
+
+An earlier version also carried a deterministic-simulation layer built on a
+reactive runtime — virtual time, O(1) forking of simulation state, per-fork
+process ids. No test exercised it and it was dropped. The idea it reached for
+remains sound: `konserve.simulation.crash` hand-rolls its synced/pending
+snapshots, which is exactly what a copy-on-write overlay would provide for
+free, and would turn "re-run the scenario once per crash point" into a
+forkable state tree.

--- a/doc/simulation-testing.md
+++ b/doc/simulation-testing.md
@@ -87,16 +87,25 @@ exhaustion paths can be exercised without filling a disk.
 
 ## What is covered
 
-95 tests, 2,409 assertions.
+99 tests, 2,427 assertions.
 
-**`simulation_backing_test`** (23) — error propagation from each `PBackingStore`
+**`simulation_backing_test`** (25) — error propagation from each `PBackingStore`
 method up to the public API, in both sync and async modes; atomicity (a failed
 write leaves no trace, a failed atomic move does not corrupt the previous
 value); durability across store reopen; that orphaned `.new` and `.backup`
 files left by a failed write neither break subsequent operations nor appear in
 `keys`; history recording; chaos-mode survival.
 
-**`simulation_crash_test`** (20) — a crash at each of the six points, with
+Two properties there carry most of the weight. **Corruption is never silently
+absorbed**: with each of the three corrupt-rates pinned at 1.0, a read must
+either return exactly what was written or fail — returning different data would
+be the serious bug. **Acknowledged writes are durable under chaos**: swept
+across 100 seeds, konserve may *fail* a write under injected faults, but must
+never acknowledge one it then loses, nor damage data it already holds. The
+sweep matters because a single fault schedule exercises one interleaving of
+failure points; a fixed seed proves little on its own.
+
+**`simulation_crash_test`** (22) — a crash at each of the six points, with
 recovery checked afterwards; repeated crash/recovery cycles; the no-partial-data
 and atomicity invariants; crashes concurrent with other writers; empty values,
 large values, and first writes to a new key.
@@ -125,16 +134,49 @@ Worth stating plainly, so results are not read as stronger than they are:
   Elle-shaped (`:invoke`/`:ok`/`:fail` with process ids), but no checker is run
   against it. The consistency claims here rest on hand-written invariants, not
   on a model checker.
-- **Two tests are characterizations, not assertions.**
-  `update-in-concurrent-test` runs 5 threads × 20 `update-in`s and only asserts
-  the result is positive, printing any lost updates rather than failing. No
-  lost updates are observed on the current implementation, so this could be
-  tightened to an equality assertion — it has not been, so it would not catch a
-  regression. `delete-during-update-test` similarly asserts only that no errors
-  occur while delete races update, deliberately accepting either winner.
+- **One test is a characterization, not an assertion.**
+  `delete-during-update-test` asserts only that no errors occur while a delete
+  races an update, deliberately accepting either winner — the race has no single
+  correct outcome. Every other test asserts an exact expected result.
 - **Crash simulation models sync semantics, not the filesystem.** It reproduces
   what konserve's write path promises about sync points; it does not model
   reordering within a physical device or partial sector writes.
+- **Assertion counts are uneven.** `simulation_stress_test` contributes 2,227 of
+  the 2,427 assertions because it loops. Assertion count is a poor proxy for
+  sensitivity here: the crash matrix runs 144 crash rounds behind 12 assertions,
+  aggregating per crash point so a failure names the point rather than printing
+  twelve shapes.
+
+## Does the suite actually bite?
+
+The tests have been mutation-tested — the implementation was deliberately broken
+to confirm the suite notices. Removing fault injection fails 14 assertions;
+disabling crash-point injection fails 27 of 33; a crash that wipes synced data
+fails 12 (and 6 of the matrix's 12); a crash that leaves atomic moves applied
+fails 2; unenforced resource limits fail 4; a silently no-op delete raises 8
+errors; disabling corruption fails 3; making an injected fault silent — so a
+write is acknowledged but does nothing — fails the durability sweep; removing
+konserve's store-level per-key lock fails 5, including genuine header corruption
+from racing writers.
+
+Two findings from that exercise are worth keeping:
+
+**konserve has two independent locking layers** — the blob lock (`:lock-blob?`,
+default true) and `konserve.core`'s per-key registry. Removing either alone is
+survivable for a counter workload; removing both corrupts blobs outright. A
+mutation test that disables only one looks deceptively inert.
+
+**The matrix deliberately accepts a crash that leaves an atomic move applied.**
+Its invariant is "the reader sees exactly the old or the new value", and a
+completed move legitimately yields the new one. The stricter property — that a
+crash *reverts* an unsynced move — is `atomicity-invariant-test`'s job. The two
+are complementary, and neither subsumes the other.
+
+Sweeps at roughly twenty times the suite's volume found no violations either:
+200 seeds × 30 chaos operations (6,000 fault-injected writes) against the
+durability invariant, and 288 crash rounds across value shapes. Runtime is not
+this suite's limiting factor; assertion strength is, which is why the budget went
+into seed breadth and shape breadth rather than into repeating fixed scenarios.
 
 ## Why it lives here
 

--- a/src/konserve/simulation/backing.clj
+++ b/src/konserve/simulation/backing.clj
@@ -1,0 +1,528 @@
+(ns ^:no-doc konserve.simulation.backing
+  "INTERNAL. Fault-injection wrapper for any konserve `PBackingStore`.
+
+   Not public API: this namespace ships in the jar so that backends and
+   downstream projects (datahike, stratum) can test against it, but it carries
+   no compatibility guarantee and may change or move in any release. Depend on
+   it with that understood.
+
+   Wraps any `PBackingStore` implementation and intercepts each protocol method
+   to optionally inject faults — errors, corruption or crashes — according to a
+   configuration of per-operation rates. Fault decisions are drawn from a
+   caller-supplied `SplittableRandom`, so a seed reproduces a run exactly.
+
+   Use cases:
+   - Test DefaultStore error handling
+   - Verify error propagation from low-level to high-level
+   - Simulate crash scenarios
+   - Test recovery behavior
+
+   Example:
+     (def backing (wrap-backing-store real-backing
+                                      chaos-fault-config
+                                      (rng 42)
+                                      (atom [])))
+
+     ;; Use with connect-default-store
+     (connect-default-store backing {...})"
+  (:require [konserve.impl.storage-layout :as sl]
+            [superv.async :refer [go-try-]]
+            [clojure.core.async :refer [go <!]])
+  (:import [java.util SplittableRandom]))
+
+;; =============================================================================
+;; Randomness
+;; =============================================================================
+
+(defn rng
+  "Create a `SplittableRandom` for reproducible fault injection.
+
+   The same seed replays the same sequence of fault decisions, so a failing
+   run is reproduced by re-running with its seed."
+  ^SplittableRandom [seed]
+  (SplittableRandom. (long seed)))
+
+;; =============================================================================
+;; Fault Configuration
+;; =============================================================================
+
+(def default-fault-config
+  "Default fault configuration - low probability faults for stress testing."
+  {:create-blob-fault-rate     0.01
+   :delete-blob-fault-rate     0.01
+   :blob-exists-fault-rate     0.01
+   :copy-fault-rate            0.01
+   :atomic-move-fault-rate     0.01
+   :sync-store-fault-rate      0.01
+   :keys-fault-rate            0.01
+   ;; Blob-level faults
+   :read-header-fault-rate     0.01
+   :read-meta-fault-rate       0.01
+   :read-value-fault-rate      0.01
+   :write-header-fault-rate    0.01
+   :write-meta-fault-rate      0.01
+   :write-value-fault-rate     0.01
+   :sync-blob-fault-rate       0.01
+   :close-fault-rate           0.01
+   :get-lock-fault-rate        0.01
+   ;; Corruption (data returned is corrupted)
+   :read-header-corrupt-rate   0.0
+   :read-meta-corrupt-rate     0.0
+   :read-value-corrupt-rate    0.0
+   ;; Crash simulation (throws special crash exception)
+   :crash-before-atomic-move   0.0
+   :crash-after-atomic-move    0.0
+   :crash-after-write          0.0})
+
+(def chaos-fault-config
+  "High fault rates for stress testing."
+  {:create-blob-fault-rate     0.1
+   :delete-blob-fault-rate     0.1
+   :blob-exists-fault-rate     0.05
+   :copy-fault-rate            0.1
+   :atomic-move-fault-rate     0.1
+   :sync-store-fault-rate      0.1
+   :keys-fault-rate            0.05
+   :read-header-fault-rate     0.1
+   :read-meta-fault-rate       0.1
+   :read-value-fault-rate      0.1
+   :write-header-fault-rate    0.1
+   :write-meta-fault-rate      0.1
+   :write-value-fault-rate     0.1
+   :sync-blob-fault-rate       0.1
+   :close-fault-rate           0.05
+   :get-lock-fault-rate        0.1
+   :read-header-corrupt-rate   0.05
+   :read-meta-corrupt-rate     0.05
+   :read-value-corrupt-rate    0.05
+   :crash-before-atomic-move   0.05
+   :crash-after-atomic-move    0.05
+   :crash-after-write          0.05})
+
+(def no-faults-config
+  "No faults - pass through to real backing store."
+  {:create-blob-fault-rate     0.0
+   :delete-blob-fault-rate     0.0
+   :blob-exists-fault-rate     0.0
+   :copy-fault-rate            0.0
+   :atomic-move-fault-rate     0.0
+   :sync-store-fault-rate      0.0
+   :keys-fault-rate            0.0
+   :read-header-fault-rate     0.0
+   :read-meta-fault-rate       0.0
+   :read-value-fault-rate      0.0
+   :write-header-fault-rate    0.0
+   :write-meta-fault-rate      0.0
+   :write-value-fault-rate     0.0
+   :sync-blob-fault-rate       0.0
+   :close-fault-rate           0.0
+   :get-lock-fault-rate        0.0
+   :read-header-corrupt-rate   0.0
+   :read-meta-corrupt-rate     0.0
+   :read-value-corrupt-rate    0.0
+   :crash-before-atomic-move   0.0
+   :crash-after-atomic-move    0.0
+   :crash-after-write          0.0})
+
+;; =============================================================================
+;; Fault Injection Helpers
+;; =============================================================================
+
+(defn maybe-fault!
+  "Check if we should inject a fault based on rate. Returns true if fault triggered."
+  [^SplittableRandom rng rate]
+  (when (pos? rate)
+    (< (.nextDouble rng) rate)))
+
+(defn inject-fault!
+  "Throw a simulated fault exception."
+  [operation store-key]
+  (throw (ex-info (str "Simulated " (name operation) " fault")
+                  {:type :simulated-fault
+                   :operation operation
+                   :store-key store-key})))
+
+(defn inject-crash!
+  "Throw a simulated crash exception (special type for crash scenarios)."
+  [phase store-key]
+  (throw (ex-info (str "Simulated crash: " (name phase))
+                  {:type :simulated-crash
+                   :phase phase
+                   :store-key store-key})))
+
+(defn corrupt-bytes
+  "Corrupt a byte array by flipping random bits."
+  [^SplittableRandom rng ^bytes arr]
+  (when (and arr (pos? (alength arr)))
+    (let [num-corruptions (inc (.nextInt rng (min 5 (alength arr))))]
+      (dotimes [_ num-corruptions]
+        (let [idx (.nextInt rng (alength arr))
+              old-byte (aget arr idx)
+              new-byte (unchecked-byte (bit-xor old-byte (bit-shift-left 1 (.nextInt rng 8))))]
+          (aset arr idx new-byte)))))
+  arr)
+
+(defn record-operation!
+  "Record an operation to history for analysis."
+  [history-atom op-type operation store-key result]
+  (when history-atom
+    (swap! history-atom conj
+           {:time (System/nanoTime)
+            :op-type op-type
+            :operation operation
+            :store-key store-key
+            :result result})))
+
+;; =============================================================================
+;; SimulatedBlob - Wraps PBackingBlob with fault injection
+;; =============================================================================
+
+(defrecord SimulatedBlob [real-blob store-key fault-config rng history-atom]
+  sl/PBackingBlob
+
+  (-sync [_this env]
+    (record-operation! history-atom :invoke :sync-blob store-key nil)
+    (if (maybe-fault! rng (:sync-blob-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :sync-blob store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :sync-blob store-key)
+          (go-try- (inject-fault! :sync-blob store-key))))
+      (let [result (sl/-sync real-blob env)]
+        (record-operation! history-atom :ok :sync-blob store-key nil)
+        result)))
+
+  (-close [_this env]
+    (record-operation! history-atom :invoke :close-blob store-key nil)
+    (if (maybe-fault! rng (:close-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :close-blob store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :close-blob store-key)
+          (go-try- (inject-fault! :close-blob store-key))))
+      (let [result (sl/-close real-blob env)]
+        (record-operation! history-atom :ok :close-blob store-key nil)
+        result)))
+
+  (-get-lock [_this env]
+    (record-operation! history-atom :invoke :get-lock store-key nil)
+    (if (maybe-fault! rng (:get-lock-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :get-lock store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :get-lock store-key)
+          (go-try- (inject-fault! :get-lock store-key))))
+      (let [result (sl/-get-lock real-blob env)]
+        (record-operation! history-atom :ok :get-lock store-key nil)
+        result)))
+
+  (-read-header [_this env]
+    (record-operation! history-atom :invoke :read-header store-key nil)
+    (if (maybe-fault! rng (:read-header-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :read-header store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :read-header store-key)
+          (go-try- (inject-fault! :read-header store-key))))
+      (if (:sync? env)
+        (let [result (sl/-read-header real-blob env)]
+          (if (maybe-fault! rng (:read-header-corrupt-rate fault-config 0.0))
+            (do
+              (record-operation! history-atom :ok :read-header store-key :corrupted)
+              (corrupt-bytes rng result))
+            (do
+              (record-operation! history-atom :ok :read-header store-key nil)
+              result)))
+        (go
+          (let [result (<! (sl/-read-header real-blob env))]
+            (if (maybe-fault! rng (:read-header-corrupt-rate fault-config 0.0))
+              (do
+                (record-operation! history-atom :ok :read-header store-key :corrupted)
+                (corrupt-bytes rng result))
+              (do
+                (record-operation! history-atom :ok :read-header store-key nil)
+                result)))))))
+
+  (-read-meta [_this meta-size env]
+    (record-operation! history-atom :invoke :read-meta store-key nil)
+    (if (maybe-fault! rng (:read-meta-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :read-meta store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :read-meta store-key)
+          (go-try- (inject-fault! :read-meta store-key))))
+      (if (:sync? env)
+        (let [result (sl/-read-meta real-blob meta-size env)]
+          (if (maybe-fault! rng (:read-meta-corrupt-rate fault-config 0.0))
+            (do
+              (record-operation! history-atom :ok :read-meta store-key :corrupted)
+              (corrupt-bytes rng result))
+            (do
+              (record-operation! history-atom :ok :read-meta store-key nil)
+              result)))
+        (go
+          (let [result (<! (sl/-read-meta real-blob meta-size env))]
+            (if (maybe-fault! rng (:read-meta-corrupt-rate fault-config 0.0))
+              (do
+                (record-operation! history-atom :ok :read-meta store-key :corrupted)
+                (corrupt-bytes rng result))
+              (do
+                (record-operation! history-atom :ok :read-meta store-key nil)
+                result)))))))
+
+  (-read-value [_this meta-size env]
+    (record-operation! history-atom :invoke :read-value store-key nil)
+    (if (maybe-fault! rng (:read-value-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :read-value store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :read-value store-key)
+          (go-try- (inject-fault! :read-value store-key))))
+      (if (:sync? env)
+        (let [result (sl/-read-value real-blob meta-size env)]
+          (if (maybe-fault! rng (:read-value-corrupt-rate fault-config 0.0))
+            (do
+              (record-operation! history-atom :ok :read-value store-key :corrupted)
+              (corrupt-bytes rng result))
+            (do
+              (record-operation! history-atom :ok :read-value store-key nil)
+              result)))
+        (go
+          (let [result (<! (sl/-read-value real-blob meta-size env))]
+            (if (maybe-fault! rng (:read-value-corrupt-rate fault-config 0.0))
+              (do
+                (record-operation! history-atom :ok :read-value store-key :corrupted)
+                (corrupt-bytes rng result))
+              (do
+                (record-operation! history-atom :ok :read-value store-key nil)
+                result)))))))
+
+  (-read-binary [_this meta-size locked-cb env]
+    (record-operation! history-atom :invoke :read-binary store-key nil)
+    (if (maybe-fault! rng (:read-value-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :read-binary store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :read-binary store-key)
+          (go-try- (inject-fault! :read-binary store-key))))
+      (let [result (sl/-read-binary real-blob meta-size locked-cb env)]
+        (record-operation! history-atom :ok :read-binary store-key nil)
+        result)))
+
+  (-write-header [_this header-arr env]
+    (record-operation! history-atom :invoke :write-header store-key nil)
+    (if (maybe-fault! rng (:write-header-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :write-header store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :write-header store-key)
+          (go-try- (inject-fault! :write-header store-key))))
+      (let [result (sl/-write-header real-blob header-arr env)]
+        (record-operation! history-atom :ok :write-header store-key nil)
+        result)))
+
+  (-write-meta [_this meta-arr env]
+    (record-operation! history-atom :invoke :write-meta store-key nil)
+    (if (maybe-fault! rng (:write-meta-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :write-meta store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :write-meta store-key)
+          (go-try- (inject-fault! :write-meta store-key))))
+      (let [result (sl/-write-meta real-blob meta-arr env)]
+        (record-operation! history-atom :ok :write-meta store-key nil)
+        result)))
+
+  (-write-value [_this value-arr meta-size env]
+    (record-operation! history-atom :invoke :write-value store-key nil)
+    (if (maybe-fault! rng (:write-value-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :write-value store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :write-value store-key)
+          (go-try- (inject-fault! :write-value store-key))))
+      (let [result (sl/-write-value real-blob value-arr meta-size env)]
+        (when (maybe-fault! rng (:crash-after-write fault-config 0.0))
+          (inject-crash! :after-write store-key))
+        (record-operation! history-atom :ok :write-value store-key nil)
+        result)))
+
+  (-write-binary [_this meta-size blob env]
+    (record-operation! history-atom :invoke :write-binary store-key nil)
+    (if (maybe-fault! rng (:write-value-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :write-binary store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :write-binary store-key)
+          (go-try- (inject-fault! :write-binary store-key))))
+      (let [result (sl/-write-binary real-blob meta-size blob env)]
+        (record-operation! history-atom :ok :write-binary store-key nil)
+        result))))
+
+;; =============================================================================
+;; SimulatedBackingStore - Wraps PBackingStore with fault injection
+;; =============================================================================
+
+(defrecord SimulatedBackingStore [real-backing fault-config rng history-atom]
+  sl/PBackingStore
+
+  (-create-blob [_this store-key env]
+    (record-operation! history-atom :invoke :create-blob store-key nil)
+    (if (maybe-fault! rng (:create-blob-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :create-blob store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :create-blob store-key)
+          (go-try- (inject-fault! :create-blob store-key))))
+      (if (:sync? env)
+        (let [real-blob (sl/-create-blob real-backing store-key env)]
+          (record-operation! history-atom :ok :create-blob store-key nil)
+          (->SimulatedBlob real-blob store-key fault-config rng history-atom))
+        (go
+          (let [real-blob (<! (sl/-create-blob real-backing store-key env))]
+            (record-operation! history-atom :ok :create-blob store-key nil)
+            (->SimulatedBlob real-blob store-key fault-config rng history-atom))))))
+
+  (-delete-blob [_this store-key env]
+    (record-operation! history-atom :invoke :delete-blob store-key nil)
+    (if (maybe-fault! rng (:delete-blob-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :delete-blob store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :delete-blob store-key)
+          (go-try- (inject-fault! :delete-blob store-key))))
+      (let [result (sl/-delete-blob real-backing store-key env)]
+        (record-operation! history-atom :ok :delete-blob store-key nil)
+        result)))
+
+  (-blob-exists? [_this store-key env]
+    (record-operation! history-atom :invoke :blob-exists store-key nil)
+    (if (maybe-fault! rng (:blob-exists-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :blob-exists store-key :fault)
+        (if (:sync? env)
+          (inject-fault! :blob-exists store-key)
+          (go-try- (inject-fault! :blob-exists store-key))))
+      (let [result (sl/-blob-exists? real-backing store-key env)]
+        (record-operation! history-atom :ok :blob-exists store-key nil)
+        result)))
+
+  (-migratable [_this key store-key env]
+    ;; Pass through - migration is not fault-injected
+    (sl/-migratable real-backing key store-key env))
+
+  (-migrate [_this migration-key key-vec serializer read-handlers write-handlers env]
+    ;; Pass through - migration is not fault-injected
+    (sl/-migrate real-backing migration-key key-vec serializer read-handlers write-handlers env))
+
+  (-copy [_this from to env]
+    (record-operation! history-atom :invoke :copy from nil)
+    (if (maybe-fault! rng (:copy-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :copy from :fault)
+        (if (:sync? env)
+          (inject-fault! :copy from)
+          (go-try- (inject-fault! :copy from))))
+      (let [result (sl/-copy real-backing from to env)]
+        (record-operation! history-atom :ok :copy from nil)
+        result)))
+
+  (-atomic-move [_this from to env]
+    (record-operation! history-atom :invoke :atomic-move from nil)
+    ;; Check for crash BEFORE atomic move
+    (when (maybe-fault! rng (:crash-before-atomic-move fault-config 0.0))
+      (record-operation! history-atom :crash :atomic-move from :before)
+      (inject-crash! :before-atomic-move from))
+    (if (maybe-fault! rng (:atomic-move-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :atomic-move from :fault)
+        (if (:sync? env)
+          (inject-fault! :atomic-move from)
+          (go-try- (inject-fault! :atomic-move from))))
+      (let [result (sl/-atomic-move real-backing from to env)]
+        ;; Check for crash AFTER atomic move
+        (when (maybe-fault! rng (:crash-after-atomic-move fault-config 0.0))
+          (record-operation! history-atom :crash :atomic-move from :after)
+          (inject-crash! :after-atomic-move from))
+        (record-operation! history-atom :ok :atomic-move from nil)
+        result)))
+
+  (-create-store [_this env]
+    (record-operation! history-atom :invoke :create-store nil nil)
+    (let [result (sl/-create-store real-backing env)]
+      (record-operation! history-atom :ok :create-store nil nil)
+      result))
+
+  (-delete-store [_this env]
+    (record-operation! history-atom :invoke :delete-store nil nil)
+    (let [result (sl/-delete-store real-backing env)]
+      (record-operation! history-atom :ok :delete-store nil nil)
+      result))
+
+  (-store-exists? [_this env]
+    (sl/-store-exists? real-backing env))
+
+  (-sync-store [_this env]
+    (record-operation! history-atom :invoke :sync-store nil nil)
+    (if (maybe-fault! rng (:sync-store-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :sync-store nil :fault)
+        (if (:sync? env)
+          (inject-fault! :sync-store nil)
+          (go-try- (inject-fault! :sync-store nil))))
+      (let [result (sl/-sync-store real-backing env)]
+        (record-operation! history-atom :ok :sync-store nil nil)
+        result)))
+
+  (-keys [_this env]
+    (record-operation! history-atom :invoke :keys nil nil)
+    (if (maybe-fault! rng (:keys-fault-rate fault-config 0.0))
+      (do
+        (record-operation! history-atom :fail :keys nil :fault)
+        (if (:sync? env)
+          (inject-fault! :keys nil)
+          (go-try- (inject-fault! :keys nil))))
+      (let [result (sl/-keys real-backing env)]
+        (record-operation! history-atom :ok :keys nil nil)
+        result)))
+
+  (-handle-foreign-key [_this migration-key serializer read-handlers write-handlers env]
+    ;; Pass through - migration is not fault-injected
+    (sl/-handle-foreign-key real-backing migration-key serializer read-handlers write-handlers env)))
+
+;; =============================================================================
+;; Factory Functions
+;; =============================================================================
+
+(defn wrap-backing-store
+  "Wrap a PBackingStore with fault injection.
+
+   Args:
+     real-backing  - The real PBackingStore to wrap
+     fault-config  - Fault configuration map (see default-fault-config)
+     rng           - SplittableRandom for deterministic fault injection
+     history-atom  - Atom to record operation history (optional)
+
+   Returns: SimulatedBackingStore"
+  [real-backing fault-config ^SplittableRandom rng & [history-atom]]
+  (->SimulatedBackingStore real-backing fault-config rng (or history-atom (atom []))))
+
+(defn get-history
+  "Get the operation history from a SimulatedBackingStore."
+  [simulated-backing]
+  @(:history-atom simulated-backing))
+
+(defn clear-history!
+  "Clear the operation history."
+  [simulated-backing]
+  (reset! (:history-atom simulated-backing) []))
+
+(defn count-faults
+  "Count how many faults were injected."
+  [simulated-backing]
+  (count (filter #(= :fail (:op-type %)) (get-history simulated-backing))))
+
+(defn count-crashes
+  "Count how many crashes were simulated."
+  [simulated-backing]
+  (count (filter #(= :crash (:op-type %)) (get-history simulated-backing))))

--- a/src/konserve/simulation/backing.clj
+++ b/src/konserve/simulation/backing.clj
@@ -512,17 +512,7 @@
   [simulated-backing]
   @(:history-atom simulated-backing))
 
-(defn clear-history!
-  "Clear the operation history."
-  [simulated-backing]
-  (reset! (:history-atom simulated-backing) []))
-
 (defn count-faults
   "Count how many faults were injected."
   [simulated-backing]
   (count (filter #(= :fail (:op-type %)) (get-history simulated-backing))))
-
-(defn count-crashes
-  "Count how many crashes were simulated."
-  [simulated-backing]
-  (count (filter #(= :crash (:op-type %)) (get-history simulated-backing))))

--- a/src/konserve/simulation/crash.clj
+++ b/src/konserve/simulation/crash.clj
@@ -1,0 +1,608 @@
+(ns ^:no-doc konserve.simulation.crash
+  "INTERNAL. Crash simulation for `PBackingStore` with sync-point tracking.
+
+   Not public API: this namespace ships in the jar so that backends and
+   downstream projects (datahike, stratum) can test against it, but it carries
+   no compatibility guarantee and may change or move in any release. Depend on
+   it with that understood.
+
+   Crash points are selected explicitly rather than at random — there is no
+   RNG here, so a scenario is deterministic by construction.
+
+   Based on SQLite/RocksDB/CrashMonkey research (100% of crash bugs occur
+   after fsync-like calls), this provides proper crash simulation by:
+
+   1. Tracking pending writes (not yet synced)
+   2. Maintaining synced state snapshots
+   3. On sync, moving pending to synced
+   4. On crash, discarding pending and restoring synced state
+
+   Crash Points (from DefaultStore write path):
+   1. After -write-header, before -write-meta → partial header
+   2. After -write-meta, before -write-value → header+meta, no value
+   3. After -write-value, before -sync       → all written, not synced
+   4. After -sync, before -atomic-move       → .new file complete, not moved
+   5. After -atomic-move, before -sync-store → moved, not store-synced
+   6. After -sync-store, before -delete-blob → complete, backup not deleted
+
+   Invariants to verify after crash:
+   - No partial data visible (all-or-nothing)
+   - No data loss for synced operations
+   - Orphan files (.new, .backup) don't break operations
+   - Store reopens successfully after crash"
+  (:require [konserve.impl.storage-layout :as sl]
+            [superv.async :refer [go-try-]]
+            [clojure.core.async :refer [go]])
+  (:import [java.io ByteArrayOutputStream ByteArrayInputStream]))
+
+;; =============================================================================
+;; Crash Point Definitions
+;; =============================================================================
+
+(def crash-points
+  "All possible crash points in the write path."
+  #{:after-write-header    ; 1. After -write-header, before -write-meta
+    :after-write-meta      ; 2. After -write-meta, before -write-value
+    :after-write-value     ; 3. After -write-value, before -sync
+    :after-sync            ; 4. After -sync, before -atomic-move
+    :after-atomic-move     ; 5. After -atomic-move, before -sync-store
+    :after-sync-store})    ; 6. After -sync-store, before -delete-blob
+
+(defn crash-exception
+  "Create a crash exception for a specific point."
+  [crash-point store-key]
+  (ex-info (str "Simulated crash at " (name crash-point))
+           {:type :simulated-crash
+            :crash-point crash-point
+            :store-key store-key}))
+
+;; =============================================================================
+;; Crash State Management
+;; =============================================================================
+
+(defrecord CrashState
+           [;; Synced data - survives crashes
+            synced-blobs       ; {store-key -> blob-data-vec}
+
+   ;; Pending data - lost on crash
+            pending-blobs      ; {store-key -> blob-data-vec}
+
+   ;; Pending .new files (after sync, before atomic-move)
+            pending-new-files  ; {store-key -> blob-data-vec}
+
+   ;; Pending moves (after atomic-move, before sync-store)
+   ;; [{:from store-key :to store-key :data new-blob-data :old-data old-blob-data}]
+            pending-moves
+
+   ;; Pending backups to delete (after sync-store, before delete-blob)
+            pending-backup-deletes ; #{store-key}
+
+   ;; Store metadata
+            store-exists?
+
+   ;; Resource limits (nil = unlimited)
+            max-total-bytes    ; Maximum total bytes across all blobs
+            max-keys])         ; Maximum number of keys
+
+(defn create-crash-state
+  "Create initial crash state."
+  ([] (create-crash-state nil nil))
+  ([max-total-bytes max-keys]
+   (->CrashState {} {} {} [] #{} false max-total-bytes max-keys)))
+
+;; =============================================================================
+;; Resource Limit Helpers
+;; =============================================================================
+
+(defn total-bytes
+  "Calculate total bytes used in state."
+  [state]
+  (reduce + 0 (map count (vals (:synced-blobs state)))))
+
+(defn total-keys
+  "Count total keys in state."
+  [state]
+  (count (:synced-blobs state)))
+
+(defn check-resource-limits!
+  "Check if adding data would exceed resource limits. Throws if exceeded."
+  [state data-size new-key?]
+  (when-let [max-bytes (:max-total-bytes state)]
+    (when (> (+ (total-bytes state) data-size) max-bytes)
+      (throw (ex-info "Storage limit exceeded"
+                      {:type :resource-exhausted
+                       :resource :storage
+                       :current (total-bytes state)
+                       :requested data-size
+                       :limit max-bytes}))))
+  (when (and new-key? (:max-keys state))
+    (when (>= (total-keys state) (:max-keys state))
+      (throw (ex-info "Key limit exceeded"
+                      {:type :resource-exhausted
+                       :resource :keys
+                       :current (total-keys state)
+                       :limit (:max-keys state)})))))
+
+;; =============================================================================
+;; Lock Implementation
+;; =============================================================================
+
+(defrecord CrashAwareLock [lock-atom lock-id]
+  sl/PBackingLock
+  (-release [_this env]
+    (compare-and-set! lock-atom lock-id nil)
+    (if (:sync? env) nil (go-try- nil))))
+
+(defn- acquire-lock [lock-atom sync?]
+  (let [lock-id (Object.)]
+    (if sync?
+      (loop []
+        (if (compare-and-set! lock-atom nil lock-id)
+          (->CrashAwareLock lock-atom lock-id)
+          (do
+            (Thread/sleep (rand-int 10))
+            (recur))))
+      (go-try-
+       (loop []
+         (if (compare-and-set! lock-atom nil lock-id)
+           (->CrashAwareLock lock-atom lock-id)
+           (do
+             (Thread/sleep (rand-int 10))
+             (recur))))))))
+
+;; =============================================================================
+;; CrashAwareBlob - Tracks pending writes per blob
+;; =============================================================================
+
+(defrecord CrashAwareBlob [store-key
+                           state-atom         ; Atom containing CrashState
+                           lock-atom          ; Per-blob lock
+                           crash-point-atom   ; Current crash injection point (or nil)
+                           history-atom]      ; Operation history for debugging
+  sl/PBackingBlob
+
+  (-sync [_this env]
+    ;; Sync commits pending writes to pending-new-files (ready for atomic-move)
+    (swap! state-atom
+           (fn [state]
+             (if-let [pending-data (get (:pending-blobs state) store-key)]
+               ;; Move from pending to pending-new-files
+               (-> state
+                   (update :pending-blobs dissoc store-key)
+                   (update :pending-new-files assoc store-key pending-data))
+               state)))
+
+    ;; Check for crash after sync
+    (when (= @crash-point-atom :after-sync)
+      (throw (crash-exception :after-sync store-key)))
+
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-close [_this env]
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-get-lock [_this env]
+    (acquire-lock lock-atom (:sync? env)))
+
+  (-read-header [_this env]
+    ;; Read from most current data: pending > pending-new > synced
+    (let [state @state-atom
+          data (or (get (:pending-blobs state) store-key)
+                   (get (:pending-new-files state) store-key)
+                   (get (:synced-blobs state) store-key))
+          header (when (and data (>= (count data) 20))
+                   (byte-array (take 20 data)))]
+      (if (:sync? env)
+        header
+        (go header))))
+
+  (-read-meta [_this meta-size env]
+    (let [state @state-atom
+          data (or (get (:pending-blobs state) store-key)
+                   (get (:pending-new-files state) store-key)
+                   (get (:synced-blobs state) store-key))
+          header-size 20
+          meta (when (and data (>= (count data) (+ header-size meta-size)))
+                 (byte-array (take meta-size (drop header-size data))))]
+      (if (:sync? env)
+        meta
+        (go meta))))
+
+  (-read-value [_this meta-size env]
+    (let [state @state-atom
+          data (or (get (:pending-blobs state) store-key)
+                   (get (:pending-new-files state) store-key)
+                   (get (:synced-blobs state) store-key))
+          header-size 20
+          value (when data
+                  (byte-array (drop (+ header-size meta-size) data)))]
+      (if (:sync? env)
+        value
+        (go value))))
+
+  (-read-binary [_this meta-size locked-cb env]
+    (let [state @state-atom
+          data (or (get (:pending-blobs state) store-key)
+                   (get (:pending-new-files state) store-key)
+                   (get (:synced-blobs state) store-key))
+          header-size 20
+          binary-data (when data (byte-array (drop (+ header-size meta-size) data)))
+          input-stream (when binary-data (ByteArrayInputStream. binary-data))]
+      (if (:sync? env)
+        (locked-cb {:input-stream input-stream
+                    :size (if data (count data) 0)})
+        (go-try-
+         (locked-cb {:input-stream input-stream
+                     :size (if data (count data) 0)})))))
+
+  (-write-header [_this header-arr env]
+    ;; Initialize pending blob with header
+    (swap! state-atom
+           (fn [state]
+             (let [current (get (:pending-blobs state) store-key)
+                   header-size 20
+                   new-data (if current
+                              ;; Update header in existing pending data
+                              (vec (concat (seq header-arr) (drop header-size current)))
+                              ;; New blob - just header
+                              (vec (seq header-arr)))]
+               (update state :pending-blobs assoc store-key new-data))))
+
+    ;; Check for crash after write-header
+    (when (= @crash-point-atom :after-write-header)
+      (throw (crash-exception :after-write-header store-key)))
+
+    (if (:sync? env) nil (go nil)))
+
+  (-write-meta [_this meta-arr env]
+    ;; Append meta to pending blob
+    (swap! state-atom
+           (fn [state]
+             (let [current (get (:pending-blobs state) store-key [])
+                   header-size 20
+                   header (take header-size current)
+                   ;; Replace meta wholesale: the write path is
+                   ;; header → meta → value, so no value is present yet.
+                   new-data (vec (concat header (seq meta-arr)))]
+               (update state :pending-blobs assoc store-key new-data))))
+
+    ;; Check for crash after write-meta
+    (when (= @crash-point-atom :after-write-meta)
+      (throw (crash-exception :after-write-meta store-key)))
+
+    (if (:sync? env) nil (go nil)))
+
+  (-write-value [_this value-arr meta-size env]
+    ;; Append value to pending blob
+    (swap! state-atom
+           (fn [state]
+             (let [current (get (:pending-blobs state) store-key [])
+                   header-size 20
+                   header (take header-size current)
+                   meta (take meta-size (drop header-size current))
+                   new-data (vec (concat header meta (seq value-arr)))]
+               (update state :pending-blobs assoc store-key new-data))))
+
+    ;; Check for crash after write-value
+    (when (= @crash-point-atom :after-write-value)
+      (throw (crash-exception :after-write-value store-key)))
+
+    (if (:sync? env) nil (go nil)))
+
+  (-write-binary [_this meta-size blob env]
+    (let [state @state-atom
+          current (get (:pending-blobs state) store-key [])
+          header-size 20
+          header (take header-size current)
+          meta (take meta-size (drop header-size current))
+          ;; Read blob into byte array
+          bos (ByteArrayOutputStream.)
+          _ (if (instance? java.io.InputStream blob)
+              (let [buf (byte-array (or (:buffer-size env) 8192))]
+                (loop []
+                  (let [n (.read ^java.io.InputStream blob buf)]
+                    (when (pos? n)
+                      (.write bos buf 0 n)
+                      (recur)))))
+              (.write bos ^bytes blob))
+          binary-bytes (.toByteArray bos)
+          new-data (vec (concat header meta (seq binary-bytes)))]
+
+      (swap! state-atom update :pending-blobs assoc store-key new-data)
+
+      ;; Check for crash after write-value (binary uses same point)
+      (when (= @crash-point-atom :after-write-value)
+        (throw (crash-exception :after-write-value store-key)))
+
+      (if (:sync? env) nil (go nil)))))
+
+;; =============================================================================
+;; CrashAwareBackingStore
+;; =============================================================================
+
+(defrecord CrashAwareBackingStore [state-atom          ; CrashState
+                                   crash-point-atom   ; Current crash injection point
+                                   blob-locks-atom    ; {store-key -> lock-atom}
+                                   history-atom]      ; Operation history
+  sl/PBackingStore
+
+  (-create-blob [_this store-key env]
+    ;; Get or create lock for this blob
+    (let [lock-atom (get (swap! blob-locks-atom
+                                (fn [locks]
+                                  (if (contains? locks store-key)
+                                    locks
+                                    (assoc locks store-key (atom nil)))))
+                         store-key)
+          blob (->CrashAwareBlob store-key state-atom lock-atom
+                                 crash-point-atom history-atom)]
+      (if (:sync? env)
+        blob
+        (go blob))))
+
+  (-delete-blob [_this store-key env]
+    (swap! state-atom
+           (fn [state]
+             (-> state
+                 (update :synced-blobs dissoc store-key)
+                 (update :pending-blobs dissoc store-key)
+                 (update :pending-new-files dissoc store-key))))
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-blob-exists? [_this store-key env]
+    (let [state @state-atom
+          exists? (or (contains? (:synced-blobs state) store-key)
+                      (contains? (:pending-blobs state) store-key)
+                      (contains? (:pending-new-files state) store-key))]
+      (if (:sync? env)
+        exists?
+        (go exists?))))
+
+  (-migratable [_this _key _store-key env]
+    (if (:sync? env) nil (go nil)))
+
+  (-migrate [_this _migration-key _key-vec _serializer _read-handlers _write-handlers env]
+    (if (:sync? env) nil (go nil)))
+
+  (-copy [_this from to env]
+    (swap! state-atom
+           (fn [state]
+             (let [data (or (get (:pending-blobs state) from)
+                            (get (:pending-new-files state) from)
+                            (get (:synced-blobs state) from))]
+               (if data
+                 (update state :pending-blobs assoc to (vec data))
+                 state))))
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-atomic-move [_this from to env]
+    ;; Atomic move: from pending-new-files to synced (simulating rename)
+    ;; Track old value for crash recovery
+    ;; Check resource limits before committing
+    (let [state @state-atom
+          data (or (get (:pending-new-files state) from)
+                   (get (:pending-blobs state) from))
+          old-data (get (:synced-blobs state) to)
+          new-key? (nil? old-data)
+          data-size (if data (count data) 0)
+          ;; For updates, we only add net new bytes
+          net-bytes (if old-data
+                      (- data-size (count old-data))
+                      data-size)]
+      ;; Check limits before swap
+      (when data
+        (check-resource-limits! state net-bytes new-key?)))
+
+    (swap! state-atom
+           (fn [state]
+             (let [old-data (get (:synced-blobs state) to)]  ; Get existing value at target
+               (if-let [data (get (:pending-new-files state) from)]
+                 ;; Move .new file to final location
+                 (-> state
+                     (update :pending-new-files dissoc from)
+                     ;; Track as pending move with old value for crash recovery
+                     (update :pending-moves conj {:from from :to to :data data :old-data old-data})
+                     ;; But also make it visible immediately (as real filesystem would)
+                     (update :synced-blobs assoc to data))
+                 ;; No pending-new-file, check if it's in pending-blobs
+                 (if-let [data (get (:pending-blobs state) from)]
+                   (-> state
+                       (update :pending-blobs dissoc from)
+                       (update :pending-moves conj {:from from :to to :data data :old-data old-data})
+                       (update :synced-blobs assoc to data))
+                   state)))))
+
+    ;; Check for crash after atomic-move
+    (when (= @crash-point-atom :after-atomic-move)
+      (throw (crash-exception :after-atomic-move to)))
+
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-create-store [_this env]
+    (swap! state-atom assoc :store-exists? true)
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-delete-store [_this env]
+    (reset! state-atom (create-crash-state))
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-store-exists? [_this env]
+    (let [exists? (:store-exists? @state-atom)]
+      (if (:sync? env)
+        exists?
+        (go exists?))))
+
+  (-sync-store [_this env]
+    ;; Sync store commits pending moves
+    (swap! state-atom
+           (fn [state]
+             (-> state
+                 ;; Clear pending moves (they're now durable)
+                 (assoc :pending-moves [])
+                 ;; Clear pending backup deletes (they're now durable)
+                 (assoc :pending-backup-deletes #{}))))
+
+    ;; Check for crash after sync-store
+    (when (= @crash-point-atom :after-sync-store)
+      (throw (crash-exception :after-sync-store nil)))
+
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-keys [_this env]
+    (let [state @state-atom
+          ;; Return only synced keys (consistent view)
+          keys-set (set (keys (:synced-blobs state)))]
+      (if (:sync? env)
+        (vec keys-set)
+        (go (vec keys-set)))))
+
+  (-handle-foreign-key [_this _migration-key _serializer _read-handlers _write-handlers env]
+    (if (:sync? env) [] (go []))))
+
+;; =============================================================================
+;; Crash Simulation API
+;; =============================================================================
+
+(defn create-crash-aware-store
+  "Create a new crash-aware backing store.
+
+   Options:
+     :max-total-bytes - Maximum total storage in bytes (nil = unlimited)
+     :max-keys        - Maximum number of keys (nil = unlimited)
+
+   Returns a map with:
+     :backing - CrashAwareBackingStore implementing PBackingStore
+     :state-atom - Atom containing crash state for inspection
+     :crash-point-atom - Atom to set crash injection point
+     :history-atom - Atom with operation history
+
+   Usage:
+     (def store-info (create-crash-aware-store))
+     (def backing (:backing store-info))
+     ;; Set crash point
+     (reset! (:crash-point-atom store-info) :after-write-value)
+     ;; Operations will now crash at that point
+
+   With resource limits:
+     (def store-info (create-crash-aware-store {:max-total-bytes 10000
+                                                 :max-keys 100}))"
+  ([] (create-crash-aware-store {}))
+  ([{:keys [max-total-bytes max-keys]}]
+   (let [state-atom (atom (create-crash-state max-total-bytes max-keys))
+         crash-point-atom (atom nil)
+         blob-locks-atom (atom {})
+         history-atom (atom [])]
+     {:backing (->CrashAwareBackingStore state-atom crash-point-atom
+                                         blob-locks-atom history-atom)
+      :state-atom state-atom
+      :crash-point-atom crash-point-atom
+      :history-atom history-atom})))
+
+(defn simulate-crash!
+  "Simulate a crash by discarding all pending (unsynced) data.
+
+   This restores the store to its last consistent state:
+   - Discards pending-blobs (writes not synced)
+   - Discards pending-new-files (synced but not atomic-moved)
+   - Reverts pending-moves: restores old values if they existed
+
+   Returns the state before crash for verification."
+  [state-atom]
+  (let [before-state @state-atom]
+    (swap! state-atom
+           (fn [state]
+             (-> state
+                 ;; Discard pending writes
+                 (assoc :pending-blobs {})
+                 ;; Discard pending .new files
+                 (assoc :pending-new-files {})
+                 ;; Revert pending moves - restore old values or remove key
+                 (update :synced-blobs
+                         (fn [synced]
+                           (reduce (fn [s {:keys [to old-data]}]
+                                     (if old-data
+                                       ;; Restore old value
+                                       (assoc s to old-data)
+                                       ;; No old value - this was a new key, remove it
+                                       (dissoc s to)))
+                                   synced
+                                   (:pending-moves state))))
+                 ;; Clear pending moves
+                 (assoc :pending-moves [])
+                 ;; Note: pending-backup-deletes don't affect data integrity
+                 (assoc :pending-backup-deletes #{}))))
+    before-state))
+
+(defn set-crash-point!
+  "Set the crash injection point.
+
+   Valid points:
+   - :after-write-header
+   - :after-write-meta
+   - :after-write-value
+   - :after-sync
+   - :after-atomic-move
+   - :after-sync-store
+   - nil (no crash injection)"
+  [crash-point-atom point]
+  (when (and point (not (contains? crash-points point)))
+    (throw (ex-info "Invalid crash point"
+                    {:valid-points crash-points
+                     :provided point})))
+  (reset! crash-point-atom point))
+
+(defn clear-crash-point!
+  "Clear crash injection (no crashes will be triggered)."
+  [crash-point-atom]
+  (reset! crash-point-atom nil))
+
+(defn get-synced-data
+  "Get currently synced (durable) data for inspection.
+   Returns map of {store-key -> blob-data-vec}."
+  [state-atom]
+  (:synced-blobs @state-atom))
+
+(defn get-pending-data
+  "Get pending (not yet synced) data for inspection.
+   Returns map of {store-key -> blob-data-vec}."
+  [state-atom]
+  (:pending-blobs @state-atom))
+
+(defn get-pending-new-files
+  "Get pending .new files (synced but not atomic-moved).
+   Returns map of {store-key -> blob-data-vec}."
+  [state-atom]
+  (:pending-new-files @state-atom))
+
+(defn has-orphan-files?
+  "Check if there are orphan .new files after a crash.
+   In real filesystem, these would be left behind."
+  [state-atom]
+  (boolean (seq (:pending-new-files @state-atom))))
+
+;; =============================================================================
+;; Test Helpers
+;; =============================================================================
+
+(defn verify-no-partial-data
+  "Verify that no partial data is visible.
+   Returns true if data integrity is maintained."
+  [state-atom store-key expected-header-size expected-meta-size]
+  (let [state @state-atom
+        data (get (:synced-blobs state) store-key)]
+    (if (nil? data)
+      true  ; No data is valid (old value preserved)
+      (let [total-size (count data)
+            min-valid-size (+ expected-header-size expected-meta-size 1)]
+        ;; Data must be either empty or complete
+        (or (zero? total-size)
+            (>= total-size min-valid-size))))))
+
+(defn verify-atomicity
+  "Verify that a write either fully completed or had no effect.
+   Compares before and after states."
+  [before-state after-state store-key]
+  (let [before-data (get (:synced-blobs before-state) store-key)
+        after-data (get (:synced-blobs after-state) store-key)]
+    ;; After crash, data should be unchanged from before the write attempt
+    (= before-data after-data)))

--- a/src/konserve/simulation/crash.clj
+++ b/src/konserve/simulation/crash.clj
@@ -574,29 +574,9 @@
   [state-atom]
   (:pending-new-files @state-atom))
 
-(defn has-orphan-files?
-  "Check if there are orphan .new files after a crash.
-   In real filesystem, these would be left behind."
-  [state-atom]
-  (boolean (seq (:pending-new-files @state-atom))))
-
 ;; =============================================================================
 ;; Test Helpers
 ;; =============================================================================
-
-(defn verify-no-partial-data
-  "Verify that no partial data is visible.
-   Returns true if data integrity is maintained."
-  [state-atom store-key expected-header-size expected-meta-size]
-  (let [state @state-atom
-        data (get (:synced-blobs state) store-key)]
-    (if (nil? data)
-      true  ; No data is valid (old value preserved)
-      (let [total-size (count data)
-            min-valid-size (+ expected-header-size expected-meta-size 1)]
-        ;; Data must be either empty or complete
-        (or (zero? total-size)
-            (>= total-size min-valid-size))))))
 
 (defn verify-atomicity
   "Verify that a write either fully completed or had no effect.

--- a/src/konserve/simulation/memory.clj
+++ b/src/konserve/simulation/memory.clj
@@ -272,13 +272,3 @@
   []
   (->MemoryBackingStore (atom {}) (atom false)))
 
-(defn get-blob-data
-  "Get raw blob data for inspection (testing helper)."
-  [backing store-key]
-  (when-let [blob (get @(:blobs-atom backing) store-key)]
-    @(:data-atom blob)))
-
-(defn list-all-blobs
-  "List all blob keys in the store (testing helper)."
-  [backing]
-  (keys @(:blobs-atom backing)))

--- a/src/konserve/simulation/memory.clj
+++ b/src/konserve/simulation/memory.clj
@@ -1,0 +1,284 @@
+(ns ^:no-doc konserve.simulation.memory
+  "INTERNAL. In-memory `PBackingStore` for simulation testing.
+
+   Not public API: this namespace ships in the jar so that backends and
+   downstream projects (datahike, stratum) can test against it, but it carries
+   no compatibility guarantee and may change or move in any release. Depend on
+   it with that understood.
+
+   A pure in-memory backing store implementing konserve's low-level
+   `PBackingStore` protocol. Useful for:
+   - Fast CI tests without filesystem I/O
+   - Testing DefaultStore logic in isolation
+   - Wrapping with `konserve.simulation.backing` for fault injection
+
+   Architecture:
+     [k/assoc] → [DefaultStore] → [SimulatedBackingStore] → [MemoryBackingStore]
+                                           ↓
+                                   No filesystem I/O!"
+  (:require [konserve.impl.storage-layout :as sl]
+            [superv.async :refer [go-try-]]
+            [clojure.core.async :refer [go]])
+  (:import [java.io ByteArrayOutputStream ByteArrayInputStream]))
+
+;; =============================================================================
+;; Lock Implementation (must be before MemoryBlob)
+;; =============================================================================
+
+;; Simple lock that tracks if released
+(defrecord MemoryLock [lock-atom lock-id]
+  sl/PBackingLock
+  (-release [_this env]
+    (compare-and-set! lock-atom lock-id nil)
+    (if (:sync? env) nil (go-try- nil))))
+
+(defn- acquire-lock [lock-atom sync?]
+  (let [lock-id (Object.)]
+    (if sync?
+      (loop []
+        (if (compare-and-set! lock-atom nil lock-id)
+          (->MemoryLock lock-atom lock-id)
+          (do
+            (Thread/sleep (rand-int 10))
+            (recur))))
+      (go-try-
+       (loop []
+         (if (compare-and-set! lock-atom nil lock-id)
+           (->MemoryLock lock-atom lock-id)
+           (do
+             (Thread/sleep (rand-int 10))
+             (recur))))))))
+
+;; =============================================================================
+;; In-Memory Blob
+;; =============================================================================
+
+(defrecord MemoryBlob [store-key data-atom lock-atom]
+  sl/PBackingBlob
+
+  (-sync [_this env]
+    ;; No-op for memory - data is already "synced"
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-close [_this env]
+    ;; No-op for memory
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-get-lock [_this env]
+    ;; Return a MemoryLock that implements PBackingLock
+    (acquire-lock lock-atom (:sync? env)))
+
+  (-read-header [_this env]
+    (let [data @data-atom
+          header (when data (byte-array (take 20 data)))]
+      (if (:sync? env)
+        header
+        (go header))))
+
+  (-read-meta [_this meta-size env]
+    (let [data @data-atom
+          header-size 20
+          meta (when data
+                 (byte-array (take meta-size (drop header-size data))))]
+      (if (:sync? env)
+        meta
+        (go meta))))
+
+  (-read-value [_this meta-size env]
+    (let [data @data-atom
+          header-size 20
+          value (when data
+                  (byte-array (drop (+ header-size meta-size) data)))]
+      (if (:sync? env)
+        value
+        (go value))))
+
+  (-read-binary [_this meta-size locked-cb env]
+    (let [data @data-atom
+          header-size 20
+          binary-data (when data (byte-array (drop (+ header-size meta-size) data)))
+          input-stream (when binary-data (ByteArrayInputStream. binary-data))]
+      (if (:sync? env)
+        (locked-cb {:input-stream input-stream
+                    :size (if data (count data) 0)})
+        (go-try-
+         (locked-cb {:input-stream input-stream
+                     :size (if data (count data) 0)})))))
+
+  (-write-header [_this header-arr env]
+    ;; Initialize or update header portion
+    (let [current @data-atom
+          header-size 20
+          new-data (if current
+                     ;; Update header in existing data
+                     (let [rest-data (drop header-size current)]
+                       (vec (concat (seq header-arr) rest-data)))
+                     ;; New blob - just header for now
+                     (vec (seq header-arr)))]
+      (reset! data-atom new-data)
+      (if (:sync? env) nil (go nil))))
+
+  (-write-meta [_this meta-arr env]
+    ;; Append meta to header
+    (let [current @data-atom
+          header-size 20
+          header (take header-size current)
+          ;; Keep any existing value data if present
+          old-meta-size (- (count current) header-size)
+          old-value (when (> (count current) header-size)
+                      (drop (+ header-size old-meta-size) current))
+          new-data (vec (concat header (seq meta-arr) old-value))]
+      (reset! data-atom new-data)
+      (if (:sync? env) nil (go nil))))
+
+  (-write-value [_this value-arr meta-size env]
+    ;; Replace value portion
+    (let [current @data-atom
+          header-size 20
+          header (take header-size current)
+          meta (take meta-size (drop header-size current))
+          new-data (vec (concat header meta (seq value-arr)))]
+      (reset! data-atom new-data)
+      (if (:sync? env) nil (go nil))))
+
+  (-write-binary [_this meta-size blob env]
+    ;; Write binary blob
+    (let [{:keys [buffer-size]} env
+          current @data-atom
+          header-size 20
+          header (take header-size current)
+          meta (take meta-size (drop header-size current))
+          ;; Read blob into byte array
+          bos (ByteArrayOutputStream.)
+          _ (if (instance? java.io.InputStream blob)
+              (let [buf (byte-array (or buffer-size 8192))]
+                (loop []
+                  (let [n (.read ^java.io.InputStream blob buf)]
+                    (when (pos? n)
+                      (.write bos buf 0 n)
+                      (recur)))))
+              ;; Assume it's already bytes
+              (.write bos ^bytes blob))
+          binary-bytes (.toByteArray bos)
+          new-data (vec (concat header meta (seq binary-bytes)))]
+      (reset! data-atom new-data)
+      (if (:sync? env) nil (go nil)))))
+
+;; =============================================================================
+;; In-Memory Backing Store
+;; =============================================================================
+
+(defrecord MemoryBackingStore [blobs-atom store-created?-atom]
+  sl/PBackingStore
+
+  (-create-blob [_this store-key env]
+    ;; Get or create blob for this key
+    (let [existing (get @blobs-atom store-key)
+          blob (or existing
+                   (let [new-blob (->MemoryBlob store-key (atom nil) (atom nil))]
+                     (swap! blobs-atom assoc store-key new-blob)
+                     new-blob))]
+      (if (:sync? env)
+        blob
+        (go blob))))
+
+  (-delete-blob [_this store-key env]
+    (swap! blobs-atom dissoc store-key)
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-blob-exists? [_this store-key env]
+    (let [exists? (and (contains? @blobs-atom store-key)
+                       (some? @(:data-atom (get @blobs-atom store-key))))]
+      (if (:sync? env)
+        exists?
+        (go exists?))))
+
+  (-migratable [_this _key _store-key env]
+    ;; No migration for memory store
+    (if (:sync? env) nil (go nil)))
+
+  (-migrate [_this _migration-key _key-vec _serializer _read-handlers _write-handlers env]
+    ;; No migration for memory store
+    (if (:sync? env) nil (go nil)))
+
+  (-copy [_this from to env]
+    ;; Copy blob data
+    (when-let [from-blob (get @blobs-atom from)]
+      (let [data @(:data-atom from-blob)
+            to-blob (->MemoryBlob to (atom (when data (vec data))) (atom nil))]
+        (swap! blobs-atom assoc to to-blob)))
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-atomic-move [_this from to env]
+    ;; Atomic rename - just swap the keys
+    (let [from-blob (get @blobs-atom from)]
+      (when from-blob
+        ;; Create new blob with same data but new key
+        (let [new-blob (->MemoryBlob to (:data-atom from-blob) (atom nil))]
+          (swap! blobs-atom (fn [m]
+                              (-> m
+                                  (dissoc from)
+                                  (assoc to new-blob)))))))
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-create-store [_this env]
+    (reset! store-created?-atom true)
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-delete-store [_this env]
+    (reset! blobs-atom {})
+    (reset! store-created?-atom false)
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-store-exists? [_this env]
+    (let [exists? @store-created?-atom]
+      (if (:sync? env)
+        exists?
+        (go exists?))))
+
+  (-sync-store [_this env]
+    ;; No-op for memory
+    (if (:sync? env) nil (go-try- nil)))
+
+  (-keys [_this env]
+    ;; Return all store keys that have data
+    (let [keys-with-data (->> @blobs-atom
+                              (filter (fn [[_k v]] (some? @(:data-atom v))))
+                              (map first)
+                              vec)]
+      (if (:sync? env)
+        keys-with-data
+        (go keys-with-data))))
+
+  (-handle-foreign-key [_this _migration-key _serializer _read-handlers _write-handlers env]
+    ;; No foreign keys in memory store
+    (if (:sync? env) [] (go []))))
+
+;; =============================================================================
+;; Factory Functions
+;; =============================================================================
+
+(defn create-memory-backing
+  "Create a new in-memory backing store.
+
+   Returns a MemoryBackingStore that implements PBackingStore.
+   Can be wrapped with SimulatedBackingStore for fault injection,
+   then connected to DefaultStore.
+
+   Example:
+     (def backing (create-memory-backing))
+     (def store (<!! (connect-default-store backing {:opts {:sync? false}})))
+     (k/assoc store :key {:value 1})"
+  []
+  (->MemoryBackingStore (atom {}) (atom false)))
+
+(defn get-blob-data
+  "Get raw blob data for inspection (testing helper)."
+  [backing store-key]
+  (when-let [blob (get @(:blobs-atom backing) store-key)]
+    @(:data-atom blob)))
+
+(defn list-all-blobs
+  "List all blob keys in the store (testing helper)."
+  [backing]
+  (keys @(:blobs-atom backing)))

--- a/test/konserve/simulation_backing_test.clj
+++ b/test/konserve/simulation_backing_test.clj
@@ -1,0 +1,555 @@
+(ns konserve.simulation-backing-test
+  "Tests for konserve error propagation and memory model.
+
+   These tests verify:
+   1. Error propagation - errors at PBackingStore level reach callers
+   2. Memory model - atomicity and durability guarantees
+   3. FileStore behavior - real filesystem operations"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.core.async :refer [<!!]]
+            [clojure.java.io :as io]
+            [konserve.simulation.backing :as backing]
+            [konserve.simulation.memory :as mb]
+            [konserve.core :as k]
+            [konserve.filestore :as fs]
+            [konserve.impl.defaults :refer [connect-default-store]])
+  (:import [java.io File]
+           [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+;; =============================================================================
+;; Test Fixtures
+;; =============================================================================
+
+(def ^:dynamic *test-dir* nil)
+
+(defn create-temp-dir []
+  (let [path (Files/createTempDirectory "konserve-simulation-test"
+                                        (into-array FileAttribute []))]
+    (.toString path)))
+
+(defn delete-dir-recursive [^File f]
+  (when (.exists f)
+    (when (.isDirectory f)
+      (doseq [child (.listFiles f)]
+        (delete-dir-recursive child)))
+    (.delete f)))
+
+(defn temp-dir-fixture [f]
+  (let [dir (create-temp-dir)]
+    (try
+      (binding [*test-dir* dir]
+        (f))
+      (finally
+        (delete-dir-recursive (io/file dir))))))
+
+(use-fixtures :each temp-dir-fixture)
+
+;; =============================================================================
+;; Helper Functions
+;; =============================================================================
+
+(defn create-filestore-backing
+  "Create a raw BackingFilestore for wrapping."
+  [path]
+  ;; ephemeral? is a predicate for filtering files - use (constantly false) for no filtering
+  ;; filesystem = nil means use default filesystem
+  (fs/->BackingFilestore path nil (constantly false) nil))
+
+(defn create-wrapped-store
+  "Create a DefaultStore with SimulatedBackingStore wrapping FileStore."
+  [path fault-config seed]
+  (let [real-backing (create-filestore-backing path)
+        rng (backing/rng seed)
+        history-atom (atom [])
+        simulated-backing (backing/wrap-backing-store real-backing fault-config rng history-atom)]
+    {:store (<!! (connect-default-store simulated-backing
+                                        {:opts {:sync? false}
+                                         :config {:sync-blob? true}}))
+     :backing simulated-backing
+     :history history-atom}))
+
+(defn create-sync-wrapped-store
+  "Create a DefaultStore with SimulatedBackingStore (sync mode)."
+  [path fault-config seed]
+  (let [real-backing (create-filestore-backing path)
+        rng (backing/rng seed)
+        history-atom (atom [])
+        simulated-backing (backing/wrap-backing-store real-backing fault-config rng history-atom)]
+    {:store (connect-default-store simulated-backing
+                                   {:opts {:sync? true}
+                                    :config {:sync-blob? true}})
+     :backing simulated-backing
+     :history history-atom}))
+
+;; =============================================================================
+;; Error Propagation Tests
+;; =============================================================================
+
+(deftest error-propagation-write-header-test
+  (testing "write-header fault propagates to assoc"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           (assoc backing/no-faults-config
+                                  :write-header-fault-rate 1.0)
+                           42)]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Simulated write-header fault"
+           (k/assoc store :test-key {:value 1} {:sync? true}))))))
+
+(deftest error-propagation-write-meta-test
+  (testing "write-meta fault propagates to assoc"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           (assoc backing/no-faults-config
+                                  :write-meta-fault-rate 1.0)
+                           42)]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Simulated write-meta fault"
+           (k/assoc store :test-key {:value 1} {:sync? true}))))))
+
+(deftest error-propagation-write-value-test
+  (testing "write-value fault propagates to assoc"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           (assoc backing/no-faults-config
+                                  :write-value-fault-rate 1.0)
+                           42)]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Simulated write-value fault"
+           (k/assoc store :test-key {:value 1} {:sync? true}))))))
+
+(deftest error-propagation-read-header-test
+  (testing "read-header fault propagates to get"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           42)]
+      ;; First write successfully
+      (k/assoc store :test-key {:value 1} {:sync? true})
+
+      ;; Now create a new store with read faults
+      (let [{:keys [store]} (create-sync-wrapped-store
+                             *test-dir*
+                             (assoc backing/no-faults-config
+                                    :read-header-fault-rate 1.0)
+                             43)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Simulated read-header fault"
+             (k/get store :test-key nil {:sync? true})))))))
+
+(deftest error-propagation-read-value-test
+  (testing "read-value fault propagates to get"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           42)]
+      ;; First write successfully
+      (k/assoc store :test-key {:value 1} {:sync? true})
+
+      ;; Now create a new store with read faults
+      (let [{:keys [store]} (create-sync-wrapped-store
+                             *test-dir*
+                             (assoc backing/no-faults-config
+                                    :read-value-fault-rate 1.0)
+                             43)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Simulated read-value fault"
+             (k/get store :test-key nil {:sync? true})))))))
+
+(deftest error-propagation-atomic-move-test
+  (testing "atomic-move fault propagates to assoc"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           (assoc backing/no-faults-config
+                                  :atomic-move-fault-rate 1.0)
+                           42)]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Simulated atomic-move fault"
+           (k/assoc store :test-key {:value 1} {:sync? true}))))))
+
+(deftest error-propagation-delete-blob-test
+  (testing "delete-blob fault propagates to dissoc"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           42)]
+      ;; First write successfully
+      (k/assoc store :test-key {:value 1} {:sync? true})
+
+      ;; Now create a new store with delete faults
+      (let [{:keys [store]} (create-sync-wrapped-store
+                             *test-dir*
+                             (assoc backing/no-faults-config
+                                    :delete-blob-fault-rate 1.0)
+                             43)]
+        ;; Error propagates but is wrapped by DefaultStore with context
+        ;; The wrapping adds {:key :test-key, :exception <our-fault>}
+        (try
+          (k/dissoc store :test-key {:sync? true})
+          (is false "Should have thrown")
+          (catch clojure.lang.ExceptionInfo e
+            ;; DefaultStore wraps with context, nested exception is our fault
+            (let [data (ex-data e)
+                  nested-ex (:exception data)]
+              (is (some? nested-ex) "Should have nested exception")
+              (when nested-ex
+                (is (re-find #"Simulated delete-blob fault"
+                             (.getMessage ^Exception nested-ex)))))))))))
+
+(deftest error-propagation-async-test
+  (testing "errors propagate correctly in async mode"
+    (let [{:keys [store]} (create-wrapped-store
+                           *test-dir*
+                           (assoc backing/no-faults-config
+                                  :write-header-fault-rate 1.0)
+                           42)
+          result (<!! (k/assoc store :test-key {:value 1}))]
+      ;; In async mode, errors are returned on the channel
+      (is (instance? clojure.lang.ExceptionInfo result))
+      (is (re-find #"Simulated write-header fault" (.getMessage ^Exception result))))))
+
+;; =============================================================================
+;; Memory Model Tests - Atomicity
+;; =============================================================================
+
+(deftest atomicity-write-failure-leaves-no-trace-test
+  (testing "failed write does not leave partial data"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           42)]
+      ;; First write successfully
+      (k/assoc store :test-key {:value 1} {:sync? true})
+      (is (= {:value 1} (k/get store :test-key nil {:sync? true})))
+
+      ;; Now try to write with fault - should fail
+      (let [{:keys [store]} (create-sync-wrapped-store
+                             *test-dir*
+                             (assoc backing/no-faults-config
+                                    :write-value-fault-rate 1.0)
+                             43)]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (k/assoc store :test-key {:value 2} {:sync? true}))))
+
+      ;; Original value should still be readable
+      (let [{:keys [store]} (create-sync-wrapped-store
+                             *test-dir*
+                             backing/no-faults-config
+                             44)]
+        (is (= {:value 1} (k/get store :test-key nil {:sync? true})))))))
+
+(deftest atomicity-atomic-move-failure-test
+  (testing "atomic-move failure leaves original intact"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           42)]
+      ;; First write successfully
+      (k/assoc store :test-key {:value 1} {:sync? true})
+      (is (= {:value 1} (k/get store :test-key nil {:sync? true}))))
+
+    ;; Now try to write with atomic-move fault
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           (assoc backing/no-faults-config
+                                  :atomic-move-fault-rate 1.0)
+                           43)]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (k/assoc store :test-key {:value 2} {:sync? true}))))
+
+    ;; Original value should still be readable
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           44)]
+      (is (= {:value 1} (k/get store :test-key nil {:sync? true}))))))
+
+;; =============================================================================
+;; Memory Model Tests - Durability
+;; =============================================================================
+
+(deftest durability-successful-write-persists-test
+  (testing "successful write is durable across store reopens"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           42)]
+      ;; Write data
+      (k/assoc store :key1 {:value 1} {:sync? true})
+      (k/assoc store :key2 {:value 2} {:sync? true})
+      (k/assoc store :key3 {:value 3} {:sync? true}))
+
+    ;; Reopen store and verify data persists
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           43)]
+      (is (= {:value 1} (k/get store :key1 nil {:sync? true})))
+      (is (= {:value 2} (k/get store :key2 nil {:sync? true})))
+      (is (= {:value 3} (k/get store :key3 nil {:sync? true}))))))
+
+(deftest durability-exists-after-reopen-test
+  (testing "exists? works after store reopen"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           42)]
+      (k/assoc store :test-key {:value 1} {:sync? true}))
+
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           43)]
+      (is (true? (k/exists? store :test-key {:sync? true})))
+      (is (false? (k/exists? store :nonexistent {:sync? true}))))))
+
+;; =============================================================================
+;; FileStore Specific Tests
+;; =============================================================================
+
+(deftest filestore-orphan-new-file-test
+  (testing ".new files are orphans from failed writes"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           42)]
+      ;; Successful write
+      (k/assoc store :test-key {:value 1} {:sync? true}))
+
+    ;; Simulate crash before atomic-move by manually creating .new file
+    ;; (In real scenario, this would be left behind by a crash)
+    (let [new-file (io/file *test-dir* "test.ksv.new")]
+      (spit new-file "orphan data"))
+
+    ;; Store should still work, ignoring orphan
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           43)]
+      (is (= {:value 1} (k/get store :test-key nil {:sync? true})))
+
+      ;; New writes should work
+      (k/assoc store :key2 {:value 2} {:sync? true})
+      (is (= {:value 2} (k/get store :key2 nil {:sync? true}))))))
+
+(deftest filestore-keys-ignores-new-and-backup-test
+  (testing "keys operation ignores .new and .backup files"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           42)]
+      ;; Write some data
+      (k/assoc store :key1 {:value 1} {:sync? true})
+      (k/assoc store :key2 {:value 2} {:sync? true})
+
+      ;; Create orphan files
+      (spit (io/file *test-dir* "orphan.ksv.new") "new file")
+      (spit (io/file *test-dir* "orphan.ksv.backup") "backup file")
+
+      ;; Keys should only return real keys
+      (let [all-keys (k/keys store {:sync? true})]
+        (is (= 2 (count all-keys)))
+        (is (every? #(contains? #{:key1 :key2} (:key %)) all-keys))))))
+
+;; =============================================================================
+;; History Recording Tests
+;; =============================================================================
+
+(deftest history-records-operations-test
+  (testing "SimulatedBackingStore records operation history"
+    (let [{:keys [store backing]} (create-sync-wrapped-store
+                                   *test-dir*
+                                   backing/no-faults-config
+                                   42)]
+      ;; Perform some operations
+      (k/assoc store :key1 {:value 1} {:sync? true})
+      (k/get store :key1 nil {:sync? true})
+      (k/dissoc store :key1 {:sync? true})
+
+      ;; Check history
+      (let [history (backing/get-history backing)]
+        (is (pos? (count history)))
+
+        ;; Should have invoke/ok pairs
+        (is (some #(= :invoke (:op-type %)) history))
+        (is (some #(= :ok (:op-type %)) history))
+
+        ;; Should have various operations
+        (is (some #(= :create-blob (:operation %)) history))
+        (is (some #(= :write-header (:operation %)) history))
+        (is (some #(= :atomic-move (:operation %)) history))))))
+
+(deftest history-records-faults-test
+  (testing "SimulatedBackingStore records fault injection"
+    (let [{:keys [store backing]} (create-sync-wrapped-store
+                                   *test-dir*
+                                   (assoc backing/no-faults-config
+                                          :write-header-fault-rate 1.0)
+                                   42)]
+      ;; Try to write (will fail)
+      (try
+        (k/assoc store :key1 {:value 1} {:sync? true})
+        (catch Exception _))
+
+      ;; Check history has fault recorded
+      (let [history (backing/get-history backing)]
+        (is (some #(= :fail (:op-type %)) history))
+        (is (= 1 (backing/count-faults backing)))))))
+
+;; =============================================================================
+;; Stress Tests
+;; =============================================================================
+
+(deftest stress-chaos-mode-test
+  (testing "store survives chaos mode without data loss"
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           42)]
+      ;; Write initial data without faults
+      (dotimes [i 10]
+        (k/assoc store (keyword (str "key" i)) {:value i} {:sync? true})))
+
+    ;; Now operate with chaos - some operations will fail
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/chaos-fault-config
+                           43)
+          successes (atom 0)
+          failures (atom 0)]
+      (dotimes [i 20]
+        (try
+          (k/assoc store (keyword (str "chaos" i)) {:value i} {:sync? true})
+          (swap! successes inc)
+          (catch Exception _
+            (swap! failures inc))))
+
+      ;; Some should succeed, some should fail
+      (is (pos? @successes) "Some writes should succeed")
+      (is (pos? @failures) "Some writes should fail due to chaos"))
+
+    ;; Original data should still be intact
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           *test-dir*
+                           backing/no-faults-config
+                           44)]
+      (dotimes [i 10]
+        (is (= {:value i} (k/get store (keyword (str "key" i)) nil {:sync? true})))))))
+
+;; =============================================================================
+;; MemoryBackingStore Tests (Fast, no filesystem)
+;; =============================================================================
+
+(deftest memory-backing-basic-operations-test
+  (testing "MemoryBackingStore supports basic operations"
+    (let [backing (mb/create-memory-backing)
+          store (<!! (connect-default-store backing {:opts {:sync? false}}))]
+
+      ;; Write
+      (<!! (k/assoc store :key1 {:value 1}))
+      (<!! (k/assoc store :key2 {:value 2}))
+
+      ;; Read
+      (is (= {:value 1} (<!! (k/get store :key1))))
+      (is (= {:value 2} (<!! (k/get store :key2))))
+
+      ;; Exists
+      (is (true? (<!! (k/exists? store :key1))))
+      (is (false? (<!! (k/exists? store :nonexistent))))
+
+      ;; Delete
+      (<!! (k/dissoc store :key1))
+      (is (false? (<!! (k/exists? store :key1))))
+      (is (= {:value 2} (<!! (k/get store :key2)))))))
+
+(deftest memory-backing-sync-mode-test
+  (testing "MemoryBackingStore works in sync mode"
+    (let [backing (mb/create-memory-backing)
+          store (connect-default-store backing {:opts {:sync? true}})]
+
+      ;; Write
+      (k/assoc store :key1 {:value 1} {:sync? true})
+
+      ;; Read
+      (is (= {:value 1} (k/get store :key1 nil {:sync? true})))
+
+      ;; Exists
+      (is (true? (k/exists? store :key1 {:sync? true}))))))
+
+(deftest memory-backing-update-test
+  (testing "MemoryBackingStore supports update-in"
+    (let [backing (mb/create-memory-backing)
+          store (<!! (connect-default-store backing {:opts {:sync? false}}))]
+
+      (<!! (k/assoc store :counter 0))
+      (<!! (k/update store :counter inc))
+      (<!! (k/update store :counter inc))
+      (<!! (k/update store :counter inc))
+
+      (is (= 3 (<!! (k/get store :counter)))))))
+
+(deftest memory-backing-with-fault-injection-test
+  (testing "MemoryBackingStore + SimulatedBackingStore for fast fault testing"
+    (let [real-backing (mb/create-memory-backing)
+          rng (backing/rng 42)
+          history-atom (atom [])
+          simulated-backing (backing/wrap-backing-store
+                             real-backing
+                             backing/no-faults-config
+                             rng
+                             history-atom)
+          store (<!! (connect-default-store simulated-backing {:opts {:sync? false}}))]
+
+      ;; Operations work through simulated layer
+      (<!! (k/assoc store :key1 {:value 1}))
+      (is (= {:value 1} (<!! (k/get store :key1))))
+
+      ;; History is recorded
+      (let [history (backing/get-history simulated-backing)]
+        (is (pos? (count history)))
+        (is (some #(= :create-blob (:operation %)) history))))))
+
+(deftest memory-backing-fault-propagation-test
+  (testing "Faults propagate from MemoryBackingStore through DefaultStore"
+    (let [real-backing (mb/create-memory-backing)
+          rng (backing/rng 42)
+          simulated-backing (backing/wrap-backing-store
+                             real-backing
+                             (assoc backing/no-faults-config
+                                    :write-header-fault-rate 1.0)
+                             rng)
+          store (connect-default-store simulated-backing {:opts {:sync? true}})]
+
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Simulated write-header fault"
+           (k/assoc store :test-key {:value 1} {:sync? true}))))))
+
+(deftest memory-backing-keys-test
+  (testing "MemoryBackingStore keys operation works"
+    (let [backing (mb/create-memory-backing)
+          store (<!! (connect-default-store backing {:opts {:sync? false}}))]
+
+      ;; Write multiple keys
+      (<!! (k/assoc store :key1 {:value 1}))
+      (<!! (k/assoc store :key2 {:value 2}))
+      (<!! (k/assoc store :key3 {:value 3}))
+
+      ;; Keys should return all
+      (let [all-keys (<!! (k/keys store))]
+        (is (= 3 (count all-keys)))))))
+
+(comment
+  ;; Run tests
+  (clojure.test/run-tests 'konserve.simulation-backing-test)
+
+  ;; Run single test
+  (clojure.test/test-var #'error-propagation-write-header-test)
+  (clojure.test/test-var #'memory-backing-basic-operations-test))

--- a/test/konserve/simulation_backing_test.clj
+++ b/test/konserve/simulation_backing_test.clj
@@ -546,6 +546,110 @@
       (let [all-keys (<!! (k/keys store))]
         (is (= 3 (count all-keys)))))))
 
+;; =============================================================================
+;; Corruption Tests
+;; =============================================================================
+;;
+;; The three :*-corrupt-rate knobs flip bits in bytes returned by a read rather
+;; than throwing. The property that matters is not WHICH error surfaces but that
+;; corruption is never silently absorbed: a read returns exactly what was
+;; written, or it fails. Returning a different value would be the serious bug.
+
+(defn- read-under-corruption
+  "Write `{:value \"original\"}` cleanly, then read it back through a store that
+   corrupts `knob` on every read. Returns [:returned v] or [:threw class]."
+  [knob reader]
+  (let [dir *test-dir*]
+    (let [{:keys [store]} (create-sync-wrapped-store dir backing/no-faults-config 1)]
+      (k/assoc store :corrupt-key {:value "original"} {:sync? true}))
+    (let [{:keys [store]} (create-sync-wrapped-store
+                           dir (assoc backing/no-faults-config knob 1.0) 7)]
+      (try [:returned (reader store)]
+           (catch Throwable t [:threw (class t)])))))
+
+(deftest corruption-is-never-silently-absorbed-test
+  (testing "a corrupted value read fails rather than returning wrong data"
+    (let [[outcome v] (read-under-corruption
+                       :read-value-corrupt-rate
+                       #(k/get % :corrupt-key nil {:sync? true}))]
+      (is (or (= outcome :threw) (= v {:value "original"}))
+          (str "corrupted value read returned wrong data silently: " v))
+      ;; At rate 1.0 the corruption always fires, so it must be detected.
+      (is (= :threw outcome)
+          "value corruption at rate 1.0 should be detected, not absorbed")))
+
+  (testing "a corrupted header read fails rather than returning wrong data"
+    (let [[outcome v] (read-under-corruption
+                       :read-header-corrupt-rate
+                       #(k/get % :corrupt-key nil {:sync? true}))]
+      (is (or (= outcome :threw) (= v {:value "original"}))
+          (str "corrupted header read returned wrong data silently: " v))
+      (is (= :threw outcome)
+          "header corruption at rate 1.0 should be detected, not absorbed")))
+
+  (testing "a corrupted meta read fails rather than returning wrong metadata"
+    ;; k/get does not consult the meta bytes, so meta corruption is only
+    ;; observable through get-meta.
+    (let [[outcome _] (read-under-corruption
+                       :read-meta-corrupt-rate
+                       #(k/get-meta % :corrupt-key nil {:sync? true}))]
+      (is (= :threw outcome)
+          "meta corruption at rate 1.0 should be detected, not absorbed"))))
+
+;; =============================================================================
+;; Durability Under Faults
+;; =============================================================================
+
+(deftest acknowledged-writes-are-durable-under-chaos-test
+  (testing "every write that returned normally is readable afterwards, and
+            data written before the chaos survives it"
+    ;; The strongest property in this domain, and the one chaos-mode testing
+    ;; exists to check: konserve may FAIL a write under injected faults, but it
+    ;; must never acknowledge a write it then loses, and must never damage data
+    ;; it already holds. Swept across seeds because a single fault schedule
+    ;; exercises only one interleaving of failure points.
+    ;; 100 seeds ~= 3.5s. Seed count is the axis that finds new interleavings:
+    ;; each seed is a distinct fault schedule, whereas repeating one schedule
+    ;; re-runs the same failure points.
+    (let [n-seeds 100
+          n-ops 25
+          violations (atom [])]
+      (doseq [seed (range 1 (inc n-seeds))]
+        (let [dir (create-temp-dir)]
+          ;; Pre-existing data, written cleanly.
+          (let [{:keys [store]} (create-sync-wrapped-store dir backing/no-faults-config 1)]
+            (dotimes [i 5]
+              (k/assoc store (keyword (str "pre" i)) {:value i} {:sync? true})))
+          ;; Chaos phase: remember only the writes that were acknowledged.
+          (let [{:keys [store]} (create-sync-wrapped-store dir backing/chaos-fault-config seed)
+                acked (atom {})]
+            (dotimes [i n-ops]
+              (let [key (keyword (str "chaos" i))
+                    value {:value i :seed seed}]
+                (try
+                  (k/assoc store key value {:sync? true})
+                  (swap! acked assoc key value)
+                  (catch Throwable _ nil))))
+            ;; Verify through a fault-free store.
+            (let [{:keys [store]} (create-sync-wrapped-store dir backing/no-faults-config 2)
+                  read-safely (fn [key]
+                                (try (k/get store key nil {:sync? true})
+                                     (catch Throwable t {:threw (str t)})))]
+              (doseq [[key value] @acked]
+                (let [got (read-safely key)]
+                  (when-not (= value got)
+                    (swap! violations conj {:kind :acknowledged-write-lost
+                                            :seed seed :key key
+                                            :wrote value :read got}))))
+              (dotimes [i 5]
+                (let [got (read-safely (keyword (str "pre" i)))]
+                  (when-not (= {:value i} got)
+                    (swap! violations conj {:kind :pre-existing-data-damaged
+                                            :seed seed :index i :read got}))))))))
+      (is (empty? @violations)
+          (str "durability violated in " (count @violations) " case(s) across "
+               n-seeds " seeds: " (vec (take 5 @violations)))))))
+
 (comment
   ;; Run tests
   (clojure.test/run-tests 'konserve.simulation-backing-test)

--- a/test/konserve/simulation_crash_test.clj
+++ b/test/konserve/simulation_crash_test.clj
@@ -435,3 +435,101 @@
       (is (seq (crash/get-synced-data state-atom)))
       (is (empty? (crash/get-pending-data state-atom))
           "No pending data after successful sync"))))
+
+;; =============================================================================
+;; Crash Point x Value Shape Matrix
+;; =============================================================================
+;;
+;; The tests above each pin one crash point to one simple value. This sweeps
+;; every crash point across value shapes that exercise different write-path
+;; sizes and structures, in both of the two cases that matter: overwriting an
+;; existing key, and writing a key that does not exist yet.
+;;
+;; The invariant is the whole point of crash-consistency testing: after a crash
+;; and recovery a reader sees EXACTLY the old value or EXACTLY the new one --
+;; never a partial value, never a throw, and (when a prior value was durably
+;; synced) never nil.
+;;
+;; Deterministic by construction: crash points are chosen explicitly and this
+;; namespace injects no randomness, so a failure here reproduces exactly. It
+;; runs entirely in memory, which is why the whole matrix costs ~150ms.
+
+(def ^:private crash-matrix-shapes
+  "[old new] pairs spanning small/large, growing/shrinking, empty/populated,
+   flat/nested, and nil-valued writes."
+  (let [big (apply str (repeat 5000 \x))]
+    [[{:a 1}                        {:a 2}]
+     [{:s "short"}                  {:s big}]
+     [{:s big}                      {:s "short"}]
+     [{}                            {:now "non-empty"}]
+     [{:was "non-empty"}            {}]
+     [{:nested {:deep {:v [1 2 3]}}} {:nested {:deep {:v [4 5 6 7 8 9]}}}]
+     [{:v (vec (range 500))}        {:v (vec (range 3))}]
+     [{:v (vec (range 3))}          {:v (vec (range 500))}]
+     [{:unicode "ascii"}            {:unicode "ümläut ✓ 日本語"}]
+     [{:mixed [1 "two" :three {:four 4}]} {:mixed []}]
+     [{:value nil}                  {:value :now-set}]
+     [{:value :was-set}             {:value nil}]]))
+
+(defn- brief
+  "A short printable summary of a value, so failure messages stay readable even
+   when the shape is a 5 KB string or a 500-element vector."
+  [v]
+  (let [s (pr-str v)]
+    (if (<= (count s) 70) s (str (subs s 0 70) "... <" (count s) " chars>"))))
+
+(defn- crash-round
+  "Write `old` (unless ::absent) and let it sync. Then write `new`, crashing at
+   `crash-point`. Crash, recover, read. Returns nil when the invariant holds, or
+   a map describing the violation."
+  [crash-point old new]
+  (let [{:keys [store state-atom crash-point-atom]} (create-test-store)
+        prior? (not= old ::absent)]
+    (when prior?
+      (sync-assoc! store :k old))
+    (crash/set-crash-point! crash-point-atom crash-point)
+    (try
+      (sync-assoc! store :k new)
+      (catch ExceptionInfo _ nil))
+    (crash/simulate-crash! state-atom)
+    (crash/clear-crash-point! crash-point-atom)
+    (let [got (try (sync-get store :k)
+                   (catch Throwable t {::threw (str t)}))
+          acceptable (if prior? #{old new} #{nil new})]
+      (when-not (contains? acceptable got)
+        ;; Shapes include 5 KB strings and 500-element vectors; printing them in
+        ;; full makes a failure unreadable. Summarise instead.
+        {:crash-point crash-point
+         :prior (if prior? (brief old) ::absent)
+         :attempted (brief new)
+         :read (brief got)}))))
+
+(defn- violations-at
+  "Run every shape at `crash-point`. `prior` is :overwrite (write the old value
+   first) or :new-key (the key starts absent). Returns the violations."
+  [crash-point prior]
+  (vec (for [[old new] crash-matrix-shapes
+             :let [v (crash-round crash-point
+                                  (if (= prior :new-key) ::absent old)
+                                  new)]
+             :when v]
+         v)))
+
+(defn- report-violations [crash-point violations]
+  (is (empty? violations)
+      (str crash-point ": " (count violations) " of " (count crash-matrix-shapes)
+           " shapes violated the invariant -- " (vec (take 2 violations)))))
+
+(deftest crash-matrix-overwrite-test
+  (testing "every crash point x value shape, overwriting an existing key:
+            the reader sees exactly the old or the new value"
+    ;; One assertion per crash point, so a failure names the point directly
+    ;; rather than burying it in a list of twelve shapes.
+    (doseq [crash-point (sort crash/crash-points)]
+      (report-violations crash-point (violations-at crash-point :overwrite)))))
+
+(deftest crash-matrix-new-key-test
+  (testing "every crash point x value shape, writing a key that does not exist:
+            the reader sees exactly nil or the new value"
+    (doseq [crash-point (sort crash/crash-points)]
+      (report-violations crash-point (violations-at crash-point :new-key)))))

--- a/test/konserve/simulation_crash_test.clj
+++ b/test/konserve/simulation_crash_test.clj
@@ -1,0 +1,437 @@
+(ns konserve.simulation-crash-test
+  "Tests for CrashAwareBackingStore - verifying crash simulation with sync-point tracking.
+
+   Based on CrashMonkey research: Most crash bugs reproduce with 3 operations or fewer,
+   and 100% of reported bugs occurred after fsync-like calls."
+  (:require [clojure.test :refer :all]
+            [konserve.simulation.crash :as crash]
+            [konserve.impl.defaults :as defaults]
+            [konserve.impl.storage-layout :as sl]
+            [konserve.serializers :as ser]
+            [konserve.core :as k])
+  (:import [clojure.lang ExceptionInfo]))
+
+;; =============================================================================
+;; Test Fixtures and Helpers
+;; =============================================================================
+
+(defn create-test-store
+  "Create a DefaultStore backed by CrashAwareBackingStore for testing."
+  []
+  (let [{:keys [backing state-atom crash-point-atom history-atom]} (crash/create-crash-aware-store)
+        ;; Create the store directory
+        _ (sl/-create-store backing {:sync? true})
+        ;; Connect DefaultStore with sync mode for easier testing
+        ;; In sync mode, connect-default-store returns the store directly
+        store (defaults/connect-default-store
+               backing
+               {:opts {:sync? true}  ; Use sync mode
+                :config {:default-serializer :FressianSerializer
+                         :serializers {:FressianSerializer (ser/fressian-serializer)}}
+                :buffer-size 8192})]
+    {:store store
+     :backing backing
+     :state-atom state-atom
+     :crash-point-atom crash-point-atom
+     :history-atom history-atom}))
+
+(defn sync-assoc!
+  "Synchronously assoc a value."
+  [store key value]
+  (k/assoc store key value {:sync? true}))
+
+(defn sync-get
+  "Synchronously get a value."
+  [store key]
+  (k/get store key nil {:sync? true}))
+
+(defn sync-dissoc!
+  "Synchronously dissoc a key."
+  [store key]
+  (k/dissoc store key {:sync? true}))
+
+;; =============================================================================
+;; Basic Operation Tests (No Crashes)
+;; =============================================================================
+
+(deftest basic-operations-test
+  (testing "Basic operations work without crash injection"
+    (let [{:keys [store state-atom]} (create-test-store)]
+      ;; Write
+      (sync-assoc! store :test-key {:value 1})
+
+      ;; Read back
+      (is (= {:value 1} (sync-get store :test-key)))
+
+      ;; Verify data is in synced state
+      (is (seq (crash/get-synced-data state-atom))
+          "Data should be in synced state after successful write"))))
+
+(deftest multiple-writes-test
+  (testing "Multiple writes work correctly"
+    (let [{:keys [store]} (create-test-store)]
+      (sync-assoc! store :key1 {:a 1})
+      (sync-assoc! store :key2 {:b 2})
+      (sync-assoc! store :key3 {:c 3})
+
+      (is (= {:a 1} (sync-get store :key1)))
+      (is (= {:b 2} (sync-get store :key2)))
+      (is (= {:c 3} (sync-get store :key3))))))
+
+(deftest overwrite-test
+  (testing "Overwriting a key preserves new value"
+    (let [{:keys [store]} (create-test-store)]
+      (sync-assoc! store :key {:version 1})
+      (is (= {:version 1} (sync-get store :key)))
+
+      (sync-assoc! store :key {:version 2})
+      (is (= {:version 2} (sync-get store :key))))))
+
+;; =============================================================================
+;; Crash Point Tests
+;; =============================================================================
+
+(deftest crash-after-write-header-test
+  (testing "Crash after write-header leaves no partial data"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      ;; First write succeeds
+      (sync-assoc! store :key {:before-crash true})
+      (is (= {:before-crash true} (sync-get store :key)))
+
+      ;; Set crash point
+      (crash/set-crash-point! crash-point-atom :after-write-header)
+
+      ;; Attempt write - should crash
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Simulated crash at after-write-header"
+           (sync-assoc! store :key {:after-crash true})))
+
+      ;; Simulate the crash (discard pending data)
+      (crash/simulate-crash! state-atom)
+
+      ;; Original value should be preserved
+      (crash/clear-crash-point! crash-point-atom)
+      (is (= {:before-crash true} (sync-get store :key))
+          "Original value should be preserved after crash"))))
+
+(deftest crash-after-write-meta-test
+  (testing "Crash after write-meta leaves no partial data"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      (sync-assoc! store :key {:original true})
+
+      (crash/set-crash-point! crash-point-atom :after-write-meta)
+
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Simulated crash at after-write-meta"
+           (sync-assoc! store :key {:new-value true})))
+
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      (is (= {:original true} (sync-get store :key))))))
+
+(deftest crash-after-write-value-test
+  (testing "Crash after write-value (before sync) loses the write"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      (sync-assoc! store :key {:original true})
+
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Simulated crash at after-write-value"
+           (sync-assoc! store :key {:new-value true})))
+
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      (is (= {:original true} (sync-get store :key))
+          "Value written but not synced should be lost"))))
+
+(deftest crash-after-sync-test
+  (testing "Crash after sync (before atomic-move) loses the write"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      (sync-assoc! store :key {:original true})
+
+      (crash/set-crash-point! crash-point-atom :after-sync)
+
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Simulated crash at after-sync"
+           (sync-assoc! store :key {:new-value true})))
+
+      ;; At this point, .new file exists but original is unchanged
+      (is (seq (crash/get-pending-new-files state-atom))
+          "Pending .new file should exist")
+
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; After crash, .new file is discarded
+      (is (empty? (crash/get-pending-new-files state-atom))
+          "Pending .new file should be discarded after crash")
+
+      (is (= {:original true} (sync-get store :key))))))
+
+(deftest crash-after-atomic-move-test
+  (testing "Crash after atomic-move (before sync-store) - write may or may not survive"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      (sync-assoc! store :key {:original true})
+
+      (crash/set-crash-point! crash-point-atom :after-atomic-move)
+
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Simulated crash at after-atomic-move"
+           (sync-assoc! store :key {:new-value true})))
+
+      ;; After atomic-move but before sync-store, data may be visible
+      ;; but on real crash, it could be lost if filesystem doesn't persist directory entries
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; In our simulation, we revert pending moves
+      (is (= {:original true} (sync-get store :key))
+          "In strict crash model, pending moves are reverted"))))
+
+(deftest crash-after-sync-store-test
+  (testing "Crash after sync-store - write survives (fully durable)"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      (sync-assoc! store :key {:original true})
+
+      ;; Note: This crash happens after sync-store completes
+      ;; so the write IS durable, crash just prevents backup deletion
+      (crash/set-crash-point! crash-point-atom :after-sync-store)
+
+      ;; This should actually succeed since sync-store completed
+      ;; but then crash - the backup file just won't be deleted
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Simulated crash at after-sync-store"
+           (sync-assoc! store :key {:new-value true})))
+
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; After sync-store, the write is durable
+      ;; Note: Our crash simulation doesn't revert after sync-store
+      (is (= {:new-value true} (sync-get store :key))
+          "After sync-store, write is durable even if crash follows"))))
+
+;; =============================================================================
+;; Recovery Tests
+;; =============================================================================
+
+(deftest recovery-after-crash-test
+  (testing "Store can recover after crash simulation"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      ;; Write some initial data
+      (sync-assoc! store :key1 {:data 1})
+      (sync-assoc! store :key2 {:data 2})
+
+      ;; Crash during a write
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+      (try
+        (sync-assoc! store :key3 {:data 3})
+        (catch ExceptionInfo _))
+
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; Verify recovery
+      (is (= {:data 1} (sync-get store :key1)) "key1 should survive")
+      (is (= {:data 2} (sync-get store :key2)) "key2 should survive")
+      (is (nil? (sync-get store :key3)) "key3 should not exist (crash during write)"))))
+
+(deftest multiple-crash-recovery-test
+  (testing "Store survives multiple crashes"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      ;; First write
+      (sync-assoc! store :key {:version 1})
+
+      ;; First crash
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+      (try
+        (sync-assoc! store :key {:version 2})
+        (catch ExceptionInfo _))
+      (crash/simulate-crash! state-atom)
+
+      ;; Second write succeeds
+      (crash/clear-crash-point! crash-point-atom)
+      (sync-assoc! store :key {:version 3})
+
+      ;; Second crash
+      (crash/set-crash-point! crash-point-atom :after-write-meta)
+      (try
+        (sync-assoc! store :key {:version 4})
+        (catch ExceptionInfo _))
+      (crash/simulate-crash! state-atom)
+
+      ;; Verify final state
+      (crash/clear-crash-point! crash-point-atom)
+      (is (= {:version 3} (sync-get store :key))
+          "Should have version 3 (last successful write)"))))
+
+;; =============================================================================
+;; Invariant Verification Tests
+;; =============================================================================
+
+(deftest no-partial-data-invariant-test
+  (testing "No partial data is ever visible to reads"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      ;; Write a value
+      (sync-assoc! store :key {:complete-value "with lots of data"})
+
+      ;; Try crash at each point and verify no partial reads
+      (doseq [crash-point [:after-write-header
+                           :after-write-meta
+                           :after-write-value
+                           :after-sync]]
+        (crash/set-crash-point! crash-point-atom crash-point)
+        (try
+          (sync-assoc! store :key {:new-value "should not be visible"})
+          (catch ExceptionInfo _))
+
+        (crash/simulate-crash! state-atom)
+        (crash/clear-crash-point! crash-point-atom)
+
+        ;; Verify we get either old value or nil, never partial
+        (let [value (sync-get store :key)]
+          (is (or (= {:complete-value "with lots of data"} value)
+                  (nil? value))
+              (str "At crash point " crash-point ", got unexpected: " value)))))))
+
+(deftest atomicity-invariant-test
+  (testing "Writes are atomic - either fully applied or not at all"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      (sync-assoc! store :key {:before true})
+
+      (doseq [crash-point [:after-write-header
+                           :after-write-meta
+                           :after-write-value
+                           :after-sync
+                           :after-atomic-move]]
+        (let [before-state @state-atom]
+          (crash/set-crash-point! crash-point-atom crash-point)
+          (try
+            (sync-assoc! store :key {:after true :crash-point crash-point})
+            (catch ExceptionInfo _))
+
+          (crash/simulate-crash! state-atom)
+          (crash/clear-crash-point! crash-point-atom)
+
+          (let [after-state @state-atom]
+            ;; Synced data should either be unchanged or completely updated
+            (is (crash/verify-atomicity before-state after-state
+                                        (first (keys (:synced-blobs before-state))))
+                (str "Atomicity violated at " crash-point))))))))
+
+;; =============================================================================
+;; Concurrent Operations Tests
+;; =============================================================================
+
+(deftest concurrent-write-with-crash-test
+  (testing "Concurrent writes handle crash correctly"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      ;; Write two different keys
+      (sync-assoc! store :key1 {:data 1})
+
+      ;; Crash during second write
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+      (try
+        (sync-assoc! store :key2 {:data 2})
+        (catch ExceptionInfo _))
+
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; key1 survives, key2 doesn't
+      (is (= {:data 1} (sync-get store :key1)))
+      (is (nil? (sync-get store :key2))))))
+
+;; =============================================================================
+;; Edge Cases
+;; =============================================================================
+
+(deftest empty-value-crash-test
+  (testing "Crash during write of empty/nil value"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      (sync-assoc! store :key {:non-empty "value"})
+
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+      (try
+        (sync-assoc! store :key nil)
+        (catch ExceptionInfo _))
+
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; Original value preserved
+      (is (= {:non-empty "value"} (sync-get store :key))))))
+
+(deftest large-value-crash-test
+  (testing "Crash during write of large value"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)
+          large-value (vec (repeat 10000 "x"))]
+      (sync-assoc! store :key {:small "value"})
+
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+      (try
+        (sync-assoc! store :key {:large large-value})
+        (catch ExceptionInfo _))
+
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      (is (= {:small "value"} (sync-get store :key))))))
+
+(deftest new-key-crash-test
+  (testing "Crash during write of new key (not overwrite)"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+
+      (try
+        (sync-assoc! store :new-key {:data 1})
+        (catch ExceptionInfo _))
+
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; Key should not exist
+      (is (nil? (sync-get store :new-key))))))
+
+;; =============================================================================
+;; API Tests
+;; =============================================================================
+
+(deftest invalid-crash-point-test
+  (testing "Invalid crash point throws error"
+    (let [{:keys [crash-point-atom]} (crash/create-crash-aware-store)]
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Invalid crash point"
+           (crash/set-crash-point! crash-point-atom :invalid-point))))))
+
+(deftest crash-point-clearing-test
+  (testing "Clearing crash point allows normal operation"
+    (let [{:keys [store crash-point-atom]} (create-test-store)]
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; Should work normally
+      (sync-assoc! store :key {:value 1})
+      (is (= {:value 1} (sync-get store :key))))))
+
+(deftest state-inspection-test
+  (testing "State inspection APIs work correctly"
+    (let [{:keys [store state-atom]} (create-test-store)]
+      ;; Initial state
+      (is (empty? (crash/get-synced-data state-atom)))
+      (is (empty? (crash/get-pending-data state-atom)))
+
+      ;; After write
+      (sync-assoc! store :key {:value 1})
+      (is (seq (crash/get-synced-data state-atom)))
+      (is (empty? (crash/get-pending-data state-atom))
+          "No pending data after successful sync"))))

--- a/test/konserve/simulation_gc_test.clj
+++ b/test/konserve/simulation_gc_test.clj
@@ -1,0 +1,361 @@
+(ns konserve.simulation-gc-test
+  "Tests for konserve GC (garbage collection) with crash simulation.
+
+   Verifies that sweep! correctly handles:
+   - Whitelist preservation
+   - Timestamp-based filtering
+   - Crash recovery during sweep
+   - Concurrent operations during GC"
+  (:require [clojure.test :refer :all]
+            [konserve.simulation.crash :as crash]
+            [konserve.impl.defaults :as defaults]
+            [konserve.impl.storage-layout :as sl]
+            [konserve.serializers :as ser]
+            [konserve.core :as k]
+            [konserve.gc :as gc]
+            [clojure.core.async :as a])
+  (:import [java.util Date]))
+
+;; =============================================================================
+;; Test Fixtures and Helpers
+;; =============================================================================
+
+(defn create-test-store
+  "Create a DefaultStore backed by CrashAwareBackingStore for testing."
+  []
+  (let [{:keys [backing state-atom crash-point-atom history-atom]} (crash/create-crash-aware-store)
+        _ (sl/-create-store backing {:sync? true})
+        store (defaults/connect-default-store
+               backing
+               {:opts {:sync? true}
+                :config {:default-serializer :FressianSerializer
+                         :serializers {:FressianSerializer (ser/fressian-serializer)}}
+                :buffer-size 8192})]
+    {:store store
+     :backing backing
+     :state-atom state-atom
+     :crash-point-atom crash-point-atom
+     :history-atom history-atom}))
+
+(defn sync-assoc!
+  "Synchronously assoc a value."
+  [store key value]
+  (k/assoc store key value {:sync? true}))
+
+(defn sync-get
+  "Synchronously get a value."
+  [store key]
+  (k/get store key nil {:sync? true}))
+
+(defn sync-keys
+  "Synchronously get all keys."
+  [store]
+  (a/<!! (k/keys store)))
+
+(defn future-timestamp
+  "Return a timestamp in the future (1 hour from now).
+   Use this to DELETE keys - sweep deletes keys with last-write < ts."
+  []
+  (Date. (+ (System/currentTimeMillis) 3600000)))
+
+(defn past-timestamp
+  "Return a timestamp in the past (1 hour ago).
+   Use this to PRESERVE keys by timestamp - sweep keeps keys with last-write >= ts."
+  []
+  (Date. (- (System/currentTimeMillis) 3600000)))
+
+;; =============================================================================
+;; Basic GC Tests
+;; =============================================================================
+
+(deftest basic-sweep-test
+  (testing "sweep! deletes non-whitelisted keys"
+    (let [{:keys [store]} (create-test-store)]
+      ;; Create several keys
+      (sync-assoc! store :keep1 {:data 1})
+      (sync-assoc! store :keep2 {:data 2})
+      (sync-assoc! store :delete1 {:data 3})
+      (sync-assoc! store :delete2 {:data 4})
+
+      ;; Verify all exist
+      (is (= 4 (count (sync-keys store))))
+
+      ;; Sweep with whitelist - use future timestamp so all are eligible for deletion
+      (a/<!! (gc/sweep! store #{:keep1 :keep2} (future-timestamp)))
+
+      ;; Verify only whitelisted keys remain
+      (is (= #{:keep1 :keep2} (set (map :key (sync-keys store)))))
+      (is (= {:data 1} (sync-get store :keep1)))
+      (is (= {:data 2} (sync-get store :keep2)))
+      (is (nil? (sync-get store :delete1)))
+      (is (nil? (sync-get store :delete2))))))
+
+(deftest empty-whitelist-sweep-test
+  (testing "sweep! with empty whitelist deletes everything"
+    (let [{:keys [store]} (create-test-store)]
+      (sync-assoc! store :key1 {:data 1})
+      (sync-assoc! store :key2 {:data 2})
+      (sync-assoc! store :key3 {:data 3})
+
+      (a/<!! (gc/sweep! store #{} (future-timestamp)))
+
+      (is (empty? (sync-keys store))))))
+
+(deftest full-whitelist-sweep-test
+  (testing "sweep! with full whitelist deletes nothing"
+    (let [{:keys [store]} (create-test-store)]
+      (sync-assoc! store :key1 {:data 1})
+      (sync-assoc! store :key2 {:data 2})
+
+      (a/<!! (gc/sweep! store #{:key1 :key2} (future-timestamp)))
+
+      (is (= 2 (count (sync-keys store))))
+      (is (= {:data 1} (sync-get store :key1)))
+      (is (= {:data 2} (sync-get store :key2))))))
+
+;; =============================================================================
+;; Timestamp-based Filtering Tests
+;; =============================================================================
+
+(deftest timestamp-preserves-recent-writes-test
+  (testing "sweep! preserves keys written after timestamp"
+    (let [{:keys [store]} (create-test-store)]
+      ;; Create keys - all will have recent timestamps
+      (sync-assoc! store :key1 {:data 1})
+      (sync-assoc! store :key2 {:data 2})
+      (sync-assoc! store :key3 {:data 3})
+
+      ;; Sweep with past timestamp and empty whitelist
+      ;; Keys are preserved because last-write >= ts (all keys written now > past)
+      (a/<!! (gc/sweep! store #{} (past-timestamp)))
+
+      ;; All keys should still exist (written after the past timestamp)
+      (is (= 3 (count (sync-keys store)))))))
+
+(deftest timestamp-and-whitelist-combined-test
+  (testing "sweep! respects both timestamp and whitelist"
+    (let [{:keys [store]} (create-test-store)]
+      ;; Create keys
+      (sync-assoc! store :whitelist-key {:data 1})
+      (sync-assoc! store :not-whitelisted {:data 2})
+
+      ;; Sweep with future timestamp - makes all keys eligible for deletion
+      ;; Only whitelist-key is protected by whitelist
+      (a/<!! (gc/sweep! store #{:whitelist-key} (future-timestamp)))
+
+      ;; Only whitelisted key survives
+      (is (= 1 (count (sync-keys store))))
+      (is (= {:data 1} (sync-get store :whitelist-key)))
+      (is (nil? (sync-get store :not-whitelisted))))))
+
+;; =============================================================================
+;; Crash During GC Tests
+;; =============================================================================
+
+(deftest crash-during-sweep-delete-test
+  (testing "crash during sweep! delete leaves store consistent"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      ;; Create keys
+      (sync-assoc! store :keep {:data "keep"})
+      (sync-assoc! store :delete1 {:data "delete1"})
+      (sync-assoc! store :delete2 {:data "delete2"})
+      (sync-assoc! store :delete3 {:data "delete3"})
+
+      ;; Set crash point during delete operation
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+
+      ;; Attempt sweep - may crash during deletion
+      (try
+        (a/<!! (gc/sweep! store #{:keep} (future-timestamp)))
+        (catch Exception _))
+
+      ;; Simulate crash
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; Verify store is consistent
+      ;; :keep must exist, others may or may not depending on crash timing
+      (is (= {:data "keep"} (sync-get store :keep))
+          "Whitelisted key must survive crash during GC")
+
+      ;; All remaining keys should be readable (no corruption)
+      (doseq [{:keys [key]} (sync-keys store)]
+        (is (some? (sync-get store key))
+            (str "Key " key " should be readable after crash"))))))
+
+(deftest crash-recovery-gc-idempotent-test
+  (testing "GC can be re-run after crash without data loss"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      ;; Create keys
+      (sync-assoc! store :important1 {:critical "data1"})
+      (sync-assoc! store :important2 {:critical "data2"})
+      (sync-assoc! store :garbage {:trash true})
+
+      ;; First GC attempt crashes
+      (crash/set-crash-point! crash-point-atom :after-sync)
+      (try
+        (a/<!! (gc/sweep! store #{:important1 :important2} (future-timestamp)))
+        (catch Exception _))
+
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; Re-run GC after recovery
+      (a/<!! (gc/sweep! store #{:important1 :important2} (future-timestamp)))
+
+      ;; Important keys must survive
+      (is (= {:critical "data1"} (sync-get store :important1)))
+      (is (= {:critical "data2"} (sync-get store :important2)))
+      ;; Garbage should be gone (either from first partial GC or second complete GC)
+      (is (nil? (sync-get store :garbage))))))
+
+;; =============================================================================
+;; Concurrent Operations During GC Tests
+;; =============================================================================
+
+(deftest concurrent-write-during-gc-test
+  (testing "writes during GC are preserved"
+    (let [{:keys [store]} (create-test-store)
+          gc-started (promise)
+          gc-done (promise)]
+      ;; Create initial keys
+      (sync-assoc! store :existing {:data "existing"})
+      (sync-assoc! store :garbage {:data "garbage"})
+
+      ;; Start GC in background (will use batch-size 1 to slow it down)
+      (future
+        (deliver gc-started true)
+        (a/<!! (gc/sweep! store #{:existing :new-during-gc} (future-timestamp) 1))
+        (deliver gc-done true))
+
+      @gc-started
+
+      ;; Write new key during GC
+      (sync-assoc! store :new-during-gc {:data "new"})
+
+      @gc-done
+
+      ;; New key should survive (in whitelist)
+      (is (= {:data "new"} (sync-get store :new-during-gc)))
+      (is (= {:data "existing"} (sync-get store :existing)))
+      ;; Garbage may or may not be deleted depending on timing
+      )))
+
+(deftest gc-with-ongoing-reads-test
+  (testing "reads during GC return consistent data"
+    (let [{:keys [store]} (create-test-store)
+          read-results (atom [])
+          read-count 100]
+      ;; Create keys
+      (sync-assoc! store :stable {:data "stable"})
+      (sync-assoc! store :garbage {:data "garbage"})
+
+      ;; Start concurrent reads
+      (let [readers (doall
+                     (for [_ (range read-count)]
+                       (future
+                          ;; long: Thread/sleep has no (int) overload, and
+                          ;; konserve builds on Clojure 1.11 where this is a
+                          ;; reflective call.
+                         (Thread/sleep (long (rand-int 10)))
+                         (let [v (sync-get store :stable)]
+                           (swap! read-results conj v)
+                           v))))]
+
+        ;; Run GC while reads are happening
+        (a/<!! (gc/sweep! store #{:stable} (future-timestamp)))
+
+        ;; Wait for all reads
+        (doseq [r readers] @r))
+
+      ;; All reads should have gotten the correct value
+      (is (every? #(= {:data "stable"} %) @read-results)
+          "All concurrent reads should see consistent data"))))
+
+;; =============================================================================
+;; Edge Cases
+;; =============================================================================
+
+(deftest gc-empty-store-test
+  (testing "sweep! on empty store is safe"
+    (let [{:keys [store]} (create-test-store)]
+      (a/<!! (gc/sweep! store #{} (future-timestamp)))
+      (is (empty? (sync-keys store))))))
+
+(deftest gc-with-nested-data-test
+  (testing "sweep! correctly handles complex nested values"
+    (let [{:keys [store]} (create-test-store)]
+      (sync-assoc! store :complex {:nested {:deeply {:data [1 2 3]}}
+                                   :list [1 2 3 4 5]
+                                   :set #{:a :b :c}})
+      (sync-assoc! store :simple {:x 1})
+
+      (a/<!! (gc/sweep! store #{:complex} (future-timestamp)))
+
+      (is (= {:nested {:deeply {:data [1 2 3]}}
+              :list [1 2 3 4 5]
+              :set #{:a :b :c}}
+             (sync-get store :complex)))
+      (is (nil? (sync-get store :simple))))))
+
+(deftest gc-preserves-nil-values-test
+  (testing "sweep! preserves keys with nil values when whitelisted"
+    (let [{:keys [store]} (create-test-store)]
+      (sync-assoc! store :nil-val nil)
+      (sync-assoc! store :delete-me {:data 1})
+
+      (a/<!! (gc/sweep! store #{:nil-val} (future-timestamp)))
+
+      ;; nil-val key should exist (even though value is nil)
+      (is (contains? (set (map :key (sync-keys store))) :nil-val))
+      (is (nil? (sync-get store :delete-me))))))
+
+(deftest repeated-gc-cycles-test
+  (testing "multiple GC cycles work correctly"
+    (let [{:keys [store]} (create-test-store)]
+      ;; Cycle 1: Create and GC
+      (sync-assoc! store :persistent {:cycle 1})
+      (sync-assoc! store :temp1 {:temp true})
+      (a/<!! (gc/sweep! store #{:persistent} (future-timestamp)))
+
+      (is (= {:cycle 1} (sync-get store :persistent)))
+      (is (nil? (sync-get store :temp1)))
+
+      ;; Cycle 2: Add more and GC again
+      (sync-assoc! store :persistent {:cycle 2})  ; Update
+      (sync-assoc! store :temp2 {:temp true})
+      (a/<!! (gc/sweep! store #{:persistent} (future-timestamp)))
+
+      (is (= {:cycle 2} (sync-get store :persistent)))
+      (is (nil? (sync-get store :temp2)))
+
+      ;; Cycle 3: Final check
+      (sync-assoc! store :temp3 {:temp true})
+      (a/<!! (gc/sweep! store #{:persistent} (future-timestamp)))
+
+      (is (= 1 (count (sync-keys store))))
+      (is (= {:cycle 2} (sync-get store :persistent))))))
+
+;; =============================================================================
+;; Batch Size Tests
+;; =============================================================================
+
+(deftest gc-batch-size-test
+  (testing "sweep! with different batch sizes works correctly"
+    (doseq [batch-size [1 5 10 100]]
+      (let [{:keys [store]} (create-test-store)]
+        ;; Create 20 keys
+        (doseq [i (range 20)]
+          (sync-assoc! store (keyword (str "key" i)) {:index i}))
+
+        ;; Keep only even-numbered keys
+        (let [whitelist (set (for [i (range 0 20 2)]
+                               (keyword (str "key" i))))]
+          (a/<!! (gc/sweep! store whitelist (future-timestamp) batch-size))
+
+          ;; Verify only even keys remain
+          (is (= 10 (count (sync-keys store)))
+              (str "With batch-size " batch-size ", should have 10 keys"))
+          (doseq [i (range 0 20 2)]
+            (is (= {:index i} (sync-get store (keyword (str "key" i))))
+                (str "Key" i " should exist"))))))))

--- a/test/konserve/simulation_stress_test.clj
+++ b/test/konserve/simulation_stress_test.clj
@@ -585,16 +585,15 @@
 
         (.await latch 30 TimeUnit/SECONDS)
 
-        ;; With proper locking, should be exact
-        ;; Without, we might lose some updates - test documents actual behavior
+        ;; konserve serialises update-in on a per-key lock, so every increment
+        ;; must land. This is asserted exactly, not merely reported: a weaker
+        ;; check (final-value is positive) passes even when most updates are
+        ;; lost, and would not catch a regression in the locking path.
         (let [final-value (:value (sync-get store :shared-counter))
               expected (* n-threads n-updates)]
-          (is (pos? final-value) "Should have some updates")
-          ;; Document whether we get exact count or not
-          (when (< final-value expected)
-            (println (format "Note: Lost %d updates out of %d (%.1f%%)"
-                             (- expected final-value) expected
-                             (* 100.0 (/ (- expected final-value) expected))))))
+          (is (= expected final-value)
+              (format "lost %d of %d updates -- per-key locking did not hold"
+                      (- expected final-value) expected)))
 
         (finally
           (.shutdown executor))))))

--- a/test/konserve/simulation_stress_test.clj
+++ b/test/konserve/simulation_stress_test.clj
@@ -1,0 +1,928 @@
+(ns konserve.simulation-stress-test
+  "Stress tests for konserve backing stores.
+
+   Covers:
+   - Resource exhaustion (storage limits, key limits)
+   - Concurrent access (parallel writes, read/write contention)
+   - Long-running stability (many operations over time)
+   - Error recovery under load"
+  (:require [clojure.test :refer :all]
+            [konserve.simulation.crash :as crash]
+            [konserve.impl.defaults :as defaults]
+            [konserve.impl.storage-layout :as sl]
+            [konserve.serializers :as ser]
+            [konserve.core :as k])
+  (:import [clojure.lang ExceptionInfo]
+           [java.util.concurrent CountDownLatch Executors TimeUnit]))
+
+;; =============================================================================
+;; Test Fixtures and Helpers
+;; =============================================================================
+
+(defn create-test-store
+  "Create a DefaultStore backed by CrashAwareBackingStore."
+  ([] (create-test-store {}))
+  ([opts]
+   (let [{:keys [backing state-atom crash-point-atom history-atom]}
+         (crash/create-crash-aware-store opts)
+         _ (sl/-create-store backing {:sync? true})
+         store (defaults/connect-default-store
+                backing
+                {:opts {:sync? true}
+                 :config {:default-serializer :FressianSerializer
+                          :serializers {:FressianSerializer (ser/fressian-serializer)}}
+                 :buffer-size 8192})]
+     {:store store
+      :backing backing
+      :state-atom state-atom
+      :crash-point-atom crash-point-atom
+      :history-atom history-atom})))
+
+(defn sync-assoc!
+  [store key value]
+  (k/assoc store key value {:sync? true}))
+
+(defn sync-get
+  [store key]
+  (k/get store key nil {:sync? true}))
+
+(defn sync-dissoc!
+  [store key]
+  (k/dissoc store key {:sync? true}))
+
+;; =============================================================================
+;; Resource Exhaustion Tests
+;; =============================================================================
+
+(deftest storage-limit-test
+  (testing "Storage limit is enforced"
+    (let [{:keys [store state-atom]} (create-test-store {:max-total-bytes 1000})]
+      ;; First write should succeed
+      (sync-assoc! store :key1 {:small "value"})
+      (is (= {:small "value"} (sync-get store :key1)))
+
+      ;; Large write should fail
+      (let [large-value (vec (repeat 2000 "x"))]
+        (is (thrown-with-msg?
+             ExceptionInfo
+             #"Storage limit exceeded"
+             (sync-assoc! store :key2 {:large large-value}))))
+
+      ;; Original data intact
+      (is (= {:small "value"} (sync-get store :key1))))))
+
+(deftest key-limit-test
+  (testing "Key limit is enforced"
+    (let [{:keys [store]} (create-test-store {:max-keys 3})]
+      ;; First 3 keys succeed
+      (sync-assoc! store :key1 {:v 1})
+      (sync-assoc! store :key2 {:v 2})
+      (sync-assoc! store :key3 {:v 3})
+
+      ;; 4th key fails
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Key limit exceeded"
+           (sync-assoc! store :key4 {:v 4})))
+
+      ;; Can still update existing keys
+      (sync-assoc! store :key1 {:v 100})
+      (is (= {:v 100} (sync-get store :key1))))))
+
+(deftest storage-reclaim-test
+  (testing "Deleting keys frees storage"
+    (let [{:keys [store state-atom]} (create-test-store {:max-total-bytes 500})]
+      ;; Fill up storage
+      (sync-assoc! store :key1 {:data (vec (repeat 100 "x"))})
+
+      ;; This should fail (would exceed limit)
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"Storage limit exceeded"
+           (sync-assoc! store :key2 {:data (vec (repeat 100 "y"))})))
+
+      ;; Delete first key
+      (sync-dissoc! store :key1)
+
+      ;; Now second write should succeed
+      (sync-assoc! store :key2 {:data (vec (repeat 100 "y"))})
+      (is (some? (sync-get store :key2))))))
+
+(deftest update-within-limits-test
+  (testing "Updating existing key stays within limits"
+    (let [{:keys [store]} (create-test-store {:max-total-bytes 500})]
+      ;; Write a value
+      (sync-assoc! store :key {:data (vec (repeat 50 "x"))})
+
+      ;; Update to larger value should consider net change
+      (sync-assoc! store :key {:data (vec (repeat 60 "y"))})
+      (is (some? (sync-get store :key))))))
+
+;; =============================================================================
+;; Concurrent Access Tests
+;; =============================================================================
+
+(deftest concurrent-writes-same-key-test
+  (testing "Concurrent writes to same key serialize correctly"
+    (let [{:keys [store]} (create-test-store)
+          n-threads 10
+          n-writes 50
+          latch (CountDownLatch. n-threads)
+          results (atom [])
+          executor (Executors/newFixedThreadPool n-threads)]
+      (try
+        ;; Launch concurrent writers
+        (dotimes [t n-threads]
+          (.submit executor
+                   ^Runnable
+                   (fn []
+                     (try
+                       (dotimes [i n-writes]
+                         (sync-assoc! store :shared-key {:thread t :iteration i}))
+                       (catch Exception e
+                         (swap! results conj {:error (.getMessage e)}))
+                       (finally
+                         (.countDown latch))))))
+
+        (.await latch 30 TimeUnit/SECONDS)
+
+        ;; Verify final value is from one of the threads
+        (let [final-value (sync-get store :shared-key)]
+          (is (some? final-value))
+          (is (contains? (set (range n-threads)) (:thread final-value))))
+
+        (finally
+          (.shutdown executor))))))
+
+(deftest concurrent-writes-different-keys-test
+  (testing "Concurrent writes to different keys all succeed"
+    (let [{:keys [store]} (create-test-store)
+          n-threads 10
+          latch (CountDownLatch. n-threads)
+          executor (Executors/newFixedThreadPool n-threads)]
+      (try
+        ;; Each thread writes to its own key
+        (dotimes [t n-threads]
+          (.submit executor
+                   ^Runnable
+                   (fn []
+                     (try
+                       (sync-assoc! store (keyword (str "key-" t)) {:thread t})
+                       (finally
+                         (.countDown latch))))))
+
+        (.await latch 30 TimeUnit/SECONDS)
+
+        ;; Verify all keys exist
+        (dotimes [t n-threads]
+          (is (= {:thread t} (sync-get store (keyword (str "key-" t))))
+              (str "Key for thread " t " should exist")))
+
+        (finally
+          (.shutdown executor))))))
+
+(deftest read-write-contention-test
+  (testing "Reads during writes return consistent data"
+    (let [{:keys [store]} (create-test-store)
+          _ (sync-assoc! store :key {:version 0})
+          n-readers 5
+          n-writers 3
+          n-ops 20
+          latch (CountDownLatch. (+ n-readers n-writers))
+          read-results (atom [])
+          executor (Executors/newFixedThreadPool (+ n-readers n-writers))]
+      (try
+        ;; Launch writers
+        (dotimes [w n-writers]
+          (.submit executor
+                   ^Runnable
+                   (fn []
+                     (try
+                       (dotimes [i n-ops]
+                         (sync-assoc! store :key {:version (+ (* w 1000) i)}))
+                       (finally
+                         (.countDown latch))))))
+
+        ;; Launch readers
+        (dotimes [_r n-readers]
+          (.submit executor
+                   ^Runnable
+                   (fn []
+                     (try
+                       (dotimes [_ n-ops]
+                         (when-let [v (sync-get store :key)]
+                           (swap! read-results conj v)))
+                       (finally
+                         (.countDown latch))))))
+
+        (.await latch 30 TimeUnit/SECONDS)
+
+        ;; All reads should have valid version structure
+        (doseq [result @read-results]
+          (is (contains? result :version)
+              "Every read should return a map with :version"))
+
+        (finally
+          (.shutdown executor))))))
+
+;; =============================================================================
+;; Long-Running Stability Tests
+;; =============================================================================
+
+(deftest many-operations-stability-test
+  (testing "Store remains stable after many operations"
+    (let [{:keys [store state-atom]} (create-test-store)
+          n-keys 50
+          n-iterations 20]
+      ;; Perform many write/read/delete cycles
+      (dotimes [iter n-iterations]
+        (dotimes [k n-keys]
+          (let [key (keyword (str "key-" k))]
+            ;; Write
+            (sync-assoc! store key {:iteration iter :key k})
+            ;; Read back
+            (is (= {:iteration iter :key k} (sync-get store key))))))
+
+      ;; Verify final state
+      (dotimes [k n-keys]
+        (is (= {:iteration (dec n-iterations) :key k}
+               (sync-get store (keyword (str "key-" k)))))))))
+
+(deftest write-delete-cycle-test
+  (testing "Write/delete cycles don't leak state"
+    (let [{:keys [store state-atom]} (create-test-store)
+          n-cycles 100]
+      (dotimes [i n-cycles]
+        (sync-assoc! store :ephemeral {:cycle i})
+        (is (= {:cycle i} (sync-get store :ephemeral)))
+        (sync-dissoc! store :ephemeral)
+        (is (nil? (sync-get store :ephemeral))))
+
+      ;; Verify no keys remain
+      (is (empty? (crash/get-synced-data state-atom))))))
+
+(deftest growing-values-test
+  (testing "Store handles growing value sizes"
+    (let [{:keys [store]} (create-test-store)]
+      (doseq [size [10 100 1000 5000]]
+        (let [value (vec (repeat size "x"))]
+          (sync-assoc! store :growing {:size size :data value})
+          (let [result (sync-get store :growing)]
+            (is (= size (:size result)))
+            (is (= size (count (:data result))))))))))
+
+;; =============================================================================
+;; Error Recovery Under Load
+;; =============================================================================
+
+(deftest crash-during-concurrent-writes-test
+  (testing "Crash during concurrent writes recovers correctly"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)
+          _ (sync-assoc! store :stable {:value "original"})
+          n-threads 5
+          latch (CountDownLatch. n-threads)
+          executor (Executors/newFixedThreadPool n-threads)]
+      (try
+        ;; Set crash point for some writes
+        (crash/set-crash-point! crash-point-atom :after-write-value)
+
+        ;; Launch concurrent writers (they will all crash)
+        (dotimes [t n-threads]
+          (.submit executor
+                   ^Runnable
+                   (fn []
+                     (try
+                       (sync-assoc! store :stable {:value (str "thread-" t)})
+                       (catch Exception _))
+                     (.countDown latch))))
+
+        (.await latch 10 TimeUnit/SECONDS)
+
+        ;; Simulate crash recovery
+        (crash/simulate-crash! state-atom)
+        (crash/clear-crash-point! crash-point-atom)
+
+        ;; Original value should be preserved
+        (is (= {:value "original"} (sync-get store :stable)))
+
+        (finally
+          (.shutdown executor))))))
+
+(deftest resource-exhaustion-recovery-test
+  (testing "Store recovers after resource exhaustion errors"
+    (let [{:keys [store state-atom]} (create-test-store {:max-keys 5})]
+      ;; Fill up to limit
+      (dotimes [i 5]
+        (sync-assoc! store (keyword (str "key-" i)) {:v i}))
+
+      ;; Try to exceed - should fail
+      (is (thrown? ExceptionInfo
+                   (sync-assoc! store :extra {:v 99})))
+
+      ;; Delete one and try again - should succeed
+      (sync-dissoc! store :key-0)
+      (sync-assoc! store :new-key {:v 100})
+      (is (= {:v 100} (sync-get store :new-key))))))
+
+;; =============================================================================
+;; Mixed Operation Stress Test
+;; =============================================================================
+
+(deftest mixed-operations-stress-test
+  (testing "Mixed concurrent operations maintain consistency"
+    (let [{:keys [store]} (create-test-store)
+          n-threads 8
+          n-ops 50
+          latch (CountDownLatch. n-threads)
+          errors (atom [])
+          executor (Executors/newFixedThreadPool n-threads)]
+      (try
+        ;; Initialize some keys
+        (dotimes [i 10]
+          (sync-assoc! store (keyword (str "init-" i)) {:v i}))
+
+        ;; Launch mixed operation threads
+        (dotimes [t n-threads]
+          (.submit executor
+                   ^Runnable
+                   (fn []
+                     (try
+                       (dotimes [i n-ops]
+                         (let [op (rand-nth [:read :write :delete])
+                               key (keyword (str "key-" (rand-int 20)))]
+                           (case op
+                             :read (sync-get store key)
+                             :write (sync-assoc! store key {:thread t :op i})
+                             :delete (sync-dissoc! store key))))
+                       (catch Exception e
+                         (swap! errors conj {:thread t :error (.getMessage e)}))
+                       (finally
+                         (.countDown latch))))))
+
+        (.await latch 60 TimeUnit/SECONDS)
+
+        ;; No unexpected errors
+        (is (empty? @errors)
+            (str "Unexpected errors: " @errors))
+
+        (finally
+          (.shutdown executor))))))
+
+;; =============================================================================
+;; Binary Blob Handling Tests
+;; =============================================================================
+
+(deftest binary-blob-basic-test
+  (testing "Binary blobs round-trip correctly"
+    (let [{:keys [store]} (create-test-store)]
+      ;; Write binary data
+      (let [data (byte-array [0 1 2 3 4 5 127 -128 -1])]
+        (k/bassoc store :binary data {:sync? true})
+        ;; Read back via bget
+        (let [result (k/bget store :binary
+                             (fn [{:keys [input-stream]}]
+                               (let [baos (java.io.ByteArrayOutputStream.)]
+                                 (loop []
+                                   (let [b (.read input-stream)]
+                                     (when (>= b 0)
+                                       (.write baos b)
+                                       (recur))))
+                                 (.toByteArray baos)))
+                             {:sync? true})]
+          (is (= (seq data) (seq result))))))))
+
+(deftest binary-blob-large-test
+  (testing "Large binary blobs work correctly"
+    (let [{:keys [store]} (create-test-store)]
+      (doseq [size [1000 10000 100000]]
+        (let [data (byte-array (repeatedly size #(unchecked-byte (rand-int 256))))]
+          (k/bassoc store :large-binary data {:sync? true})
+          (let [result (k/bget store :large-binary
+                               (fn [{:keys [input-stream]}]
+                                 (let [baos (java.io.ByteArrayOutputStream.)
+                                       buf (byte-array 8192)]
+                                   (loop []
+                                     (let [n (.read input-stream buf)]
+                                       (when (pos? n)
+                                         (.write baos buf 0 n)
+                                         (recur))))
+                                   (.toByteArray baos)))
+                               {:sync? true})]
+            (is (= size (count result)))
+            (is (= (seq data) (seq result)))))))))
+
+(deftest binary-blob-overwrite-test
+  (testing "Binary blob overwrites work correctly"
+    (let [{:keys [store]} (create-test-store)]
+      ;; Write initial
+      (k/bassoc store :overwrite (byte-array [1 2 3]) {:sync? true})
+      ;; Overwrite with different size
+      (k/bassoc store :overwrite (byte-array [4 5 6 7 8]) {:sync? true})
+      ;; Verify new data
+      (let [result (k/bget store :overwrite
+                           (fn [{:keys [input-stream]}]
+                             (let [baos (java.io.ByteArrayOutputStream.)]
+                               (loop []
+                                 (let [b (.read input-stream)]
+                                   (when (>= b 0)
+                                     (.write baos b)
+                                     (recur))))
+                               (.toByteArray baos)))
+                           {:sync? true})]
+        (is (= [4 5 6 7 8] (vec result)))))))
+
+(deftest binary-and-edn-mixed-test
+  (testing "Binary and EDN data coexist"
+    (let [{:keys [store]} (create-test-store)]
+      ;; Write both types
+      (sync-assoc! store :edn-key {:type "edn" :value 42})
+      (k/bassoc store :binary-key (byte-array [1 2 3]) {:sync? true})
+
+      ;; Verify both readable
+      (is (= {:type "edn" :value 42} (sync-get store :edn-key)))
+      (let [result (k/bget store :binary-key
+                           (fn [{:keys [input-stream]}]
+                             (let [baos (java.io.ByteArrayOutputStream.)]
+                               (loop []
+                                 (let [b (.read input-stream)]
+                                   (when (>= b 0)
+                                     (.write baos b)
+                                     (recur))))
+                               (.toByteArray baos)))
+                           {:sync? true})]
+        (is (= [1 2 3] (vec result)))))))
+
+;; =============================================================================
+;; Rapid Key Reuse Tests
+;; =============================================================================
+
+(deftest rapid-key-reuse-test
+  (testing "Rapid delete/recreate cycles work correctly"
+    (let [{:keys [store]} (create-test-store)
+          n-cycles 200]
+      (dotimes [i n-cycles]
+        ;; Create
+        (sync-assoc! store :rapid {:cycle i})
+        (is (= {:cycle i} (sync-get store :rapid))
+            (str "Read after create failed at cycle " i))
+        ;; Delete
+        (sync-dissoc! store :rapid)
+        (is (nil? (sync-get store :rapid))
+            (str "Read after delete failed at cycle " i))))))
+
+(deftest rapid-key-reuse-different-values-test
+  (testing "Rapid reuse with different value types"
+    (let [{:keys [store]} (create-test-store)]
+      (dotimes [i 50]
+        ;; Alternate between different value types
+        (let [value (case (mod i 4)
+                      0 {:map "value" :i i}
+                      1 ["vector" i]
+                      2 (str "string-" i)
+                      3 i)]
+          (sync-assoc! store :polymorphic value)
+          (is (= value (sync-get store :polymorphic)))
+          (sync-dissoc! store :polymorphic)
+          (is (nil? (sync-get store :polymorphic))))))))
+
+(deftest rapid-key-reuse-concurrent-test
+  (testing "Concurrent rapid key reuse"
+    (let [{:keys [store]} (create-test-store)
+          n-threads 4
+          n-cycles 50
+          latch (CountDownLatch. n-threads)
+          errors (atom [])
+          executor (Executors/newFixedThreadPool n-threads)]
+      (try
+        ;; Each thread rapidly creates/deletes its own key
+        (dotimes [t n-threads]
+          (.submit executor
+                   ^Runnable
+                   (fn []
+                     (try
+                       (let [key (keyword (str "thread-" t "-key"))]
+                         (dotimes [i n-cycles]
+                           (sync-assoc! store key {:thread t :cycle i})
+                           (let [v (sync-get store key)]
+                             (when (not= t (:thread v))
+                               (swap! errors conj {:thread t :cycle i :found v})))
+                           (sync-dissoc! store key)))
+                       (catch Exception e
+                         (swap! errors conj {:thread t :error (.getMessage e)}))
+                       (finally
+                         (.countDown latch))))))
+
+        (.await latch 30 TimeUnit/SECONDS)
+
+        (is (empty? @errors)
+            (str "Errors during concurrent rapid reuse: " @errors))
+
+        (finally
+          (.shutdown executor))))))
+
+(deftest rapid-key-reuse-with-binary-test
+  (testing "Rapid delete/recreate with binary data"
+    (let [{:keys [store]} (create-test-store)]
+      (dotimes [i 100]
+        ;; Create binary
+        (let [data (byte-array (repeatedly 100 #(unchecked-byte i)))]
+          (k/bassoc store :rapid-binary data {:sync? true})
+          ;; Verify
+          (let [result (k/bget store :rapid-binary
+                               (fn [{:keys [input-stream]}]
+                                 (.read input-stream))
+                               {:sync? true})]
+            (is (= (unchecked-byte i) (unchecked-byte result))))
+          ;; Delete
+          (sync-dissoc! store :rapid-binary)
+          (is (nil? (k/bget store :rapid-binary identity {:sync? true}))))))))
+
+;; =============================================================================
+;; Update-In Atomicity Tests
+;; =============================================================================
+
+(deftest update-in-basic-test
+  (testing "update-in correctly modifies nested values"
+    (let [{:keys [store]} (create-test-store)]
+      (sync-assoc! store :counter {:count 0 :name "test"})
+
+      (k/update-in store [:counter :count] inc {:sync? true})
+      (is (= {:count 1 :name "test"} (sync-get store :counter)))
+
+      (k/update-in store [:counter :count] #(+ % 10) {:sync? true})
+      (is (= {:count 11 :name "test"} (sync-get store :counter))))))
+
+(deftest update-in-sequential-test
+  (testing "Sequential update-in operations accumulate correctly"
+    (let [{:keys [store]} (create-test-store)
+          n-updates 100]
+      (sync-assoc! store :counter {:value 0})
+
+      (dotimes [_ n-updates]
+        (k/update-in store [:counter :value] inc {:sync? true}))
+
+      (is (= {:value n-updates} (sync-get store :counter))))))
+
+(deftest update-in-concurrent-test
+  (testing "Concurrent update-in operations - checking for lost updates"
+    (let [{:keys [store]} (create-test-store)
+          n-threads 5
+          n-updates 20
+          latch (CountDownLatch. n-threads)
+          executor (Executors/newFixedThreadPool n-threads)]
+      (try
+        (sync-assoc! store :shared-counter {:value 0})
+
+        (dotimes [_ n-threads]
+          (.submit executor
+                   ^Runnable
+                   (fn []
+                     (try
+                       (dotimes [_ n-updates]
+                         (k/update-in store [:shared-counter :value] inc {:sync? true}))
+                       (finally
+                         (.countDown latch))))))
+
+        (.await latch 30 TimeUnit/SECONDS)
+
+        ;; With proper locking, should be exact
+        ;; Without, we might lose some updates - test documents actual behavior
+        (let [final-value (:value (sync-get store :shared-counter))
+              expected (* n-threads n-updates)]
+          (is (pos? final-value) "Should have some updates")
+          ;; Document whether we get exact count or not
+          (when (< final-value expected)
+            (println (format "Note: Lost %d updates out of %d (%.1f%%)"
+                             (- expected final-value) expected
+                             (* 100.0 (/ (- expected final-value) expected))))))
+
+        (finally
+          (.shutdown executor))))))
+
+(deftest update-in-with-crash-test
+  (testing "Crash during update-in preserves atomicity"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      (sync-assoc! store :counter {:value 10})
+
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+
+      (is (thrown? ExceptionInfo
+                   (k/update-in store [:counter :value] inc {:sync? true})))
+
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; Original value preserved
+      (is (= {:value 10} (sync-get store :counter))))))
+
+;; =============================================================================
+;; Store Close/Reopen Tests
+;; =============================================================================
+
+(deftest store-reopen-preserves-data-test
+  (testing "Data survives store close and reopen"
+    (let [;; Create first store instance
+          {:keys [backing state-atom]} (crash/create-crash-aware-store)
+          _ (konserve.impl.storage-layout/-create-store backing {:sync? true})
+          store1 (defaults/connect-default-store
+                  backing
+                  {:opts {:sync? true}
+                   :config {:default-serializer :FressianSerializer
+                            :serializers {:FressianSerializer (ser/fressian-serializer)}}
+                   :buffer-size 8192})]
+
+      ;; Write data
+      (k/assoc store1 :persistent {:value "survives"} {:sync? true})
+      (k/assoc store1 :also-persistent {:count 42} {:sync? true})
+
+      ;; Create second store instance on same state
+      (let [store2 (defaults/connect-default-store
+                    backing
+                    {:opts {:sync? true}
+                     :config {:default-serializer :FressianSerializer
+                              :serializers {:FressianSerializer (ser/fressian-serializer)}}
+                     :buffer-size 8192})]
+
+        ;; Verify data visible in second instance
+        (is (= {:value "survives"} (k/get store2 :persistent nil {:sync? true})))
+        (is (= {:count 42} (k/get store2 :also-persistent nil {:sync? true})))))))
+
+(deftest store-reopen-after-crash-test
+  (testing "Store reopens correctly after crash during write"
+    (let [{:keys [backing state-atom crash-point-atom]} (crash/create-crash-aware-store)
+          _ (konserve.impl.storage-layout/-create-store backing {:sync? true})
+          store1 (defaults/connect-default-store
+                  backing
+                  {:opts {:sync? true}
+                   :config {:default-serializer :FressianSerializer
+                            :serializers {:FressianSerializer (ser/fressian-serializer)}}
+                   :buffer-size 8192})]
+
+      ;; Write some data
+      (k/assoc store1 :before-crash {:safe true} {:sync? true})
+
+      ;; Crash during another write
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+      (try
+        (k/assoc store1 :during-crash {:unsafe true} {:sync? true})
+        (catch ExceptionInfo _))
+
+      ;; Simulate crash
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; Reopen store
+      (let [store2 (defaults/connect-default-store
+                    backing
+                    {:opts {:sync? true}
+                     :config {:default-serializer :FressianSerializer
+                              :serializers {:FressianSerializer (ser/fressian-serializer)}}
+                     :buffer-size 8192})]
+
+        ;; Safe data survives, unsafe data doesn't
+        (is (= {:safe true} (k/get store2 :before-crash nil {:sync? true})))
+        (is (nil? (k/get store2 :during-crash nil {:sync? true})))))))
+
+;; =============================================================================
+;; Keys Enumeration Under Modification Tests
+;; =============================================================================
+
+(deftest keys-enumeration-basic-test
+  (testing "keys returns all stored keys"
+    (let [{:keys [store]} (create-test-store)]
+      (sync-assoc! store :key1 {:v 1})
+      (sync-assoc! store :key2 {:v 2})
+      (sync-assoc! store :key3 {:v 3})
+
+      (let [ks (k/keys store {:sync? true})]
+        (is (= 3 (count ks)))))))
+
+(deftest keys-enumeration-during-writes-test
+  (testing "keys enumeration while concurrent writes happen"
+    (let [{:keys [store]} (create-test-store)
+          writer-running (java.util.concurrent.atomic.AtomicBoolean. true)
+          latch (CountDownLatch. 1)
+          executor (Executors/newFixedThreadPool 2)
+          keys-results (atom [])
+          errors (atom [])]
+      (try
+        ;; Writer thread continuously adds/removes keys
+        (.submit executor
+                 ^Runnable
+                 (fn []
+                   (try
+                     (loop [i 0]
+                       (when (.get writer-running)
+                         (let [key (keyword (str "key-" (mod i 30)))]
+                           (if (even? i)
+                             (sync-assoc! store key {:i i})
+                             (sync-dissoc! store key)))
+                         (recur (inc i))))
+                     (finally
+                       (.countDown latch)))))
+
+        ;; Reader thread enumerates keys repeatedly
+        (dotimes [_ 50]
+          (try
+            (let [ks (k/keys store {:sync? true})]
+              (swap! keys-results conj (count ks))
+              ;; Should always return a valid set
+              (when-not (set? ks)
+                (swap! errors conj "keys did not return a set")))
+            (catch Exception e
+              (swap! errors conj (.getMessage e)))))
+
+        (.set writer-running false)
+        (.await latch 5 TimeUnit/SECONDS)
+
+        ;; Main invariant: keys should never error during concurrent modification
+        (is (empty? @errors) (str "Errors during concurrent keys enumeration: " @errors))
+        ;; We should have gotten some results
+        (is (pos? (count @keys-results)) "Should have enumerated keys multiple times")
+
+        (finally
+          (.shutdown executor))))))
+
+(deftest keys-after-delete-test
+  (testing "keys correctly reflects deletions"
+    (let [{:keys [store]} (create-test-store)]
+      (sync-assoc! store :key1 {:v 1})
+      (sync-assoc! store :key2 {:v 2})
+      (sync-assoc! store :key3 {:v 3})
+
+      (is (= 3 (count (k/keys store {:sync? true}))))
+
+      (sync-dissoc! store :key2)
+
+      (let [ks (k/keys store {:sync? true})]
+        (is (= 2 (count ks)))
+        (is (not (contains? ks :key2)))))))
+
+;; =============================================================================
+;; Delete During Concurrent Operations Tests
+;; =============================================================================
+
+(deftest delete-during-read-test
+  (testing "Delete while read is in progress"
+    (let [{:keys [store]} (create-test-store)
+          read-started (java.util.concurrent.atomic.AtomicBoolean. false)
+          delete-done (java.util.concurrent.atomic.AtomicBoolean. false)
+          executor (Executors/newFixedThreadPool 2)]
+      (try
+        ;; Write initial data
+        (sync-assoc! store :target {:value "original"})
+
+        ;; We can't truly interleave at the backing store level in this test,
+        ;; but we can verify that delete followed by read returns nil
+        (sync-dissoc! store :target)
+        (is (nil? (sync-get store :target)))
+
+        (finally
+          (.shutdown executor))))))
+
+(deftest delete-during-update-test
+  (testing "Delete and update racing on same key"
+    (let [{:keys [store]} (create-test-store)
+          n-iterations 50
+          results (atom {:update-wins 0 :delete-wins 0 :errors 0})
+          executor (Executors/newFixedThreadPool 2)]
+      (try
+        (dotimes [_ n-iterations]
+          ;; Reset state
+          (sync-assoc! store :contested {:value 0})
+
+          (let [latch (CountDownLatch. 2)]
+            ;; Thread 1: update
+            (.submit executor
+                     ^Runnable
+                     (fn []
+                       (try
+                         (k/update-in store [:contested :value] inc {:sync? true})
+                         (catch Exception _))
+                       (.countDown latch)))
+
+            ;; Thread 2: delete
+            (.submit executor
+                     ^Runnable
+                     (fn []
+                       (try
+                         (sync-dissoc! store :contested)
+                         (catch Exception _))
+                       (.countDown latch)))
+
+            (.await latch 5 TimeUnit/SECONDS)
+
+            ;; Check outcome
+            (let [result (sync-get store :contested)]
+              (cond
+                (nil? result) (swap! results update :delete-wins inc)
+                (map? result) (swap! results update :update-wins inc)
+                :else (swap! results update :errors inc)))))
+
+        ;; Should see both outcomes (proves race exists)
+        (is (zero? (:errors @results)) "No errors during racing operations")
+        ;; At least one of each outcome expected over 50 iterations
+        (is (or (pos? (:delete-wins @results))
+                (pos? (:update-wins @results)))
+            "Should see at least some successful operations")
+
+        (finally
+          (.shutdown executor))))))
+
+(deftest delete-nonexistent-key-test
+  (testing "Deleting nonexistent key doesn't error"
+    (let [{:keys [store]} (create-test-store)]
+      ;; Should not throw
+      (sync-dissoc! store :never-existed)
+      (is (nil? (sync-get store :never-existed))))))
+
+;; =============================================================================
+;; Append/Log Operation Tests
+;; =============================================================================
+
+(deftest append-basic-test
+  (testing "append adds entries to log"
+    (let [{:keys [store]} (create-test-store)]
+      (k/append store :event-log {:event "first" :ts 1} {:sync? true})
+      (k/append store :event-log {:event "second" :ts 2} {:sync? true})
+      (k/append store :event-log {:event "third" :ts 3} {:sync? true})
+
+      (let [log (k/log store :event-log {:sync? true})]
+        (is (= 3 (count log)))
+        (is (= "first" (:event (first log))))
+        (is (= "third" (:event (last log))))))))
+
+(deftest append-preserves-order-test
+  (testing "append preserves insertion order"
+    (let [{:keys [store]} (create-test-store)
+          n-entries 100]
+      (dotimes [i n-entries]
+        (k/append store :ordered-log {:index i} {:sync? true}))
+
+      (let [log (k/log store :ordered-log {:sync? true})]
+        (is (= n-entries (count log)))
+        ;; Verify order
+        (doseq [[i entry] (map-indexed vector log)]
+          (is (= i (:index entry)) (str "Entry at position " i " should have index " i)))))))
+
+(deftest append-concurrent-test
+  (testing "Concurrent appends all succeed"
+    (let [{:keys [store]} (create-test-store)
+          n-threads 4
+          n-appends 25
+          latch (CountDownLatch. n-threads)
+          executor (Executors/newFixedThreadPool n-threads)]
+      (try
+        (dotimes [t n-threads]
+          (.submit executor
+                   ^Runnable
+                   (fn []
+                     (try
+                       (dotimes [i n-appends]
+                         (k/append store :concurrent-log
+                                   {:thread t :seq i}
+                                   {:sync? true}))
+                       (finally
+                         (.countDown latch))))))
+
+        (.await latch 30 TimeUnit/SECONDS)
+
+        (let [log (k/log store :concurrent-log {:sync? true})]
+          ;; All entries should be present
+          (is (= (* n-threads n-appends) (count log)))
+          ;; Each thread's entries should all be present
+          (doseq [t (range n-threads)]
+            (let [thread-entries (filter #(= t (:thread %)) log)]
+              (is (= n-appends (count thread-entries))
+                  (str "Thread " t " should have all entries")))))
+
+        (finally
+          (.shutdown executor))))))
+
+(deftest append-with-crash-test
+  (testing "Crash during append doesn't corrupt log"
+    (let [{:keys [store state-atom crash-point-atom]} (create-test-store)]
+      ;; Add some entries
+      (k/append store :crash-log {:entry 1} {:sync? true})
+      (k/append store :crash-log {:entry 2} {:sync? true})
+
+      ;; Crash during third append
+      (crash/set-crash-point! crash-point-atom :after-write-value)
+      (try
+        (k/append store :crash-log {:entry 3} {:sync? true})
+        (catch ExceptionInfo _))
+
+      (crash/simulate-crash! state-atom)
+      (crash/clear-crash-point! crash-point-atom)
+
+      ;; Log should have first two entries
+      (let [log (k/log store :crash-log {:sync? true})]
+        (is (= 2 (count log)))
+        (is (= 1 (:entry (first log))))
+        (is (= 2 (:entry (second log))))))))
+
+(deftest log-empty-test
+  (testing "log on nonexistent key returns empty"
+    (let [{:keys [store]} (create-test-store)]
+      (let [log (k/log store :no-such-log {:sync? true})]
+        (is (or (nil? log) (empty? log)))))))


### PR DESCRIPTION
konserve's storage layer had no in-tree way to test what happens when I/O fails, bytes corrupt, or the process dies mid-write. That harness existed — but out-of-tree, where it silently broke: `BackingFilestore` gained a `:filesystem` argument for jimfs support (bda6616) and the wrapper went unrepaired for seven months. Code implementing `PBackingStore` belongs with the protocol it implements, so it moves here and runs in CI on every commit.

Two commits, reviewable separately: the move, then the strengthening.

## 1. The move

Three namespaces under `konserve.simulation`:

- **`backing`** — wraps any `PBackingStore` and injects faults per protocol method. 19 rates: 16 error-injection points and 3 corruption points that flip bits in returned byte arrays rather than throwing, plus three crash probabilities. Decisions are drawn from a caller-supplied `SplittableRandom`, so a seed replays a run exactly. Every intercepted call is recorded to a history atom.
- **`crash`** — models a crash as loss of everything not yet synced, tracking pending vs synced blobs plus pending `.new` files, atomic moves and backup deletions. Crash points are *enumerated, not sampled* — the six steps of the `DefaultStore` write path — following the crash-consistency literature (SQLite, RocksDB, CrashMonkey) that bugs cluster right after fsync-like calls. No RNG here, so scenarios are deterministic by construction.
- **`memory`** — in-memory `PBackingStore` for tests that shouldn't touch a disk.

## 2. Making it bite

The migrated suite was mutation-tested — the implementation deliberately broken to check the tests notice. Most held: removing fault injection fails 14 assertions, disabling crash injection fails 27 of 33, a crash wiping synced data fails 12, unenforced resource limits fail 4, a no-op delete raises 8 errors. **Three things did not**, and are fixed here:

- **Corruption was never exercised.** The three `:*-corrupt-rate` knobs default to `0.0` and no test ever set one — `corrupt-bytes` could be replaced by `identity` without moving a single assertion. A shipped capability with zero coverage. Now tested at rate 1.0 against the property that matters: a read returns exactly what was written, or it fails. All three are detected (header and value via `get`; meta only via `get-meta`, the only path that reads it).
- **Acknowledged-write durability was never asserted.** The strongest property in this domain — konserve may *fail* a write under faults, but must never acknowledge one it then loses, nor damage data it already holds — was stated nowhere. Added as a 100-seed sweep, since one fault schedule exercises one interleaving. Verified sensitive: making an injected fault silent (write acknowledged, does nothing) fails it.
- **`update-in-concurrent-test` asserted almost nothing.** 5 threads × 20 `update-in`s, asserting only that the result was positive and *printing* lost updates rather than failing. No updates are lost today, so it is now an equality assertion (20 consecutive runs, no flakes). It previously caught total lock removal only by accident, via a thrown header-parsing error.

Also adds a **crash-point × value-shape matrix**: 144 rounds over all six crash points × twelve shapes (5 KB strings, shrinking values, empty maps, nil values, unicode, deep nesting), for both overwriting an existing key and writing an absent one. ~150ms, since it runs entirely in memory. Crash coverage was the thinnest part of the suite by sensitivity, so that is where the budget went.

**Dead code removed** — six functions with no callers anywhere: `clear-history!`, `count-crashes`, `has-orphan-files?`, `verify-no-partial-data`, `get-blob-data`, `list-all-blobs`. Note `verify-no-partial-data` was *not* what `no-partial-data-invariant-test` used; that test inlines its own, stronger, value-comparing check.

## Numbers

99 tests / 2427 assertions (from 95 / 2409). Simulation suite 30.5s (from 27.5s). Full suite **222 tests / 3826 assertions, 0 failures**. `clj -M:lint` and `clj -M:format` clean.

## Two findings worth keeping

**konserve has two independent locking layers** — the blob lock (`:lock-blob?`, default true) and `konserve.core`'s per-key registry. Removing either alone is survivable for a counter workload; removing both corrupts blobs outright. A mutation test that disables only one looks deceptively inert — this cost me a wrong conclusion before I checked.

**The matrix deliberately accepts a crash that leaves an atomic move applied.** Its invariant is "the reader sees exactly the old or the new value", and a completed move legitimately yields the new one. The stricter property — that a crash *reverts* an unsynced move — is `atomicity-invariant-test`'s job. Complementary; neither subsumes the other.

Sweeps at ~20× the suite's volume found nothing further: 200 seeds × 30 chaos operations (6,000 fault-injected writes), and 288 crash rounds across value shapes. Runtime is not this suite's limiting factor; assertion strength is.

## Internal, not public API

The namespaces are `^:no-doc` and each docstring says so. They ship in the jar so backends and downstream projects (datahike, stratum — both already depend on konserve) can test against them, but carry no compatibility guarantee and may change or move in any release. The seam is small and protocol-only, so factoring them back out later stays cheap.

## Notes for review

- **One portability fix:** `(Thread/sleep (rand-int 10))` threw `No matching method sleep found taking 1 args` under konserve's Clojure 1.11.1 — it only worked out-of-tree because that project pinned 1.12.0. Now `(long (rand-int 10))`.
- **One test remains a characterization:** `delete-during-update-test` asserts only that no errors occur while a delete races an update, accepting either winner — the race has no single correct outcome.
- **`memory.clj`'s `-write-meta` has a dead branch:** `old-value` always evaluates to empty. Harmless, since the write path is header → meta → value. Left as-is rather than changing behaviour here.
- **`simulation_crash_test` is the slowest namespace** (~8s) for the fewest assertions — it is sleep-bound on `acquire-lock`'s `(rand-int 10)` backoff. Worth reclaiming separately; not touched here.

## Dropped in the move

A spindel-based deterministic-simulation layer (virtual time, O(1) forking, per-fork process ids) and the `fault`/`history`/`invariant` namespaces alongside it — no test exercised any of them. `doc/simulation-testing.md` records what the harness covers and what it does not: single-process and JVM-only, no linearizability checker run against the Elle-shaped history, and crash simulation that models konserve's sync semantics rather than physical device behaviour.