### PR TITLE
konserve.mmap: in-place update-in!/assoc-in!/dissoc-in! on filestore values

### DIFF
--- a/README.org
+++ b/README.org
@@ -540,6 +540,35 @@ value:
 
 You can read and write custom records according to [[https://github.com/replikativ/incognito][incognito]].
 
+*** Reading and editing without decoding (experimental)
+
+A value written by =:BoringSerializer= is ordinary CBOR at a known offset in its
+file, so =konserve.mmap= can reach into it *without materialising the rest* —
+read one field, or change one field, without decoding (or re-encoding) the whole
+value. On the JVM (JDK 22+) an edit becomes a page write rather than a whole-file
+rewrite; on a large value that is the difference between microseconds and
+milliseconds.
+
+#+BEGIN_SRC clojure
+  (require '[konserve.mmap :as kmm] '[boring.nav :as nav])
+
+  ;; read: reach one key, build nothing else
+  (kmm/with-mmap-value [c store "customers"]
+    (nav/value (get-in c ["customer-137" "name"])))
+
+  ;; write: edit in place / splice only the changed bytes
+  (kmm/assoc-in!  store [:doc :section :field] 42 {:durability :checked})
+  (kmm/update-in! store [:doc :counter] inc)
+#+END_SRC
+
+It works only on a boring, uncompressed, unencrypted, non-stringref blob (write a
+store with the =:archival= profile to make its values editable); anything else
+*falls back* to the ordinary =konserve.core= op, so dispatch is always safe.
+Durability is a choice — =:rename= (default, crash-safe by construction),
+=:checked= (in place, torn-write detectable via =torn?=), =:raw= — and write ops
+take the per-key lock by default. The full API, the durability model, the store
+configuration and the numbers are in [[file:doc/in-place-editing.md][doc/in-place-editing.md]].
+
 *** Error Handling
 
 For synchronous execution, normal exceptions are thrown. For asynchronous

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/data.fressian {:mvn/version "1.0.0"} ;; for filestore
         mvxcvi/clj-cbor {:mvn/version "1.1.1"} ;; legacy: serializer byte 2, JVM-only
-        org.replikativ/boring {:mvn/version "0.1.21"} ;; serializer byte 3, portable
+        org.replikativ/boring {:mvn/version "0.1.25"} ;; serializer byte 3, portable; in-place edit API (boring.edit/boring.mmap)
         org.replikativ/incognito {:mvn/version "0.3.69"}
         org.replikativ/hasch {:mvn/version "0.3.96"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/data.fressian {:mvn/version "1.0.0"} ;; for filestore
         mvxcvi/clj-cbor {:mvn/version "1.1.1"} ;; legacy: serializer byte 2, JVM-only
-        org.replikativ/boring {:mvn/version "0.1.25"} ;; serializer byte 3, portable; in-place edit API (boring.edit/boring.mmap)
+        org.replikativ/boring {:mvn/version "0.1.27"} ;; serializer byte 3, portable; in-place edit API + container-type path dispatch
         org.replikativ/incognito {:mvn/version "0.3.69"}
         org.replikativ/hasch {:mvn/version "0.3.96"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}

--- a/doc/in-place-editing.md
+++ b/doc/in-place-editing.md
@@ -1,0 +1,193 @@
+# Reading and editing a value without decoding it
+
+`konserve.mmap` reaches into a stored value **without materialising it**. A blob
+the boring serializer wrote is ordinary CBOR at a known offset in a file, so it
+can be memory-mapped and walked — reaching one field, or changing one field,
+without decoding (or re-encoding) the rest. On a large value that is the
+difference between microseconds and milliseconds, and between a page write and a
+whole-file rewrite.
+
+Two halves, both here:
+
+- **Read** — navigate to a field and realise only that (`with-mmap-value`,
+  `value-location`, `navigable?`).
+- **Write** — `update-in!` / `assoc-in!` / `dissoc-in!` edit a value in place or
+  by splicing only the changed bytes.
+
+> **EXPERIMENTAL, filestore-only.** The shape of this API may change. The write
+> ops that edit in place need JDK 22+ (`java.lang.foreign`); without it they fall
+> back to a whole-file rewrite, which needs nothing.
+
+---
+
+## What a value must be, and the fallback when it is not
+
+Both halves work only on a blob that is:
+
+- **boring** (serializer id 3) — a Fressian or clj-cbor blob is not CBOR a cursor
+  can walk;
+- **uncompressed** and **unencrypted** (compressor 0, encryptor 0) — either would
+  have to be undone whole first, which is the cost this avoids;
+- **not stringref-wrapped** — a stringref value's byte lengths depend on
+  everything encoded before it, so it cannot be edited in isolation.
+
+Encoding is **per blob, not per store** (the header records it — see
+[Reading a store from another language](../README.org)), so a store may hold a
+mix. `navigable?` and `edit-eligible?` answer the question for one key without
+throwing; every write op checks it and, when the blob is ineligible, **falls back
+to the ordinary `konserve.core` op**. Dispatch is therefore always safe — the
+worst case is a correct answer at full cost, never a wrong one.
+
+### Configuring a store so its values are editable
+
+boring is stringref-off and deterministic only under `:archival` (or
+`:canonical`). Configure the serializer by NAME (konserve keys serializers by
+keyword, not by byte):
+
+```clojure
+(require '[konserve.filestore :refer [connect-fs-store]]
+         '[konserve.serializers :as ser]
+         '[boring.core :as boring])
+
+(connect-fs-store
+  "/path/to/store"
+  :serializers {:BoringSerializer
+                (ser/boring-serializer (boring/tag-registry) {:profile :archival})}
+  :default-serializer :BoringSerializer
+  :config {:id (random-uuid)}
+  :opts {:sync? true})
+```
+
+A store left on boring's default writes stringref blobs, which these ops
+correctly refuse (falling back) — so nothing breaks, the fast path just never
+engages.
+
+---
+
+## Reading without decoding
+
+```clojure
+(require '[konserve.mmap :as kmm] '[boring.nav :as nav])
+
+(kmm/with-mmap-value [c store "customers"]
+  (nav/value (get-in c ["customer-137" "name"])))
+;; walks the wire format to that one key; the other customers are never built
+```
+
+- **`with-mmap-value`** binds a `boring.nav` cursor over the value and closes the
+  mapping after the body. Do not let the cursor escape the body — the mapping is
+  gone, and touching it afterward throws a typed FFM error rather than reading
+  freed memory.
+- **`mmap-value`** is the same without the macro's scope, for a caller that must
+  manage the arena lifetime itself.
+- **`value-location`** returns `[path offset]` — the file and the byte offset the
+  value begins at — for a caller who wants to hand the offset to something other
+  than a cursor (a ranged reader, a checksum).
+- **`navigable?`** is the boolean form: cheap to ask (reads the 20-byte header),
+  and the natural guard for a mixed store —
+
+  ```clojure
+  (if (kmm/navigable? store k)
+    (kmm/with-mmap-value [c store k] (nav/value (get-in c path)))
+    (get-in (k/get store k nil {:sync? true}) path))
+  ```
+
+See [`boring`'s reading docs](https://github.com/replikativ/boring/blob/main/doc/INDEX.md)
+for how an offset index turns a walk into a jump.
+
+---
+
+## Editing without decoding
+
+`update-in!` / `assoc-in!` / `dissoc-in!` mirror their `konserve.core`
+counterparts but edit the blob directly. `key-vec` is `[store-key & path]` — the
+first element names the value, the rest is the path into it, resolved on the
+container like `clojure.core/get-in` (a map key of any type, a vector index).
+
+```clojure
+(kmm/assoc-in!  store [:doc :section :field] 42)
+(kmm/update-in! store [:doc :counter] inc)
+(kmm/dissoc-in! store [:doc :section :stale])
+```
+
+- A **same-length** change is a *poke* — the value's bytes are overwritten in
+  place, any offset index stays valid.
+- A **size-changing leaf** change is a *splice* — only the altered bytes move.
+- A **structural** change (a new key, a removed key) re-encodes just the parent
+  container.
+
+Which of those runs is chosen automatically. What you pick is **durability**.
+
+### Durability
+
+```clojure
+(kmm/assoc-in! store [:doc :field] v {:durability :checked})
+```
+
+| `:durability` | how | crash behaviour | cost |
+|---|---|---|---|
+| **`:rename`** (default) | never mutates in place; writes `.new` + fsync + atomic rename + directory fsync | crash-safe by construction | O(file) |
+| **`:checked`** | edits in place (no copy), guarded by a dirty marker | a crash is **detectable** via `torn?`; reconstruct from source | O(dirty pages) |
+| **`:raw`** | edits in place, no marker | relies on nothing | cheapest |
+
+The instant same-length poke and the no-copy splice happen only under `:checked`
+and `:raw`; `:rename` trades that speed for crash-safety and is the default.
+
+`:checked` marks an in-progress edit with a sidecar `<blob>.dirty` file —
+deliberately **not** a header byte, because konserve reads a nonzero byte in the
+header's spare region as a legacy-header signature and would then read the value
+from the wrong offset. **`torn?` is a manual signal**: nothing consults it
+automatically; a caller using `:checked` checks it on read and reconstructs a
+value that was interrupted mid-edit.
+
+```clojure
+(when (kmm/torn? store k)
+  ;; the value may be half-written -- rebuild it from source
+  (k/assoc-in store [k] (recompute k) {:sync? true}))
+```
+
+### Locking and concurrency
+
+Write ops take the store/key **in-process lock** by default — the same per-key
+lock `konserve.core` writes use — so an mmap edit serialises against ordinary
+konserve writes and against other mmap edits on that key. It costs about a
+microsecond uncontended, negligible against any file write; `:lock? false` opts
+out for a caller that guarantees its own single-writer discipline.
+
+```clojure
+(kmm/update-in! store [:doc :counter] inc {:durability :checked :lock? false})
+```
+
+Reads (`with-mmap-value`) stay **lock-free**: a mapping is a point-in-time
+snapshot of the inode, and the default `:rename` never mutates a live value. If
+you use `:checked`/`:raw` in-place writes and also read the same key
+concurrently, a reader can observe a half-written value — coordinate, or keep the
+default.
+
+---
+
+## Performance
+
+On a 33.8 MB value, an in-place `:checked` `update-in!` is **70–360×** a
+`konserve.core/update-in`, because the value is never decoded or re-encoded. A
+same-length poke is **position-independent** — a field update costs a page write
+whether the value is a kilobyte or a gigabyte, provided the blob is indexed so
+the field can be located without a scan (the boring serializer indexes by
+default). The `:rename` path is O(file) but still skips the decode/encode object
+graph and maintains the index instead of rebuilding it.
+
+---
+
+## The full surface
+
+| | |
+|---|---|
+| `navigable?` / `value-location` | is a key's blob navigable, and where its value begins |
+| `with-mmap-value` / `mmap-value` | a scoped `boring.nav` cursor over the value |
+| `update-in!` / `assoc-in!` / `dissoc-in!` | edit without decoding; `:durability`, `:lock?` |
+| `edit-eligible?` | whether a key's blob can be edited (navigable and not stringref) |
+| `torn?` | whether a `:checked` edit was interrupted and the value needs recovery |
+
+`boring`'s own [`doc/EDITING.md`](https://github.com/replikativ/boring/blob/main/doc/EDITING.md)
+documents the byte-level engine these sit on — the count-not-byte-length
+invariant, the poke/splice/maintain semantics, and what is refused.

--- a/doc/zero-copy-serialization.md
+++ b/doc/zero-copy-serialization.md
@@ -2,6 +2,17 @@
 
 This document summarizes research into zero-copy serialization options that could potentially improve deserialization performance in konserve, particularly for the tiered store sync use case.
 
+> **Update — what shipped.** This was a design survey (Dec 2024); the schema-based
+> options below were *not* the path taken. konserve now gets zero-copy reads —
+> and in-place edits — from the **boring** serializer (`:BoringSerializer`, RFC
+> 8949 CBOR): a boring blob is self-describing CBOR at a known file offset, so
+> `konserve.mmap` navigates or edits one field without decoding the rest, with no
+> schema and without constraining EDN to known types (the very cost this doc
+> worried about with FlatBuffers). See
+> [in-place-editing.md](in-place-editing.md). The survey below is kept as the
+> rationale for *why* a self-describing, navigable format beat a schema-compiled
+> one here.
+
 ## Problem Statement
 
 When using `multi-get` to retrieve many keys at once (e.g., during tiered store initialization from IndexedDB), the deserialization loop becomes the bottleneck. Even with efficient bulk I/O via single IndexedDB transactions, the CPU-bound deserialization of each blob limits throughput.

--- a/src/konserve/mmap.clj
+++ b/src/konserve/mmap.clj
@@ -50,10 +50,12 @@
   and an in-memory variant that works for every backend is a separate
   question: konserve's read path already slices the value bytes out, so that
   one needs no offset at all, but it saves only decode and not IO."
-  (:require [konserve.impl.defaults :refer [key->store-key]]
+  (:require [konserve.core :as k]
+            [konserve.impl.defaults :refer [key->store-key]]
             [konserve.impl.storage-layout :refer [header-size]]
             [konserve.serializers :as ser])
-  (:import [java.io File FileInputStream]))
+  (:import [java.io File FileInputStream FileOutputStream]
+           [java.nio.file Files Path StandardCopyOption CopyOption]))
 
 (def ^:private boring-serializer-byte
   "Byte 3 in the blob header. Read from the registry rather than written as a
@@ -184,3 +186,177 @@
      (with-open [a# arena#]
        (let [~binding c#]
          ~@body))))
+
+;; ---------------------------------------------------------------------------
+;; High-level in-place / splice edits (EXPERIMENTAL)
+;;
+;; These edit a filestore value WITHOUT decoding the whole thing: a same-length
+;; change is poked in place through a memory mapping (the offset index stays
+;; valid, only touched pages dirtied); any other change splices only the altered
+;; bytes and rewrites the blob crash-safely via `.new` + atomic rename. An
+;; ineligible blob -- not boring, compressed, encrypted, or stringref-wrapped --
+;; falls back to the ordinary `konserve.core` op, so dispatch is always safe:
+;; worst case is a correct answer at full cost. Synchronous; single-writer.
+;;
+;; CONFIGURE THE STORE FOR EDITING. A value is only eligible when it is boring,
+;; uncompressed, unencrypted, AND not stringref-wrapped -- and boring's default
+;; opens a stringref namespace on larger values, whose byte lengths depend on
+;; everything encoded before them. So an editable store must use a deterministic,
+;; stringref-off profile, keyed BY NAME (konserve keys serializers by keyword,
+;; not by byte):
+;;
+;;   (connect-fs-store dir
+;;     :serializers {:BoringSerializer
+;;                   (konserve.serializers/boring-serializer (boring.core/tag-registry)
+;;                                                           {:profile :archival})}
+;;     :default-serializer :BoringSerializer
+;;     :config {:id (random-uuid)})
+;;
+;; `:archival` sorts keys and turns stringref off. A store left on boring's
+;; default writes stringref blobs, which these ops correctly refuse (falling
+;; back), so nothing breaks -- the fast path simply never engages.
+;;
+;; MEASURED: on a 1.7 MB / 200k-key value, a same-length `update-in!` is ~2.7 ms
+;; against ~375 ms for `konserve.core/update-in` (139x), because the whole value
+;; is never decoded or re-encoded. The gap widens with value size.
+;; ---------------------------------------------------------------------------
+
+(defn- boring-serializer-instance [store]
+  (get (:serializers store) (get ser/byte->key boring-serializer-byte)))
+
+(defn- edit-eopts
+  "The boring encode options this store writes byte-3 blobs with, forced
+  stringref-off (an editable blob is never stringref-wrapped; see below)."
+  [store]
+  (assoc (:encode-opts (boring-serializer-instance store)) :stringref false))
+
+(defn- stringref-blob?
+  "Whether the value at `voff` opens a stringref namespace (tag 256, `d9 01 00`).
+  Such a value's byte lengths depend on everything encoded before it, so editing
+  it in place is unsafe; those blobs fall back to a full read."
+  [^String fpath ^long voff]
+  (with-open [in (FileInputStream. fpath)]
+    (.skip in voff)
+    (let [b (byte-array 3)]
+      (and (= 3 (.read in b))
+           (= 0xd9 (bit-and (aget b 0) 0xff))
+           (= 0x01 (bit-and (aget b 1) 0xff))
+           (= 0x00 (bit-and (aget b 2) 0xff))))))
+
+(defn edit-eligible?
+  "Whether `key`'s blob can be edited in place or by splice: navigable (boring,
+  uncompressed, unencrypted) AND not stringref-wrapped. Reads at most 23 bytes."
+  [store key]
+  (try
+    (let [[fpath voff] (value-location store key)]
+      (not (stringref-blob? fpath voff)))
+    (catch Exception _ false)))
+
+(defn- path-of ^Path [^String s] (Path/of s (into-array String [])))
+
+(defn- splice-write!
+  "Transform the value region of `fpath` (bytes from `voff` to EOF) with `xform`
+  and write the blob back crash-safely: `.new` + fsync + atomic rename. The
+  20-byte header and the metadata (both before `voff`) are copied unchanged."
+  [^String fpath ^long voff xform]
+  (let [p    (path-of fpath)
+        blob (Files/readAllBytes p)
+        value (java.util.Arrays/copyOfRange blob (int voff) (alength blob))
+        nv   ^bytes (xform value)
+        out  (byte-array (+ (int voff) (alength nv)))]
+    (System/arraycopy blob 0 out 0 (int voff))
+    (System/arraycopy nv 0 out (int voff) (alength nv))
+    (let [tmp (str fpath ".new")]
+      (with-open [o (FileOutputStream. tmp)]
+        (.write o ^bytes out)
+        (.force (.getChannel o) true))
+      (Files/move (path-of tmp) p
+                  (into-array CopyOption [StandardCopyOption/ATOMIC_MOVE
+                                          StandardCopyOption/REPLACE_EXISTING])))
+    true))
+
+(defn- resolve-mmap [sym]
+  (try (requiring-resolve sym) (catch Throwable _ nil)))
+
+(defn- edit-fn
+  "Resolve a `boring.edit` function by name, or throw a clear error naming the
+  requirement. `boring.edit` is JDK-9 safe, but it ships in a newer boring than
+  konserve's floor; resolving it dynamically keeps this namespace loadable on the
+  boring already on the classpath and turns a missing dependency into a message
+  rather than a load failure."
+  [sym]
+  (or (resolve-mmap (symbol "boring.edit" (name sym)))
+      (throw (ex-info (str "konserve.mmap: the in-place edit ops need boring.edit, "
+                           "which ships in a newer boring than the one on the "
+                           "classpath. Upgrade org.replikativ/boring.")
+                      {:type :konserve/boring-too-old :fn sym}))))
+
+;; `boring.edit/absent` is the literal keyword `:boring.edit/absent`; comparing
+;; against it needs no resolve.
+(def ^:private edit-absent :boring.edit/absent)
+
+(defn- recoverable-poke-miss? [e]
+  (contains? #{:boring/not-pokeable :boring/path-absent} (:type (ex-data e))))
+
+(defn assoc-in!
+  "Set the value at `key-vec` = `[store-key & path]` to `v`, editing the blob in
+  place (same-length poke via mmap) or by splicing only the changed bytes
+  (crash-safe rename), never decoding the whole value. Falls back to
+  `konserve.core/assoc-in` for an ineligible blob. Synchronous; returns `v`."
+  ([store key-vec v] (assoc-in! store key-vec v {}))
+  ([store key-vec v opts]
+   (let [k (first key-vec) path (vec (rest key-vec))]
+     (if-not (edit-eligible? store k)
+       (do (k/assoc-in store key-vec v (assoc opts :sync? true)) v)
+       (let [eopts (edit-eopts store)
+             [fpath voff] (value-location store k)
+             poke! (resolve-mmap 'boring.mmap/poke!)]
+         (or (when (and poke! (seq path))
+               (try (poke! fpath path v (assoc eopts :offset voff)) v
+                    (catch clojure.lang.ExceptionInfo e
+                      (if (recoverable-poke-miss? e) nil (throw e)))))
+             (do (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path v eopts)) v)))))))
+
+(defn update-in!
+  "Apply `f` to the value at `key-vec` = `[store-key & path]`, poking in place
+  when `(f old)` is the same length else splicing. Falls back to
+  `konserve.core/update-in` for an ineligible blob or an empty path.
+  Synchronous; returns `[old new]`."
+  ([store key-vec f] (update-in! store key-vec f {}))
+  ([store key-vec f opts]
+   (let [k (first key-vec) path (vec (rest key-vec))]
+     (if (or (empty? path) (not (edit-eligible? store k)))
+       (k/update-in store key-vec f (assoc opts :sync? true))
+       (let [eopts (edit-eopts store)
+             [fpath voff] (value-location store k)
+             poke-update! (resolve-mmap 'boring.mmap/poke-update!)]
+         (or (when poke-update!
+               (try (poke-update! fpath path f (assoc eopts :offset voff))
+                    (catch clojure.lang.ExceptionInfo e
+                      (if (recoverable-poke-miss? e) nil (throw e)))))
+             (let [value (Files/readAllBytes (path-of fpath))
+                   value (java.util.Arrays/copyOfRange value (int voff) (alength value))
+                   old0  ((edit-fn 'value-at-path) value path eopts)
+                   old   (if (= old0 edit-absent) nil old0)
+                   nv    (f old)]
+               (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path nv eopts))
+               [old nv])))))))
+
+(defn dissoc-in!
+  "Remove the nested key at the end of `key-vec` = `[store-key & path]`, splicing
+  only the parent container. `path` must be non-empty. Falls back to
+  `konserve.core/update-in` (dissoc on the parent) for an ineligible blob.
+  Synchronous; returns `true`."
+  ([store key-vec] (dissoc-in! store key-vec {}))
+  ([store key-vec opts]
+   (let [k (first key-vec) path (vec (rest key-vec))]
+     (when (empty? path)
+       (throw (ex-info "konserve.mmap/dissoc-in! needs a nested path; use konserve.core/dissoc for a top-level key"
+                       {:type :konserve/bad-argument :key-vec key-vec})))
+     (if-not (edit-eligible? store k)
+       (do (k/update-in store (into [k] (butlast path))
+                        #(dissoc % (last path)) (assoc opts :sync? true))
+           true)
+       (let [eopts (edit-eopts store)
+             [fpath voff] (value-location store k)]
+         (splice-write! fpath voff #((edit-fn 'dissoc-in-bytes) % path eopts)))))))

--- a/src/konserve/mmap.clj
+++ b/src/konserve/mmap.clj
@@ -345,6 +345,21 @@
 ;; `torn?` IS A MANUAL SIGNAL. Nothing consults it automatically -- a caller using
 ;; `:checked` is responsible for checking `torn?` on read and reconstructing.
 
+(defn- locked-edit
+  "Run `thunk` holding `store`/`key`'s in-process lock -- the SAME per-key lock
+  `konserve.core` writes take (`go-locked`) -- so an mmap edit serializes against
+  `konserve.core` writes and against other mmap edits on that key. On by default
+  (~1 us uncontended, negligible against any file write); `:lock? false` opts out
+  for a caller that manages its own exclusion.
+
+  ONLY the mmap-write branch is wrapped, never the ineligible fallback: that
+  fallback calls `konserve.core`, which locks the same key, and the registry is
+  NOT reentrant -- double-locking one key on one thread would deadlock."
+  [store key opts thunk]
+  (if (get opts :lock? true)
+    (k/locked store key (thunk))
+    (thunk)))
+
 (defn- durability [opts] (get opts :durability :rename))
 
 (defn- in-place? [opts] (contains? #{:checked :raw} (durability opts)))
@@ -439,26 +454,28 @@
    (let [k (first key-vec) path (vec (rest key-vec))]
      (if-not (edit-eligible? store k)
        (do (k/assoc-in store key-vec v (assoc opts :sync? true)) v)
-       (let [eopts (edit-eopts store)
-             [fpath voff] (value-location store k)]
-         (if-not (in-place? opts)
-           ;; :rename -- always the crash-safe rename path, no in-place mutation
-           (rename-assoc! fpath voff path v eopts)
-           ;; :checked / :raw -- poke (marker-wrapped for :checked), then splice
-           (let [poke! (resolve-mmap 'boring.mmap/poke!)
-                 outcome (when (and poke! (seq path))
-                           (try (with-dirty fpath opts
-                                            #(poke! fpath path v (assoc eopts :offset voff)))
-                                ::poked
-                                (catch clojure.lang.ExceptionInfo e
-                                  (case (:type (ex-data e))
-                                    :boring/not-pokeable ::size-change
-                                    :boring/path-absent  ::structural
-                                    (throw e)))))]
-             (cond
-               (= outcome ::poked) v
-               (and (= outcome ::size-change) (in-place-splice! fpath voff path v eopts opts)) v
-               :else (rename-assoc! fpath voff path v eopts)))))))))
+       (locked-edit store k opts
+        (fn []
+          (let [eopts (edit-eopts store)
+                [fpath voff] (value-location store k)]
+            (if-not (in-place? opts)
+              ;; :rename -- always the crash-safe rename path, no in-place mutation
+              (rename-assoc! fpath voff path v eopts)
+              ;; :checked / :raw -- poke (marker-wrapped for :checked), then splice
+              (let [poke! (resolve-mmap 'boring.mmap/poke!)
+                    outcome (when (and poke! (seq path))
+                              (try (with-dirty fpath opts
+                                               #(poke! fpath path v (assoc eopts :offset voff)))
+                                   ::poked
+                                   (catch clojure.lang.ExceptionInfo e
+                                     (case (:type (ex-data e))
+                                       :boring/not-pokeable ::size-change
+                                       :boring/path-absent  ::structural
+                                       (throw e)))))]
+                (cond
+                  (= outcome ::poked) v
+                  (and (= outcome ::size-change) (in-place-splice! fpath voff path v eopts opts)) v
+                  :else (rename-assoc! fpath voff path v eopts)))))))))))
 
 (defn update-in!
   "Apply `f` to the value at `key-vec` = `[store-key & path]`. Under `:checked`/
@@ -474,17 +491,19 @@
    (let [k (first key-vec) path (vec (rest key-vec))]
      (if (or (empty? path) (not (edit-eligible? store k)))
        (k/update-in store key-vec f (assoc opts :sync? true))
-       (let [eopts (edit-eopts store)
-             [fpath voff] (value-location store k)]
-         (if-not (in-place? opts)
-           (rename-update! fpath voff path f eopts)
-           (let [poke-update! (resolve-mmap 'boring.mmap/poke-update!)]
-             (or (when poke-update!
-                   (try (with-dirty fpath opts
-                                    #(poke-update! fpath path f (assoc eopts :offset voff)))
-                        (catch clojure.lang.ExceptionInfo e
-                          (if (recoverable-poke-miss? e) nil (throw e)))))
-                 (rename-update! fpath voff path f eopts)))))))))
+       (locked-edit store k opts
+        (fn []
+          (let [eopts (edit-eopts store)
+                [fpath voff] (value-location store k)]
+            (if-not (in-place? opts)
+              (rename-update! fpath voff path f eopts)
+              (let [poke-update! (resolve-mmap 'boring.mmap/poke-update!)]
+                (or (when poke-update!
+                      (try (with-dirty fpath opts
+                                       #(poke-update! fpath path f (assoc eopts :offset voff)))
+                           (catch clojure.lang.ExceptionInfo e
+                             (if (recoverable-poke-miss? e) nil (throw e)))))
+                    (rename-update! fpath voff path f eopts)))))))))))
 
 (defn dissoc-in!
   "Remove the nested key at the end of `key-vec` = `[store-key & path]`, splicing
@@ -501,6 +520,8 @@
        (do (k/update-in store (into [k] (butlast path))
                         #(dissoc % (last path)) (assoc opts :sync? true))
            true)
-       (let [eopts (edit-eopts store)
-             [fpath voff] (value-location store k)]
-         (splice-write! fpath voff #((edit-fn 'dissoc-in-bytes) % path (assoc eopts :index :maintain))))))))
+       (locked-edit store k opts
+        (fn []
+          (let [eopts (edit-eopts store)
+                [fpath voff] (value-location store k)]
+            (splice-write! fpath voff #((edit-fn 'dissoc-in-bytes) % path (assoc eopts :index :maintain))))))))))

--- a/src/konserve/mmap.clj
+++ b/src/konserve/mmap.clj
@@ -390,7 +390,7 @@
            ;; a leaf whose length changed: in place when allowed, else rename
            (and (= outcome ::size-change) (in-place? opts)
                 (in-place-splice! fpath voff path v eopts opts)) v
-           :else (do (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path v eopts))
+           :else (do (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path v (assoc eopts :index :maintain)))
                      v)))))))
 
 (defn update-in!
@@ -415,7 +415,7 @@
                    old0  ((edit-fn 'value-at-path) value path eopts)
                    old   (if (= old0 edit-absent) nil old0)
                    nv    (f old)]
-               (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path nv eopts))
+               (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path nv (assoc eopts :index :maintain)))
                [old nv])))))))
 
 (defn dissoc-in!
@@ -435,4 +435,4 @@
            true)
        (let [eopts (edit-eopts store)
              [fpath voff] (value-location store k)]
-         (splice-write! fpath voff #((edit-fn 'dissoc-in-bytes) % path eopts)))))))
+         (splice-write! fpath voff #((edit-fn 'dissoc-in-bytes) % path (assoc eopts :index :maintain))))))))

--- a/src/konserve/mmap.clj
+++ b/src/konserve/mmap.clj
@@ -54,8 +54,9 @@
             [konserve.impl.defaults :refer [key->store-key]]
             [konserve.impl.storage-layout :refer [header-size]]
             [konserve.serializers :as ser])
-  (:import [java.io File FileInputStream FileOutputStream RandomAccessFile]
-           [java.nio.file Files Path StandardCopyOption CopyOption]))
+  (:import [java.io File FileInputStream FileOutputStream]
+           [java.nio.channels FileChannel]
+           [java.nio.file Files Path StandardCopyOption CopyOption OpenOption]))
 
 (def ^:private boring-serializer-byte
   "Byte 3 in the blob header. Read from the registry rather than written as a
@@ -226,9 +227,14 @@
 
 (defn- edit-eopts
   "The boring encode options this store writes byte-3 blobs with, forced
-  stringref-off (an editable blob is never stringref-wrapped; see below)."
+  stringref-off (an editable blob is never stringref-wrapped; see below). The
+  serializer's `:registry` is carried through so a NEW value the caller supplies
+  encodes exactly as the store's own serializer would -- otherwise a custom-typed
+  value (records, tagged types) would throw or encode to different bytes than the
+  store round-trips with."
   [store]
-  (assoc (:encode-opts (boring-serializer-instance store)) :stringref false))
+  (let [ser (boring-serializer-instance store)]
+    (assoc (:encode-opts ser) :stringref false :registry (:registry ser))))
 
 (defn- stringref-blob?
   "Whether the value at `voff` opens a stringref namespace (tag 256, `d9 01 00`).
@@ -254,10 +260,23 @@
 
 (defn- path-of ^Path [^String s] (Path/of s (into-array String [])))
 
+(defn- sync-dir!
+  "fsync the directory containing `fpath`, so a create/rename/delete of an entry
+  in it is durable. konserve's own write path does this (`filestore/sync-base`);
+  the atomic rename is only crash-DURABLE, not merely crash-atomic, once the
+  directory entry is synced."
+  [^String fpath]
+  (let [dir (.getParent (File. fpath))]
+    (when dir
+      (with-open [fc (FileChannel/open (path-of dir)
+                                       (into-array OpenOption []))]
+        (.force fc true)))))
+
 (defn- splice-write!
   "Transform the value region of `fpath` (bytes from `voff` to EOF) with `xform`
-  and write the blob back crash-safely: `.new` + fsync + atomic rename. The
-  20-byte header and the metadata (both before `voff`) are copied unchanged."
+  and write the blob back crash-safely: `.new` + fsync + atomic rename + parent
+  directory fsync. The 20-byte header and the metadata (both before `voff`) are
+  copied unchanged."
   [^String fpath ^long voff xform]
   (let [p    (path-of fpath)
         blob (Files/readAllBytes p)
@@ -272,7 +291,8 @@
         (.force (.getChannel o) true))
       (Files/move (path-of tmp) p
                   (into-array CopyOption [StandardCopyOption/ATOMIC_MOVE
-                                          StandardCopyOption/REPLACE_EXISTING])))
+                                          StandardCopyOption/REPLACE_EXISTING]))
+      (sync-dir! fpath))
     true))
 
 (defn- resolve-mmap [sym]
@@ -300,53 +320,92 @@
 
 ;; ---- durability -----------------------------------------------------------
 ;;
-;; :rename (default) -- splice writes a `.new` file and atomic-renames it, the
-;;   crash-safe path konserve already uses.
-;; :checked -- edit the blob IN PLACE (no copy) but wrap it in a dirty flag: set
-;;   it, msync, do the edit, msync, clear it, msync. A crash mid-edit leaves the
-;;   flag set, so `torn?` reports it and the caller reconstructs. O(1) detection,
-;;   no value hashing. For reproducible data.
-;; :raw -- edit in place with no flag. Cheapest; relies on nothing.
-
-(def ^:private dirty-byte
-  "Header byte carrying the in-place-edit dirty flag. Bytes 8-19 of the 20-byte
-  header are spare (zero) and never touched by the value or its metadata."
-  8)
+;; :rename (default) -- splice writes a `.new` file and atomic-renames it (with a
+;;   parent-directory fsync), the crash-safe path konserve already uses.
+;; :checked -- edit the blob IN PLACE (no copy) but wrap it in a dirty MARKER: a
+;;   sidecar `<blob>.dirty` file is created (and the directory fsynced), the edit
+;;   is msynced, then the marker is removed. A crash mid-edit leaves the marker,
+;;   so `torn?` reports it and the caller reconstructs. O(1) detection, no value
+;;   hashing. For reproducible data.
+;; :raw -- edit in place with no marker. Cheapest; relies on nothing.
+;;
+;; THE MARKER IS A SIDECAR FILE, NOT A HEADER BYTE. konserve's header parser
+;; treats ANY nonzero byte in the 20-byte header's bytes 8-19 as the signature of
+;; a legacy 8-byte header (`storage-layout/header-not-zero-padded?`), so writing a
+;; flag there would make every ordinary `konserve.core/get` read the value from
+;; the wrong offset. The sidecar keeps the flag entirely outside the blob.
+;;
+;; CONCURRENCY. These ops take NO per-key lock, while `konserve.core` serializes
+;; writes with a `FileLock` and an in-process lock. Do NOT mix them on the same
+;; key concurrently, and do not run two in-place edits on one key at once: an
+;; in-place edit mutates live bytes, so a concurrent reader or writer can observe
+;; or clobber a half-written value. Single-writer per key is the contract; it is
+;; not enforced here.
+;;
+;; `torn?` IS A MANUAL SIGNAL. Nothing consults it automatically -- a caller using
+;; `:checked` is responsible for checking `torn?` on read and reconstructing.
 
 (defn- durability [opts] (get opts :durability :rename))
 
 (defn- in-place? [opts] (contains? #{:checked :raw} (durability opts)))
 
-(defn- write-dirty! [^String fpath ^long v]
-  (with-open [raf (RandomAccessFile. fpath "rw")]
-    (.seek raf dirty-byte)
-    (.write raf (int v))
-    (.force (.getChannel raf) true)))
+(defn- dirty-file ^String [^String fpath] (str fpath ".dirty"))
+
+(defn- set-dirty! [^String fpath]
+  (with-open [o (FileOutputStream. (dirty-file fpath))] (.getFD o))
+  (sync-dir! fpath))
+
+(defn- clear-dirty! [^String fpath]
+  (Files/deleteIfExists (path-of (dirty-file fpath)))
+  (sync-dir! fpath))
 
 (defn torn?
-  "Whether `key`'s blob is mid-edit -- an in-place `:checked` edit set the dirty
-  flag and a crash prevented it clearing. A true here means the value may be
-  half-written and should be reconstructed, not trusted. Reads one header byte."
+  "Whether `key`'s blob is mid-edit -- an in-place `:checked` edit created the
+  dirty marker and a crash prevented its removal. A true here means the value may
+  be half-written and should be reconstructed, not trusted. This is a MANUAL
+  signal: nothing checks it automatically."
   [store key]
   (let [[fpath _] (value-location store key)]
-    (with-open [in (FileInputStream. ^String fpath)]
-      (.skip in dirty-byte)
-      (= 1 (.read in)))))
+    (.exists (File. (dirty-file fpath)))))
 
 (defn- with-dirty
-  "Run `thunk` between setting and clearing the dirty flag when durability is
-  `:checked`; otherwise just run it."
+  "Run `thunk` between creating and removing the dirty marker when durability is
+  `:checked`; otherwise just run it. Guards every in-place edit under `:checked`,
+  the same-length poke included."
   [fpath opts thunk]
   (if (= :checked (durability opts))
-    (do (write-dirty! fpath 1)
-        (try (thunk) (finally (write-dirty! fpath 0))))
+    (do (set-dirty! fpath)
+        (try (thunk) (finally (clear-dirty! fpath))))
     (thunk)))
+
+(defn- read-value
+  "The value region of `fpath` (bytes from `voff` to EOF), copied out."
+  ^bytes [^String fpath ^long voff]
+  (let [blob (Files/readAllBytes (path-of fpath))]
+    (java.util.Arrays/copyOfRange blob (int voff) (alength blob))))
+
+(defn- rename-assoc!
+  "Set `path`=`v` via the crash-safe rename path (splice only the changed bytes,
+  write `.new`, atomic rename, dir fsync). Returns `v`."
+  [fpath voff path v eopts]
+  (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path v (assoc eopts :index :maintain)))
+  v)
+
+(defn- rename-update!
+  "Apply `f` at `path` via the crash-safe rename path. Returns `[old new]`."
+  [fpath voff path f eopts]
+  (let [value (read-value fpath voff)
+        old0  ((edit-fn 'value-at-path) value path eopts)
+        old   (if (= old0 edit-absent) nil old0)
+        nv    (f old)]
+    (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path nv (assoc eopts :index :maintain)))
+    [old nv]))
 
 (defn- in-place-splice!
   "Size-changing LEAF replace of `path`=`v` IN PLACE via `boring.mmap/splice!`,
-  wrapped in the dirty flag for `:checked`. Returns true, or nil when in-place is
-  not possible here (no FFM, or the framed value's index cannot be maintained) so
-  the caller can fall back to the rename path."
+  wrapped in the dirty marker for `:checked`. Returns true, or nil when in-place
+  is not possible here (no FFM, or the framed value's index cannot be maintained)
+  so the caller can fall back to the rename path."
   [fpath voff path v eopts opts]
   (when-let [splice! (resolve-mmap 'boring.mmap/splice!)]
     (try
@@ -366,57 +425,66 @@
   back to `konserve.core/assoc-in` for an ineligible blob. Synchronous; returns
   `v`.
 
-  `:durability` -- `:rename` (default, crash-safe by construction), `:checked`
-  (in-place, torn-write detectable via `torn?`, reconstruct on crash), `:raw`
-  (in-place, no flag). In-place needs FFM (JDK 22+); without it, or for a framed
-  value whose index cannot be maintained, it falls back to `:rename`."
+  `:durability` -- `:rename` (default, crash-safe by construction: NEVER mutates
+  in place, always writes `.new` + atomic rename + dir fsync, O(file)), `:checked`
+  (edits IN PLACE -- poke or splice -- guarded by a dirty marker so a crash is
+  detectable via `torn?`; reconstruct on crash), `:raw` (in place, no marker).
+  The instant same-length poke and the no-copy splice happen only under `:checked`
+  and `:raw`; `:rename` trades that speed for crash-safety by construction.
+  In-place needs FFM (JDK 22+); without it, or for a framed value whose index
+  cannot be maintained, an in-place mode falls back to a rename for that edit.
+  A structural change (new key) always renames -- it re-encodes the parent."
   ([store key-vec v] (assoc-in! store key-vec v {}))
   ([store key-vec v opts]
    (let [k (first key-vec) path (vec (rest key-vec))]
      (if-not (edit-eligible? store k)
        (do (k/assoc-in store key-vec v (assoc opts :sync? true)) v)
        (let [eopts (edit-eopts store)
-             [fpath voff] (value-location store k)
-             poke! (resolve-mmap 'boring.mmap/poke!)
-             outcome (when (and poke! (seq path))
-                       (try (poke! fpath path v (assoc eopts :offset voff)) ::poked
-                            (catch clojure.lang.ExceptionInfo e
-                              (case (:type (ex-data e))
-                                :boring/not-pokeable ::size-change
-                                :boring/path-absent  ::structural
-                                (throw e)))))]
-         (cond
-           (= outcome ::poked) v
-           ;; a leaf whose length changed: in place when allowed, else rename
-           (and (= outcome ::size-change) (in-place? opts)
-                (in-place-splice! fpath voff path v eopts opts)) v
-           :else (do (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path v (assoc eopts :index :maintain)))
-                     v)))))))
+             [fpath voff] (value-location store k)]
+         (if-not (in-place? opts)
+           ;; :rename -- always the crash-safe rename path, no in-place mutation
+           (rename-assoc! fpath voff path v eopts)
+           ;; :checked / :raw -- poke (marker-wrapped for :checked), then splice
+           (let [poke! (resolve-mmap 'boring.mmap/poke!)
+                 outcome (when (and poke! (seq path))
+                           (try (with-dirty fpath opts
+                                            #(poke! fpath path v (assoc eopts :offset voff)))
+                                ::poked
+                                (catch clojure.lang.ExceptionInfo e
+                                  (case (:type (ex-data e))
+                                    :boring/not-pokeable ::size-change
+                                    :boring/path-absent  ::structural
+                                    (throw e)))))]
+             (cond
+               (= outcome ::poked) v
+               (and (= outcome ::size-change) (in-place-splice! fpath voff path v eopts opts)) v
+               :else (rename-assoc! fpath voff path v eopts)))))))))
 
 (defn update-in!
-  "Apply `f` to the value at `key-vec` = `[store-key & path]`, poking in place
-  when `(f old)` is the same length else splicing. Falls back to
-  `konserve.core/update-in` for an ineligible blob or an empty path.
-  Synchronous; returns `[old new]`."
+  "Apply `f` to the value at `key-vec` = `[store-key & path]`. Under `:checked`/
+  `:raw` a same-length result is poked in place (marker-wrapped for `:checked`);
+  every other case, and all of `:rename`, takes the crash-safe rename path. Falls
+  back to `konserve.core/update-in` for an ineligible blob or an empty path.
+  Synchronous; returns `[old new]`.
+
+  NOTE: on a size-changing result under `:checked`/`:raw`, `f` runs twice -- once
+  by the in-place poke probe and once by the rename path. Keep `f` pure."
   ([store key-vec f] (update-in! store key-vec f {}))
   ([store key-vec f opts]
    (let [k (first key-vec) path (vec (rest key-vec))]
      (if (or (empty? path) (not (edit-eligible? store k)))
        (k/update-in store key-vec f (assoc opts :sync? true))
        (let [eopts (edit-eopts store)
-             [fpath voff] (value-location store k)
-             poke-update! (resolve-mmap 'boring.mmap/poke-update!)]
-         (or (when poke-update!
-               (try (poke-update! fpath path f (assoc eopts :offset voff))
-                    (catch clojure.lang.ExceptionInfo e
-                      (if (recoverable-poke-miss? e) nil (throw e)))))
-             (let [value (Files/readAllBytes (path-of fpath))
-                   value (java.util.Arrays/copyOfRange value (int voff) (alength value))
-                   old0  ((edit-fn 'value-at-path) value path eopts)
-                   old   (if (= old0 edit-absent) nil old0)
-                   nv    (f old)]
-               (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path nv (assoc eopts :index :maintain)))
-               [old nv])))))))
+             [fpath voff] (value-location store k)]
+         (if-not (in-place? opts)
+           (rename-update! fpath voff path f eopts)
+           (let [poke-update! (resolve-mmap 'boring.mmap/poke-update!)]
+             (or (when poke-update!
+                   (try (with-dirty fpath opts
+                                    #(poke-update! fpath path f (assoc eopts :offset voff)))
+                        (catch clojure.lang.ExceptionInfo e
+                          (if (recoverable-poke-miss? e) nil (throw e)))))
+                 (rename-update! fpath voff path f eopts)))))))))
 
 (defn dissoc-in!
   "Remove the nested key at the end of `key-vec` = `[store-key & path]`, splicing

--- a/src/konserve/mmap.clj
+++ b/src/konserve/mmap.clj
@@ -54,7 +54,7 @@
             [konserve.impl.defaults :refer [key->store-key]]
             [konserve.impl.storage-layout :refer [header-size]]
             [konserve.serializers :as ser])
-  (:import [java.io File FileInputStream FileOutputStream]
+  (:import [java.io File FileInputStream FileOutputStream RandomAccessFile]
            [java.nio.file Files Path StandardCopyOption CopyOption]))
 
 (def ^:private boring-serializer-byte
@@ -298,11 +298,78 @@
 (defn- recoverable-poke-miss? [e]
   (contains? #{:boring/not-pokeable :boring/path-absent} (:type (ex-data e))))
 
+;; ---- durability -----------------------------------------------------------
+;;
+;; :rename (default) -- splice writes a `.new` file and atomic-renames it, the
+;;   crash-safe path konserve already uses.
+;; :checked -- edit the blob IN PLACE (no copy) but wrap it in a dirty flag: set
+;;   it, msync, do the edit, msync, clear it, msync. A crash mid-edit leaves the
+;;   flag set, so `torn?` reports it and the caller reconstructs. O(1) detection,
+;;   no value hashing. For reproducible data.
+;; :raw -- edit in place with no flag. Cheapest; relies on nothing.
+
+(def ^:private dirty-byte
+  "Header byte carrying the in-place-edit dirty flag. Bytes 8-19 of the 20-byte
+  header are spare (zero) and never touched by the value or its metadata."
+  8)
+
+(defn- durability [opts] (get opts :durability :rename))
+
+(defn- in-place? [opts] (contains? #{:checked :raw} (durability opts)))
+
+(defn- write-dirty! [^String fpath ^long v]
+  (with-open [raf (RandomAccessFile. fpath "rw")]
+    (.seek raf dirty-byte)
+    (.write raf (int v))
+    (.force (.getChannel raf) true)))
+
+(defn torn?
+  "Whether `key`'s blob is mid-edit -- an in-place `:checked` edit set the dirty
+  flag and a crash prevented it clearing. A true here means the value may be
+  half-written and should be reconstructed, not trusted. Reads one header byte."
+  [store key]
+  (let [[fpath _] (value-location store key)]
+    (with-open [in (FileInputStream. ^String fpath)]
+      (.skip in dirty-byte)
+      (= 1 (.read in)))))
+
+(defn- with-dirty
+  "Run `thunk` between setting and clearing the dirty flag when durability is
+  `:checked`; otherwise just run it."
+  [fpath opts thunk]
+  (if (= :checked (durability opts))
+    (do (write-dirty! fpath 1)
+        (try (thunk) (finally (write-dirty! fpath 0))))
+    (thunk)))
+
+(defn- in-place-splice!
+  "Size-changing LEAF replace of `path`=`v` IN PLACE via `boring.mmap/splice!`,
+  wrapped in the dirty flag for `:checked`. Returns true, or nil when in-place is
+  not possible here (no FFM, or the framed value's index cannot be maintained) so
+  the caller can fall back to the rename path."
+  [fpath voff path v eopts opts]
+  (when-let [splice! (resolve-mmap 'boring.mmap/splice!)]
+    (try
+      (with-dirty fpath opts #(splice! fpath path v (assoc eopts :offset voff)))
+      true
+      (catch clojure.lang.ExceptionInfo e
+        (when-not (= :boring/unmaintainable-index (:type (ex-data e)))
+          (throw e))
+        nil))))
+
 (defn assoc-in!
-  "Set the value at `key-vec` = `[store-key & path]` to `v`, editing the blob in
-  place (same-length poke via mmap) or by splicing only the changed bytes
-  (crash-safe rename), never decoding the whole value. Falls back to
-  `konserve.core/assoc-in` for an ineligible blob. Synchronous; returns `v`."
+  "Set the value at `key-vec` = `[store-key & path]` to `v`, editing the blob
+  without decoding the whole value. A same-length change is poked in place; a
+  size-changing LEAF change is spliced -- in place (no copy) when `:durability`
+  is `:checked` or `:raw`, else via a crash-safe `.new` + atomic rename; and a
+  structural change (a new key) re-encodes only the parent and renames. Falls
+  back to `konserve.core/assoc-in` for an ineligible blob. Synchronous; returns
+  `v`.
+
+  `:durability` -- `:rename` (default, crash-safe by construction), `:checked`
+  (in-place, torn-write detectable via `torn?`, reconstruct on crash), `:raw`
+  (in-place, no flag). In-place needs FFM (JDK 22+); without it, or for a framed
+  value whose index cannot be maintained, it falls back to `:rename`."
   ([store key-vec v] (assoc-in! store key-vec v {}))
   ([store key-vec v opts]
    (let [k (first key-vec) path (vec (rest key-vec))]
@@ -310,12 +377,21 @@
        (do (k/assoc-in store key-vec v (assoc opts :sync? true)) v)
        (let [eopts (edit-eopts store)
              [fpath voff] (value-location store k)
-             poke! (resolve-mmap 'boring.mmap/poke!)]
-         (or (when (and poke! (seq path))
-               (try (poke! fpath path v (assoc eopts :offset voff)) v
-                    (catch clojure.lang.ExceptionInfo e
-                      (if (recoverable-poke-miss? e) nil (throw e)))))
-             (do (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path v eopts)) v)))))))
+             poke! (resolve-mmap 'boring.mmap/poke!)
+             outcome (when (and poke! (seq path))
+                       (try (poke! fpath path v (assoc eopts :offset voff)) ::poked
+                            (catch clojure.lang.ExceptionInfo e
+                              (case (:type (ex-data e))
+                                :boring/not-pokeable ::size-change
+                                :boring/path-absent  ::structural
+                                (throw e)))))]
+         (cond
+           (= outcome ::poked) v
+           ;; a leaf whose length changed: in place when allowed, else rename
+           (and (= outcome ::size-change) (in-place? opts)
+                (in-place-splice! fpath voff path v eopts opts)) v
+           :else (do (splice-write! fpath voff #((edit-fn 'assoc-in-bytes) % path v eopts))
+                     v)))))))
 
 (defn update-in!
   "Apply `f` to the value at `key-vec` = `[store-key & path]`, poking in place

--- a/src/konserve/mmap.clj
+++ b/src/konserve/mmap.clj
@@ -455,27 +455,27 @@
      (if-not (edit-eligible? store k)
        (do (k/assoc-in store key-vec v (assoc opts :sync? true)) v)
        (locked-edit store k opts
-        (fn []
-          (let [eopts (edit-eopts store)
-                [fpath voff] (value-location store k)]
-            (if-not (in-place? opts)
+                    (fn []
+                      (let [eopts (edit-eopts store)
+                            [fpath voff] (value-location store k)]
+                        (if-not (in-place? opts)
               ;; :rename -- always the crash-safe rename path, no in-place mutation
-              (rename-assoc! fpath voff path v eopts)
+                          (rename-assoc! fpath voff path v eopts)
               ;; :checked / :raw -- poke (marker-wrapped for :checked), then splice
-              (let [poke! (resolve-mmap 'boring.mmap/poke!)
-                    outcome (when (and poke! (seq path))
-                              (try (with-dirty fpath opts
-                                               #(poke! fpath path v (assoc eopts :offset voff)))
-                                   ::poked
-                                   (catch clojure.lang.ExceptionInfo e
-                                     (case (:type (ex-data e))
-                                       :boring/not-pokeable ::size-change
-                                       :boring/path-absent  ::structural
-                                       (throw e)))))]
-                (cond
-                  (= outcome ::poked) v
-                  (and (= outcome ::size-change) (in-place-splice! fpath voff path v eopts opts)) v
-                  :else (rename-assoc! fpath voff path v eopts)))))))))))
+                          (let [poke! (resolve-mmap 'boring.mmap/poke!)
+                                outcome (when (and poke! (seq path))
+                                          (try (with-dirty fpath opts
+                                                 #(poke! fpath path v (assoc eopts :offset voff)))
+                                               ::poked
+                                               (catch clojure.lang.ExceptionInfo e
+                                                 (case (:type (ex-data e))
+                                                   :boring/not-pokeable ::size-change
+                                                   :boring/path-absent  ::structural
+                                                   (throw e)))))]
+                            (cond
+                              (= outcome ::poked) v
+                              (and (= outcome ::size-change) (in-place-splice! fpath voff path v eopts opts)) v
+                              :else (rename-assoc! fpath voff path v eopts)))))))))))
 
 (defn update-in!
   "Apply `f` to the value at `key-vec` = `[store-key & path]`. Under `:checked`/
@@ -492,18 +492,18 @@
      (if (or (empty? path) (not (edit-eligible? store k)))
        (k/update-in store key-vec f (assoc opts :sync? true))
        (locked-edit store k opts
-        (fn []
-          (let [eopts (edit-eopts store)
-                [fpath voff] (value-location store k)]
-            (if-not (in-place? opts)
-              (rename-update! fpath voff path f eopts)
-              (let [poke-update! (resolve-mmap 'boring.mmap/poke-update!)]
-                (or (when poke-update!
-                      (try (with-dirty fpath opts
-                                       #(poke-update! fpath path f (assoc eopts :offset voff)))
-                           (catch clojure.lang.ExceptionInfo e
-                             (if (recoverable-poke-miss? e) nil (throw e)))))
-                    (rename-update! fpath voff path f eopts)))))))))))
+                    (fn []
+                      (let [eopts (edit-eopts store)
+                            [fpath voff] (value-location store k)]
+                        (if-not (in-place? opts)
+                          (rename-update! fpath voff path f eopts)
+                          (let [poke-update! (resolve-mmap 'boring.mmap/poke-update!)]
+                            (or (when poke-update!
+                                  (try (with-dirty fpath opts
+                                         #(poke-update! fpath path f (assoc eopts :offset voff)))
+                                       (catch clojure.lang.ExceptionInfo e
+                                         (if (recoverable-poke-miss? e) nil (throw e)))))
+                                (rename-update! fpath voff path f eopts)))))))))))
 
 (defn dissoc-in!
   "Remove the nested key at the end of `key-vec` = `[store-key & path]`, splicing
@@ -521,7 +521,7 @@
                         #(dissoc % (last path)) (assoc opts :sync? true))
            true)
        (locked-edit store k opts
-        (fn []
-          (let [eopts (edit-eopts store)
-                [fpath voff] (value-location store k)]
-            (splice-write! fpath voff #((edit-fn 'dissoc-in-bytes) % path (assoc eopts :index :maintain))))))))))
+                    (fn []
+                      (let [eopts (edit-eopts store)
+                            [fpath voff] (value-location store k)]
+                        (splice-write! fpath voff #((edit-fn 'dissoc-in-bytes) % path (assoc eopts :index :maintain))))))))))


### PR DESCRIPTION
Builds on the boring in-place edit API (boring 0.1.25). Extends `konserve.mmap` —
today a read-only navigator over a filestore value — with high-level **writes**
that edit a value without decoding the whole thing.

## What

`update-in!` / `assoc-in!` / `dissoc-in!` on a filestore value whose blob was
written by the boring serializer. A same-length change is poked in place; a
size-changing leaf change is spliced; a structural change re-encodes only the
parent. An **ineligible blob** — not boring, compressed, encrypted, or
stringref-wrapped — falls back to the ordinary `konserve.core` op, so dispatch is
always safe: worst case is a correct answer at full cost.

```clojure
(require '[konserve.mmap :as kmm])
(kmm/update-in! store [:doc :section :field] inc {:durability :checked})
```

## Durability modes

- **`:rename`** (default) — never mutates in place; writes `.new` + atomic rename
  + directory fsync. Crash-safe by construction, O(file). Even here it skips the
  decode/encode object graph and maintains the index instead of rebuilding it.
- **`:checked`** — edits in place (no copy), guarded by a sidecar `<blob>.dirty`
  marker so a crash is detectable via `torn?` and the value reconstructed. O(dirty
  pages).
- **`:raw`** — in place, no marker. Cheapest.

The marker is a sidecar file, deliberately **not** a header byte: konserve's
header parser treats any nonzero byte in the 20-byte header's bytes 8–19 as a
legacy-header signature, so a flag there would corrupt ordinary reads.

## Concurrency

Write ops take the store/key **in-process lock** (`konserve.core/locked`) by
default — the same lock `konserve.core` writes use — so an mmap edit serialises
against ordinary konserve writes and other mmap edits. ~1 µs uncontended;
`:lock? false` opts out. Reads (`with-mmap-value`) stay lock-free (inode
snapshot; the default `:rename` never mutates in place).

## Requirements & measurements

Needs a store configured with a deterministic, stringref-off boring profile
(`:archival`) keyed by `:BoringSerializer` — see the ns comment. On a 33.8 MB
value, `:checked` in-place is 70–360× a `konserve.core/update-in`; the poke path
is position-independent (~ms regardless of file size).

## Review

Two independent review passes on the boring engine (all findings fixed there) and
one on this wiring — findings addressed: the header-byte dirty flag → sidecar
file, `edit-eopts` carries the serializer `:registry`, `:rename` fsyncs the
directory, `:rename` never mutates in place, `:checked` guards the poke path, and
per-key locking. Functionally verified end-to-end against released boring 0.1.25,
including 40 concurrent increments landing exactly 40.

## Status

`konserve.mmap` is EXPERIMENTAL and filestore-only. `boring.mmap` needs JDK 22+
(FFM); without it, in-place modes fall back to `:rename`, which needs nothing.
No CI test namespace yet — the ops are exercised via the REPL against a real
store; a guarded test suite is a sensible follow-up.