### PR TITLE
Conditional writes: an explicit revision, a refused option, and a domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable, user-visible changes to konserve are documented here.
   only if the stored revision is still that one, and otherwise raises
   `{:type :konserve/revision-mismatch}` having written nothing and — for
   `update-in` — WITHOUT running `up-fn`. Pass
-  `konserve.impl.defaults/absent` to mean "only if this key does not exist".
+  `konserve.core/absent` to mean "only if this key does not exist".
   `:with-revision? true` reports the revision a read saw or a write produced, so
   a fencing caller can chain writes without a re-read; on a read it returns
   `[value revision]`, on a write `[[old new] revision]`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,15 @@ All notable, user-visible changes to konserve are documented here.
   (previously `memory-store-delete` *asserted* the broken behaviour).
 
 ### Changed
+- **A fenced key carries a sidecar lock file (`<key>.cas`).** It exists because
+  konserve replaces a value by renaming a new file over it, which orphans a lock
+  taken on the old one; the sidecar is never renamed, so it is a stable thing to
+  lock. Every write to a key that has one takes it, so the fence excludes
+  unconditional writers too — without that it would grant a false pass and lose
+  their write. A key gets a sidecar the first time a conditional write or a
+  revision-bearing read touches it, so keys that are never fenced cost one
+  existence probe and no extra file. Backends that filter their own key
+  enumeration must skip this suffix (see `konserve.impl.defaults/internal-artifact?`).
 - **Every value's metadata now carries a `:revision`.** It is what
   `:expected-revision` compares and what `konserve.core/revision` returns — an
   OPAQUE token, minted per write, to be passed back rather than interpreted. It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable, user-visible changes to konserve are documented here.
 ## Unreleased
 
 ### Added
+- **Conditional writes (`:expected-revision`), with an explicit capability.** A
+  write can now be made conditional on the revision the caller read: it lands
+  only if the stored revision is still that one, and otherwise raises
+  `{:type :konserve/revision-mismatch}` having written nothing and — for
+  `update-in` — WITHOUT running `up-fn`. Pass
+  `konserve.impl.defaults/absent` to mean "only if this key does not exist".
+  `:with-revision? true` reports the revision a read saw or a write produced, so
+  a fencing caller can chain writes without a re-read; on a read it returns
+  `[value revision]`, on a write `[[old new] revision]`.
+
+  The capability is EXPLICIT and a store that lacks it REFUSES rather than
+  ignoring the option — silently degrading to an unconditional write is worse
+  than having no fencing, because the caller asked for a guarantee and got a knob
+  that reads as handled. `conditional-write-domain` reports how far a store's
+  guarantee reaches (`:process`, `:machine`, `:global`) rather than a boolean,
+  since the API is uniform and the guarantee is not: `true` would let someone
+  running two processes against a memory store, or two machines against a
+  filestore, believe they were fenced when they were only serialized against a
+  narrower set of writers. `conditional-write?` compares against a domain you
+  need. Backed by `konserve.compliance-test/conditional-write-compliance-test`,
+  which any backend can call — a store without the capability passes it by
+  refusing.
 - **Simulation testing harness** (`konserve.simulation.backing`, `.crash`,
   `.memory`). A fault-injecting wrapper around any `PBackingStore` (19
   per-operation error and corruption rates, seeded from a `SplittableRandom` so
@@ -141,6 +163,14 @@ All notable, user-visible changes to konserve are documented here.
   (previously `memory-store-delete` *asserted* the broken behaviour).
 
 ### Changed
+- **Every value's metadata now carries a `:revision`.** It is what
+  `:expected-revision` compares and what `konserve.core/revision` returns — an
+  OPAQUE token, minted per write, to be passed back rather than interpreted. It
+  is deliberately not `:last-write`: that clock is non-decreasing and admits
+  same-millisecond ties, so two writes could share one value and a fence built on
+  it would pass when it should fail. The visible consequence is that metadata
+  maps have one more key, so a test or tool comparing them whole (`k/keys`,
+  `get-meta`) should strip `:revision` alongside `:last-write`.
 - **Probe-elision now covers non-overwrite writes, not only reads.** On a
   `PReadMissSafe` backing, `update-in` / `update` / nested `assoc-in` / `bassoc`
   read the old value *read-first* (an absent key → a fresh write) instead of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,13 @@ All notable, user-visible changes to konserve are documented here.
   revision-bearing read touches it, so keys that are never fenced cost one
   existence probe and no extra file. Backends that filter their own key
   enumeration must skip this suffix (see `konserve.impl.defaults/internal-artifact?`).
+- **Fencing orders the writers that participate.** Conditional writes are
+  optimistic concurrency control: a writer that writes unconditionally overwrites
+  whatever is there, here as on S3 or against a row-version column. Fencing a key
+  means every writer to it fences. Konserve does go further than that where it
+  can — once a key has a sidecar, unconditional writers take its lock too — but a
+  deployment that mixes fenced and unfenced writers to one key is not protected
+  by any of this, and should not be read as if it were.
 - **Every value's metadata now carries a `:revision`.** It is what
   `:expected-revision` compares and what `konserve.core/revision` returns — an
   OPAQUE token, minted per write, to be passed back rather than interpreted. It

--- a/doc/backend.org
+++ b/doc/backend.org
@@ -269,6 +269,55 @@
    your store allows atomic transactions over both objects, e.g. using two
    columns in a SQL database.
 
+** Conditional writes
+   :PROPERTIES:
+   :CUSTOM_ID: h:1f4a0c62-3b7a-4f0e-9a5a-7a6c0d2b41e2
+   :END:
+   A write can be made conditional on the revision the caller read
+   (=:expected-revision=), so that concurrent writers cannot silently overwrite
+   each other. Implementing this is OPTIONAL, and a store that does not
+   implement it REFUSES the option rather than ignoring it — silently degrading
+   to an unconditional write is worse than having no fencing at all, because the
+   caller asked for a guarantee and got a knob that reads as handled.
+
+   To offer it, implement =PConditionalWrite/-conditional-write-domain= and
+   return how far your guarantee actually reaches:
+
+   - =:process= — atomic against other threads in this runtime.
+   - =:machine= — atomic against other processes on this host.
+   - =:global=  — atomic against every writer anywhere.
+
+   Return a DOMAIN and not a boolean, and return the one you can actually
+   defend. A caller planning two processes against a =:process= store, or two
+   machines against a =:machine= one, would otherwise believe it was fenced when
+   it was only serialized against a narrower set of writers.
+
+   *What the domain claims is a mechanism.* If you build on
+   =konserve.impl.defaults= you inherit its compare-and-write, which reads the
+   stored revision and writes under a local lock: that reaches =:machine= at
+   best, never =:global=. To claim =:global= your storage layer itself must
+   evaluate the precondition — konserve-s3 uses a conditional PUT (=If-Match= on
+   the object's ETag), which S3 evaluates.
+
+   *If you inherit the default backing*, note that a fenced key gets a sidecar
+   blob named =<store-key>.cas=. The lock lives there because konserve replaces
+   a value by renaming a new blob over it, which orphans a lock taken on the old
+   one; the sidecar is never renamed. It PERSISTS, so if your backend filters
+   its own key enumeration, skip that suffix — see
+   =konserve.impl.defaults/internal-artifact?=. A backend that enumerates it as
+   a key will hand it to =-handle-foreign-key=, i.e. the old-layout migration
+   path, and =k/keys= will throw from the first conditional write onwards.
+
+   *Verify the claim.* =konserve.compliance-test/conditional-write-compliance-test=
+   is the contract, and a store without the capability passes it by refusing;
+   =async-conditional-write-compliance-test= is the same contract for async-only
+   backends. Call one of them from your suite. The contract catches a backend
+   that declares a domain and does not implement the option — there is a test in
+   konserve that proves it does — but no single-process test can witness a
+   =:global= claim, which is an assertion about atomicity across machines. That
+   part rests on your storage layer, so claim it only if the storage layer is
+   what evaluates the precondition.
+
 * Migration
   :PROPERTIES:
   :CUSTOM_ID: h:6cd7020b-f14d-4feb-96b3-1db67c5cb7cb

--- a/doc/backend.org
+++ b/doc/backend.org
@@ -292,6 +292,22 @@
    machines against a =:machine= one, would otherwise believe it was fenced when
    it was only serialized against a narrower set of writers.
 
+   *Say WHO evaluates the condition, separately from how far it reaches.* If your
+   storage layer evaluates it — a conditional PUT, =UPDATE ... WHERE revision = ?=,
+   a =ConditionExpression=, a write transaction — also implement the marker
+   protocol =PSelfConditionalWrite=. It has no methods; implementing it is the
+   statement. konserve then provides no mechanism of its own: no sidecar blob, no
+   lock, and =:lock-blob?= cannot revoke your claim.
+
+   Reach and mechanism are independent, which is why this is declared and not
+   inferred. konserve once read =:process=/=:machine= as "wants konserve's lock"
+   and =:global= as "fences itself" — sound in one direction only, since plenty of
+   stores fence themselves without reaching across machines: RocksDB with a write
+   batch (=:process=), LMDB with an ACID transaction (=:machine=), and a JDBC
+   backend with one statement that is =:global= on Postgres and =:machine= on
+   SQLite. Inferring would have handed konserve's sidecar to each of them, writing
+   a phantom =.cas= row into the very table being fenced.
+
    *What the domain claims is a mechanism.* If you build on
    =konserve.impl.defaults= you inherit its compare-and-write, which reads the
    stored revision and writes under a local lock: that reaches =:machine= at

--- a/doc/backend.org
+++ b/doc/backend.org
@@ -308,6 +308,29 @@
    a key will hand it to =-handle-foreign-key=, i.e. the old-layout migration
    path, and =k/keys= will throw from the first conditional write onwards.
 
+   *Prefer your own storage layer to the sidecar.* The sidecar is the
+   FILESYSTEM's fallback, not the general design: POSIX has no
+   compare-and-rename, so konserve has to build atomicity out of a lock, and the
+   lock cannot live on the value because the write path renames a new blob over
+   it. A remote or transactional store has none of that problem and a native
+   conditional operation that costs NO extra round trips, where inheriting the
+   sidecar would cost two per write — and give a weaker guarantee than the store
+   already offers:
+
+   - SQL — =UPDATE ... WHERE revision = ?=, and check the row count
+   - Redis — =WATCH= / =MULTI=, or a Lua script
+   - DynamoDB — a =ConditionExpression=
+   - Google Cloud Storage — =x-goog-if-generation-match=
+   - S3 — =If-Match= on the ETag (see konserve-s3)
+
+   So implement the comparison where your storage evaluates it, and declare the
+   reach that gives you. Only declare =:process= or =:machine= if konserve's own
+   lock genuinely IS your mechanism — the sidecar work is gated on that, so a
+   backend which declares nothing, or which declares =:global=, pays for none of
+   it. Measured on a backing that declares no domain: a write costs exactly the
+   blob operations it always did, with no sidecar create and no extra existence
+   probe.
+
    *Verify the claim.* =konserve.compliance-test/conditional-write-compliance-test=
    is the contract, and a store without the capability passes it by refusing;
    =async-conditional-write-compliance-test= is the same contract for async-only

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,4 +1,11 @@
-{:deps {:aliases [:cljs]}
+{
+ ;; The cljs analyzer recurses deeply through `io-operation`'s go-block
+ ;; macroexpansion and overflows the default thread stack. It surfaces as a bare
+ ;; "null" compile error pointing at the `go-try-`, which reads like a syntax
+ ;; problem and is not one — CI has a larger default and compiles fine, so this
+ ;; only ever bites locally.
+ :jvm-opts ["-Xss32m"]
+:deps {:aliases [:cljs]}
  :dev-http {8021 "out/browser-tests"}
  :builds
  {:app

--- a/src/konserve/cache.cljc
+++ b/src/konserve/cache.cljc
@@ -99,7 +99,13 @@
 
 (defn get-in
   "Returns the value stored described by key-vec or nil if the path is
-  not resolvable."
+  not resolvable.
+
+   `:with-revision?` is REFUSED here: a cached value carries no revision, so the
+   only answers available are to invent one or to silently miss the cache, and a
+   revision that is sometimes real and sometimes invented is worse than none —
+   it is the token a caller fences on. Use `konserve.core/get` on the same store,
+   which does not read through the cache. Conditional WRITES are supported."
   ([store key-vec]
    (get-in store key-vec nil))
   ([store key-vec not-found]
@@ -119,7 +125,9 @@
 
 (defn get
   "Returns the value stored described by key. Returns nil if the key
-   is not present, or the not-found value if supplied."
+   is not present, or the not-found value if supplied.
+
+   See [[get-in]] on `:with-revision?`, which a cached read cannot answer."
   ([store key]
    (get store key nil))
   ([store key not-found]
@@ -136,7 +144,7 @@
    (update-in store key-vec up-fn {:sync? false}))
   ([store key-vec up-fn opts]
    (log/trace :konserve/cache-update-in {:key-vec key-vec})
-   (core/check-conditional-supported!* store opts)
+   (core/check-conditional-supported! store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
@@ -177,7 +185,7 @@
    (assoc-in store key-vec val {:sync? false}))
   ([store key-vec val opts]
    (log/trace :konserve/cache-assoc-in {:key-vec key-vec})
-   (core/check-conditional-supported!* store opts)
+   (core/check-conditional-supported! store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
@@ -205,7 +213,7 @@
    (assoc store key val {:sync? false}))
   ([store key val opts]
    (log/trace :konserve/cache-assoc {:key key})
-   (core/check-conditional-supported!* store opts)
+   (core/check-conditional-supported! store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked

--- a/src/konserve/cache.cljc
+++ b/src/konserve/cache.cljc
@@ -54,6 +54,22 @@
 (defn- revision-result [old-val new-val revision opts]
   (if (:with-revision? opts) [[old-val new-val] revision] [old-val new-val]))
 
+(defn- evict-on-conflict!
+  "Drop `key` from the cache when `e` is a revision mismatch, then rethrow.
+
+   A mismatch is PROOF that the key moved under us, so it is the one moment the
+   cached value is known to be wrong — and it was the one moment nothing was
+   evicted, because the eviction sits after the write and a rejection propagates
+   first. A read-then-CAS retry loop over this namespace could never converge: it
+   re-read the same stale value from the cache and rebuilt the same doomed write.
+
+   Takes the throwable rather than a thunk: the write parks on `<?-`, which is
+   what raises, and a parking take cannot live inside a nested fn in a go block."
+  [cache key e]
+  (when (= :konserve/revision-mismatch (:type (ex-data e)))
+    (swap! cache cache/evict key))
+  (throw e))
+
 (defn- read-through [store key opts]
   (async+sync
    (:sync? opts)
@@ -128,7 +144,9 @@
                 (let [cache (:cache store)
                       key (first key-vec)
                       [[old-val new-val] revision] (split-revision
-                                                    (<?- (-update-in store key-vec (partial meta-update (first key-vec) :edn) up-fn opts))
+                                                    (try (<?- (-update-in store key-vec (partial meta-update (first key-vec) :edn) up-fn opts))
+                                                         (catch #?(:clj Exception :cljs js/Error) e
+                                                           (evict-on-conflict! cache key e)))
                                                     opts)
                       had-key? (cache/has? @cache key)]
                   (swap! cache cache/evict key)
@@ -167,7 +185,9 @@
                 (let [cache (:cache store)
                       key (first key-vec)
                       [[old-val new-val] revision] (split-revision
-                                                    (<?- (-assoc-in store key-vec (partial meta-update key :edn) val opts))
+                                                    (try (<?- (-assoc-in store key-vec (partial meta-update key :edn) val opts))
+                                                         (catch #?(:clj Exception :cljs js/Error) e
+                                                           (evict-on-conflict! cache key e)))
                                                     opts)
                       had-key? (cache/has? @cache key)]
                   (swap! cache cache/evict key)
@@ -195,7 +215,9 @@
                 ;; consumers see the same op label as the non-cache API.
                 (let [cache (:cache store)
                       [[old-val new-val] revision] (split-revision
-                                                    (<?- (-assoc-in store [key] (partial meta-update key :edn) val opts))
+                                                    (try (<?- (-assoc-in store [key] (partial meta-update key :edn) val opts))
+                                                         (catch #?(:clj Exception :cljs js/Error) e
+                                                           (evict-on-conflict! cache key e)))
                                                     opts)
                       had-key? (cache/has? @cache key)]
                   (swap! cache cache/evict key)
@@ -212,6 +234,10 @@
    (dissoc store key {:sync? false}))
   ([store key opts]
    (log/trace :konserve/cache-dissoc {:key key})
+   ;; `konserve.core/dissoc` refuses this; the cached twin silently DELETED the
+   ;; key instead — verbatim the failure the capability exists to remove, and
+   ;; reachable by anyone who wraps their store in a cache.
+   (core/refuse-conditional-unsupported! "dissoc" opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked

--- a/src/konserve/cache.cljc
+++ b/src/konserve/cache.cljc
@@ -89,6 +89,7 @@
    (update-in store key-vec up-fn {:sync? false}))
   ([store key-vec up-fn opts]
    (log/trace :konserve/cache-update-in {:key-vec key-vec})
+   (core/check-conditional-supported!* store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
@@ -125,6 +126,7 @@
    (assoc-in store key-vec val {:sync? false}))
   ([store key-vec val opts]
    (log/trace :konserve/cache-assoc-in {:key-vec key-vec})
+   (core/check-conditional-supported!* store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
@@ -148,6 +150,7 @@
    (assoc store key val {:sync? false}))
   ([store key val opts]
    (log/trace :konserve/cache-assoc {:key key})
+   (core/check-conditional-supported!* store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked

--- a/src/konserve/cache.cljc
+++ b/src/konserve/cache.cljc
@@ -24,6 +24,36 @@
   ([store cache]
    (clojure.core/assoc store :cache cache)))
 
+(defn- refuse-revision-read!
+  "A cached read cannot report a revision, so it says so instead of guessing.
+
+   A cache HIT has no revision — only the value was stored — so the only answers
+   available are to invent one or to silently miss the cache, and a revision that
+   is sometimes real and sometimes invented is worse than no revision at all: it
+   is the token a caller fences on. `konserve.core/get` takes the same store and
+   does not consult the cache, which is the right call for a fencing read."
+  [opts]
+  (when (:with-revision? opts)
+    (throw (ex-info (str ":with-revision? is not supported on a cached read — a cached value carries "
+                         "no revision. Use konserve.core/get on the same store, which does not read "
+                         "through the cache.")
+                    {:type :konserve/with-revision-unsupported-on-cache}))))
+
+(defn- split-revision
+  "konserve answers a write with `[old new]`, or with `[[old new] revision]` when
+   the caller asked `:with-revision? true`. Normalise to `[[old new] revision]`.
+
+   Without this the cache destructured the revision-bearing shape as if it were
+   the plain one, so `old-val` became `[old new]` and `new-val` became the
+   REVISION — which was then written into the cache as the key's value. Every
+   later cached read of that key returned a revision token where the caller
+   expected their data."
+  [res opts]
+  (if (:with-revision? opts) res [res nil]))
+
+(defn- revision-result [old-val new-val revision opts]
+  (if (:with-revision? opts) [[old-val new-val] revision] [old-val new-val]))
+
 (defn- read-through [store key opts]
   (async+sync
    (:sync? opts)
@@ -60,6 +90,7 @@
    (get-in store key-vec not-found {:sync? false}))
   ([store key-vec not-found opts]
    (log/trace :konserve/cache-get-in {:key-vec key-vec})
+   (refuse-revision-read! opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
@@ -96,7 +127,9 @@
                 store (first key-vec)
                 (let [cache (:cache store)
                       key (first key-vec)
-                      [old-val new-val] (<?- (-update-in store key-vec (partial meta-update (first key-vec) :edn) up-fn opts))
+                      [[old-val new-val] revision] (split-revision
+                                                    (<?- (-update-in store key-vec (partial meta-update (first key-vec) :edn) up-fn opts))
+                                                    opts)
                       had-key? (cache/has? @cache key)]
                   (swap! cache cache/evict key)
                   (when had-key?
@@ -106,7 +139,7 @@
                                               :key-vec key-vec
                                               :old-value old-val
                                               :value new-val})
-                  [old-val new-val])))))
+                  (revision-result old-val new-val revision opts))))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn update
@@ -133,7 +166,9 @@
                 store (first key-vec)
                 (let [cache (:cache store)
                       key (first key-vec)
-                      [old-val new-val] (<?- (-assoc-in store key-vec (partial meta-update key :edn) val opts))
+                      [[old-val new-val] revision] (split-revision
+                                                    (<?- (-assoc-in store key-vec (partial meta-update key :edn) val opts))
+                                                    opts)
                       had-key? (cache/has? @cache key)]
                   (swap! cache cache/evict key)
                   (when had-key?
@@ -142,7 +177,7 @@
                                               :key key
                                               :key-vec key-vec
                                               :value val})
-                  [old-val new-val])))))
+                  (revision-result old-val new-val revision opts))))))
 
 (defn assoc
   "Associates the key to the value. This is a simple top-level overwrite."
@@ -159,7 +194,9 @@
                 ;; :assoc-in we'd inherit by delegating to assoc-in — so hook
                 ;; consumers see the same op label as the non-cache API.
                 (let [cache (:cache store)
-                      [old-val new-val] (<?- (-assoc-in store [key] (partial meta-update key :edn) val opts))
+                      [[old-val new-val] revision] (split-revision
+                                                    (<?- (-assoc-in store [key] (partial meta-update key :edn) val opts))
+                                                    opts)
                       had-key? (cache/has? @cache key)]
                   (swap! cache cache/evict key)
                   (when had-key?
@@ -167,7 +204,7 @@
                   (invoke-write-hooks! store {:api-op :assoc
                                               :key key
                                               :value val})
-                  [old-val new-val])))))
+                  (revision-result old-val new-val revision opts))))))
 
 (defn dissoc
   "Removes an entry from the store. "

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -29,46 +29,46 @@
   ;; `#?(:clj ...)` while `memory_test` referred it unconditionally, so the cljs
   ;; build simply did not compile.
   (doseq [opts #?(:clj [{:sync? false} {:sync? true}] :cljs [{:sync? true}])
-             :let [<!! (if (:sync? opts) identity #?(:clj <!! :cljs identity))
-                   k*  (keyword (str "cas-" (if (:sync? opts) "sync" "async")))
+          :let [<!! (if (:sync? opts) identity #?(:clj <!! :cljs identity))
+                k*  (keyword (str "cas-" (if (:sync? opts) "sync" "async")))
                    ;; A rejection arrives DIFFERENTLY in the two arms: synchronously
                    ;; it is thrown, asynchronously konserve delivers the exception
                    ;; as a VALUE on the channel. `(is (thrown? ...))` around `<!!`
                    ;; therefore cannot pass in the async arm — the first version of
                    ;; this test asserted exactly that and failed 3/18 the first time
                    ;; anyone ran it. Normalise, then assert on the type.
-                   rejected? (fn [f]
-                               (let [r (try (<!! (f)) (catch #?(:clj Exception :cljs js/Error) e e))]
-                                 (= :konserve/revision-mismatch
-                                    (:type (ex-data r)))))]]
-       (if-not (k/conditional-write? store)
-         (testing "a store without the capability REFUSES, it does not ignore"
-           (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                        (<!! (k/assoc store k* {:v 1} (assoc opts :expected-revision :anything))))))
-         (testing "conditional writes"
-           (testing "create-if-absent succeeds on a missing key"
-             (<!! (k/assoc store k* {:v 1} (assoc opts :expected-revision konserve.impl.defaults/absent)))
-             (is (= {:v 1} (<!! (k/get store k* nil opts)))))
+                rejected? (fn [f]
+                            (let [r (try (<!! (f)) (catch #?(:clj Exception :cljs js/Error) e e))]
+                              (= :konserve/revision-mismatch
+                                 (:type (ex-data r)))))]]
+    (if-not (k/conditional-write? store)
+      (testing "a store without the capability REFUSES, it does not ignore"
+        (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                     (<!! (k/assoc store k* {:v 1} (assoc opts :expected-revision :anything))))))
+      (testing "conditional writes"
+        (testing "create-if-absent succeeds on a missing key"
+          (<!! (k/assoc store k* {:v 1} (assoc opts :expected-revision konserve.impl.defaults/absent)))
+          (is (= {:v 1} (<!! (k/get store k* nil opts)))))
 
-           (testing "create-if-absent is rejected once the key exists"
-             (is (rejected? #(k/assoc store k* {:v :no} (assoc opts :expected-revision konserve.impl.defaults/absent)))))
+        (testing "create-if-absent is rejected once the key exists"
+          (is (rejected? #(k/assoc store k* {:v :no} (assoc opts :expected-revision konserve.impl.defaults/absent)))))
 
-           (let [r0 (<!! (k/revision store k* opts))]
-             (testing "a write on the revision we read succeeds and MOVES the revision"
-               (<!! (k/assoc store k* {:v 2} (assoc opts :expected-revision r0)))
-               (is (= {:v 2} (<!! (k/get store k* nil opts))))
-               (is (not= r0 (<!! (k/revision store k* opts)))))
+        (let [r0 (<!! (k/revision store k* opts))]
+          (testing "a write on the revision we read succeeds and MOVES the revision"
+            (<!! (k/assoc store k* {:v 2} (assoc opts :expected-revision r0)))
+            (is (= {:v 2} (<!! (k/get store k* nil opts))))
+            (is (not= r0 (<!! (k/revision store k* opts)))))
 
-             (testing "the same revision a second time is rejected, and writes nothing"
-               (is (rejected? #(k/assoc store k* {:v :lost} (assoc opts :expected-revision r0))))
-               (is (= {:v 2} (<!! (k/get store k* nil opts)))
-                   "the loser must not have overwritten the winner"))
+          (testing "the same revision a second time is rejected, and writes nothing"
+            (is (rejected? #(k/assoc store k* {:v :lost} (assoc opts :expected-revision r0))))
+            (is (= {:v 2} (<!! (k/get store k* nil opts)))
+                "the loser must not have overwritten the winner"))
 
-             (testing "update-in is fenced too, and up-fn does not run when rejected"
-               (let [ran (atom 0)]
-                 (is (rejected? #(k/update-in store [k*] (fn [v] (swap! ran inc) (assoc v :v :lost))
-                                              (assoc opts :expected-revision r0))))
-                 (is (zero? @ran) "a rejected update must not run the caller's function"))))
+          (testing "update-in is fenced too, and up-fn does not run when rejected"
+            (let [ran (atom 0)]
+              (is (rejected? #(k/update-in store [k*] (fn [v] (swap! ran inc) (assoc v :v :lost))
+                                           (assoc opts :expected-revision r0))))
+              (is (zero? @ran) "a rejected update must not run the caller's function"))))
 
            ;; The rejection must leave NO trace. A backing that creates its blob
            ;; before it can compare revisions leaves an empty one behind when the
@@ -76,26 +76,26 @@
            ;; is not absent (so `create-if-absent` can never succeed again) and it
            ;; is not readable (a header-size error, not not-found). One ordinary
            ;; conflict on a key that never existed would brick that key forever.
-           (testing "a REJECTED write on a missing key leaves the key missing"
-             (let [ghost (keyword (str "cas-ghost-" (if (:sync? opts) "sync" "async")))]
-               (is (rejected? #(k/assoc store ghost {:v :no}
-                                        (assoc opts :expected-revision :a-revision-that-never-existed))))
-               (is (false? (<!! (k/exists? store ghost opts)))
-                   "the key must not have come into existence")
-               (is (= :missing (<!! (k/get store ghost :missing opts)))
-                   "and reading it reports not-found rather than raising")
-               (testing "so create-if-absent still succeeds afterwards"
-                 (<!! (k/assoc store ghost {:v 1} (assoc opts :expected-revision konserve.impl.defaults/absent)))
-                 (is (= {:v 1} (<!! (k/get store ghost nil opts)))))))
+        (testing "a REJECTED write on a missing key leaves the key missing"
+          (let [ghost (keyword (str "cas-ghost-" (if (:sync? opts) "sync" "async")))]
+            (is (rejected? #(k/assoc store ghost {:v :no}
+                                     (assoc opts :expected-revision :a-revision-that-never-existed))))
+            (is (false? (<!! (k/exists? store ghost opts)))
+                "the key must not have come into existence")
+            (is (= :missing (<!! (k/get store ghost :missing opts)))
+                "and reading it reports not-found rather than raising")
+            (testing "so create-if-absent still succeeds afterwards"
+              (<!! (k/assoc store ghost {:v 1} (assoc opts :expected-revision konserve.impl.defaults/absent)))
+              (is (= {:v 1} (<!! (k/get store ghost nil opts)))))))
 
-           (testing "an unconditional write still works"
-             (<!! (k/assoc store k* {:v 3} opts))
-             (is (= {:v 3} (<!! (k/get store k* nil opts)))))
+        (testing "an unconditional write still works"
+          (<!! (k/assoc store k* {:v 3} opts))
+          (is (= {:v 3} (<!! (k/get store k* nil opts)))))
 
-           (testing "multi-assoc refuses to be made conditional"
-             (when (utils/multi-key-capable? store)
-               (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                            (<!! (k/multi-assoc store {:cas-m1 1} (assoc opts :expected-revision :x)))))))))))
+        (testing "multi-assoc refuses to be made conditional"
+          (when (utils/multi-key-capable? store)
+            (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                         (<!! (k/multi-assoc store {:cas-m1 1} (assoc opts :expected-revision :x)))))))))))
 
 #?(:clj
    (defn compliance-test [store]

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -3,7 +3,7 @@
             [konserve.core :as k]
             [konserve.impl.defaults]
             [konserve.utils :as utils]
-            #?(:cljs [cljs.test :refer [is]])
+            #?(:cljs [cljs.test :refer [is testing]])
             #?(:clj [clojure.test :refer [are is testing]])))
 
 #_(deftype UnknownType [])
@@ -11,9 +11,8 @@
 #_(:clj (defn exception? [thing]
           (instance? Throwable thing)))
 
-#?(:clj
-   (defn conditional-write-compliance-test
-     "The `:expected-revision` contract, for any backend that claims to support it.
+(defn conditional-write-compliance-test
+  "The `:expected-revision` contract, for any backend that claims to support it.
 
       A backend that does NOT implement `PConditionalWrite` passes trivially — that
       is the point of the capability: not supporting fencing is a legitimate state,
@@ -21,13 +20,30 @@
       store is that it refuses rather than writes.
 
       Call this from your backend's test suite with a connected, empty store."
-     [store]
-     (doseq [opts [{:sync? false} {:sync? true}]
-             :let [<!! (if (:sync? opts) identity <!!)
-                   k*  (keyword (str "cas-" (if (:sync? opts) "sync" "async")))]]
+  [store]
+  ;; The ASYNC arm is JVM-only: resolving a channel to a value needs `<!!`, which
+  ;; ClojureScript has no equivalent of. The sync arm covers cljs, where konserve
+  ;; does have synchronous IO (node-filestore, memory) — which is the arm that
+  ;; matters there anyway. Written as one function rather than two so the contract
+  ;; cannot drift between platforms; it was previously wrapped whole in
+  ;; `#?(:clj ...)` while `memory_test` referred it unconditionally, so the cljs
+  ;; build simply did not compile.
+  (doseq [opts #?(:clj [{:sync? false} {:sync? true}] :cljs [{:sync? true}])
+             :let [<!! (if (:sync? opts) identity #?(:clj <!! :cljs identity))
+                   k*  (keyword (str "cas-" (if (:sync? opts) "sync" "async")))
+                   ;; A rejection arrives DIFFERENTLY in the two arms: synchronously
+                   ;; it is thrown, asynchronously konserve delivers the exception
+                   ;; as a VALUE on the channel. `(is (thrown? ...))` around `<!!`
+                   ;; therefore cannot pass in the async arm — the first version of
+                   ;; this test asserted exactly that and failed 3/18 the first time
+                   ;; anyone ran it. Normalise, then assert on the type.
+                   rejected? (fn [f]
+                               (let [r (try (<!! (f)) (catch #?(:clj Exception :cljs js/Error) e e))]
+                                 (= :konserve/revision-mismatch
+                                    (:type (ex-data r)))))]]
        (if-not (k/conditional-write? store)
          (testing "a store without the capability REFUSES, it does not ignore"
-           (is (thrown? clojure.lang.ExceptionInfo
+           (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
                         (<!! (k/assoc store k* {:v 1} (assoc opts :expected-revision :anything))))))
          (testing "conditional writes"
            (testing "create-if-absent succeeds on a missing key"
@@ -35,8 +51,7 @@
              (is (= {:v 1} (<!! (k/get store k* nil opts)))))
 
            (testing "create-if-absent is rejected once the key exists"
-             (is (thrown? clojure.lang.ExceptionInfo
-                          (<!! (k/assoc store k* {:v :no} (assoc opts :expected-revision konserve.impl.defaults/absent))))))
+             (is (rejected? #(k/assoc store k* {:v :no} (assoc opts :expected-revision konserve.impl.defaults/absent)))))
 
            (let [r0 (<!! (k/revision store k* opts))]
              (testing "a write on the revision we read succeeds and MOVES the revision"
@@ -45,17 +60,33 @@
                (is (not= r0 (<!! (k/revision store k* opts)))))
 
              (testing "the same revision a second time is rejected, and writes nothing"
-               (is (thrown? clojure.lang.ExceptionInfo
-                            (<!! (k/assoc store k* {:v :lost} (assoc opts :expected-revision r0)))))
+               (is (rejected? #(k/assoc store k* {:v :lost} (assoc opts :expected-revision r0))))
                (is (= {:v 2} (<!! (k/get store k* nil opts)))
                    "the loser must not have overwritten the winner"))
 
              (testing "update-in is fenced too, and up-fn does not run when rejected"
                (let [ran (atom 0)]
-                 (is (thrown? clojure.lang.ExceptionInfo
-                              (<!! (k/update-in store [k*] (fn [v] (swap! ran inc) (assoc v :v :lost))
-                                                (assoc opts :expected-revision r0)))))
+                 (is (rejected? #(k/update-in store [k*] (fn [v] (swap! ran inc) (assoc v :v :lost))
+                                              (assoc opts :expected-revision r0))))
                  (is (zero? @ran) "a rejected update must not run the caller's function"))))
+
+           ;; The rejection must leave NO trace. A backing that creates its blob
+           ;; before it can compare revisions leaves an empty one behind when the
+           ;; comparison fails, and an empty blob is worse than a missing key: it
+           ;; is not absent (so `create-if-absent` can never succeed again) and it
+           ;; is not readable (a header-size error, not not-found). One ordinary
+           ;; conflict on a key that never existed would brick that key forever.
+           (testing "a REJECTED write on a missing key leaves the key missing"
+             (let [ghost (keyword (str "cas-ghost-" (if (:sync? opts) "sync" "async")))]
+               (is (rejected? #(k/assoc store ghost {:v :no}
+                                        (assoc opts :expected-revision :a-revision-that-never-existed))))
+               (is (false? (<!! (k/exists? store ghost opts)))
+                   "the key must not have come into existence")
+               (is (= :missing (<!! (k/get store ghost :missing opts)))
+                   "and reading it reports not-found rather than raising")
+               (testing "so create-if-absent still succeeds afterwards"
+                 (<!! (k/assoc store ghost {:v 1} (assoc opts :expected-revision konserve.impl.defaults/absent)))
+                 (is (= {:v 1} (<!! (k/get store ghost nil opts)))))))
 
            (testing "an unconditional write still works"
              (<!! (k/assoc store k* {:v 3} opts))
@@ -63,10 +94,8 @@
 
            (testing "multi-assoc refuses to be made conditional"
              (when (utils/multi-key-capable? store)
-               (is (thrown? clojure.lang.ExceptionInfo
+               (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
                             (<!! (k/multi-assoc store {:cas-m1 1} (assoc opts :expected-revision :x)))))))))))
-
-   )
 
 #?(:clj
    (defn compliance-test [store]

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -47,11 +47,11 @@
                      (<!! (k/assoc store k* {:v 1} (assoc opts :expected-revision :anything))))))
       (testing "conditional writes"
         (testing "create-if-absent succeeds on a missing key"
-          (<!! (k/assoc store k* {:v 1} (assoc opts :expected-revision konserve.impl.defaults/absent)))
+          (<!! (k/assoc store k* {:v 1} (assoc opts :expected-revision k/absent)))
           (is (= {:v 1} (<!! (k/get store k* nil opts)))))
 
         (testing "create-if-absent is rejected once the key exists"
-          (is (rejected? #(k/assoc store k* {:v :no} (assoc opts :expected-revision konserve.impl.defaults/absent)))))
+          (is (rejected? #(k/assoc store k* {:v :no} (assoc opts :expected-revision k/absent)))))
 
         (let [r0 (<!! (k/revision store k* opts))]
           (testing "a write on the revision we read succeeds and MOVES the revision"
@@ -85,7 +85,7 @@
             (is (= :missing (<!! (k/get store ghost :missing opts)))
                 "and reading it reports not-found rather than raising")
             (testing "so create-if-absent still succeeds afterwards"
-              (<!! (k/assoc store ghost {:v 1} (assoc opts :expected-revision konserve.impl.defaults/absent)))
+              (<!! (k/assoc store ghost {:v 1} (assoc opts :expected-revision k/absent)))
               (is (= {:v 1} (<!! (k/get store ghost nil opts)))))))
 
         ;; ENUMERATION MUST SURVIVE A FENCED WRITE. A backing may leave
@@ -408,12 +408,12 @@
               "an unsupported :expected-revision must come back as an error"))
         (testing "conditional writes"
           (is (not (rejected? (<! (k/assoc store :cas-async {:v 1}
-                                           {:expected-revision konserve.impl.defaults/absent}))))
+                                           {:expected-revision k/absent}))))
               "create-if-absent succeeds on a missing key")
           (is (= {:v 1} (<! (k/get store :cas-async nil))))
 
           (is (rejected? (<! (k/assoc store :cas-async {:v :no}
-                                      {:expected-revision konserve.impl.defaults/absent})))
+                                      {:expected-revision k/absent})))
               "create-if-absent is rejected once the key exists")
 
           (let [r0 (<! (k/revision store :cas-async))]
@@ -451,7 +451,7 @@
           (is (false? (<! (k/exists? store :cas-async-ghost)))
               "a rejected write on a missing key leaves the key missing")
           (is (not (rejected? (<! (k/assoc store :cas-async-ghost {:v 1}
-                                           {:expected-revision konserve.impl.defaults/absent}))))
+                                           {:expected-revision k/absent}))))
               "so create-if-absent still succeeds afterwards"))))))
 
 (defn async-compliance-test [store]

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -367,6 +367,72 @@
              (<!! (k/dissoc store :hook-bin opts))
              (<!! (k/dissoc store :hook-after-remove opts))))))))
 
+(defn async-conditional-write-compliance-test
+  "The `:expected-revision` contract for ASYNC-ONLY backends. Returns a channel.
+
+   The same contract as [[conditional-write-compliance-test]], and a separate
+   function for the same reason `async-compliance-test` is: resolving a result to
+   a value needs `<!!` in the sync suite, and ClojureScript has no blocking take,
+   so a shared body cannot serve both. That leaves the suite unable to reach a
+   backend that is async-only under cljs — konserve-s3's ClojureScript backing is
+   exactly that, and it claims `:global`. An unenforced claim is what this whole
+   capability exists to prevent, so the suite has to be able to get at it.
+
+   Assertions are kept in step with the sync version by hand; if you add a rule
+   to one, add it to the other."
+  [store]
+  (go
+    (let [rejected? (fn [v] (= :konserve/revision-mismatch (:type (ex-data v))))]
+      (if-not (k/conditional-write? store)
+        (testing "a store without the capability REFUSES, it does not ignore"
+          ;; Async failures arrive as a VALUE on the channel rather than thrown,
+          ;; so this asserts on what was delivered. `(is (thrown? ...))` around a
+          ;; take cannot pass here — the sync suite asserted exactly that once and
+          ;; failed 3 of its own assertions the first time anyone ran it.
+          (is (some? (ex-data (<! (k/assoc store :cas-async {:v 1}
+                                           {:expected-revision :anything}))))
+              "an unsupported :expected-revision must come back as an error"))
+        (testing "conditional writes"
+          (is (not (rejected? (<! (k/assoc store :cas-async {:v 1}
+                                           {:expected-revision konserve.impl.defaults/absent}))))
+              "create-if-absent succeeds on a missing key")
+          (is (= {:v 1} (<! (k/get store :cas-async nil))))
+
+          (is (rejected? (<! (k/assoc store :cas-async {:v :no}
+                                      {:expected-revision konserve.impl.defaults/absent})))
+              "create-if-absent is rejected once the key exists")
+
+          (let [r0 (<! (k/revision store :cas-async))]
+            (is (not (rejected? (<! (k/assoc store :cas-async {:v 2}
+                                             {:expected-revision r0}))))
+                "a write on the revision we read succeeds")
+            (is (= {:v 2} (<! (k/get store :cas-async nil))))
+            (is (not= r0 (<! (k/revision store :cas-async)))
+                "and MOVES the revision")
+
+            (is (rejected? (<! (k/assoc store :cas-async {:v :lost}
+                                        {:expected-revision r0})))
+                "the same revision a second time is rejected")
+            (is (= {:v 2} (<! (k/get store :cas-async nil)))
+                "the loser must not have overwritten the winner")
+
+            (let [ran (atom 0)]
+              (is (rejected? (<! (k/update-in store [:cas-async]
+                                              (fn [v] (swap! ran inc) (assoc v :v :lost))
+                                              {:expected-revision r0})))
+                  "update-in is fenced too")
+              (is (zero? @ran) "a rejected update must not run the caller's function")))
+
+          ;; A rejection must leave no trace on a key that never existed — an
+          ;; empty blob is neither absent nor readable, which bricks the key.
+          (is (rejected? (<! (k/assoc store :cas-async-ghost {:v :no}
+                                      {:expected-revision :a-revision-that-never-existed}))))
+          (is (false? (<! (k/exists? store :cas-async-ghost)))
+              "a rejected write on a missing key leaves the key missing")
+          (is (not (rejected? (<! (k/assoc store :cas-async-ghost {:v 1}
+                                           {:expected-revision konserve.impl.defaults/absent}))))
+              "so create-if-absent still succeeds afterwards"))))))
+
 (defn async-compliance-test [store]
   (go
     (and

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -88,6 +88,20 @@
               (<!! (k/assoc store ghost {:v 1} (assoc opts :expected-revision konserve.impl.defaults/absent)))
               (is (= {:v 1} (<!! (k/get store ghost nil opts)))))))
 
+        ;; ENUMERATION MUST SURVIVE A FENCED WRITE. A backing may leave
+        ;; bookkeeping of its own behind — the default one takes its lock on a
+        ;; `.cas` sidecar that persists — and anything not recognised as
+        ;; bookkeeping is read as a value from an older layout and MIGRATED. That
+        ;; broke `k/keys`, and `konserve.gc/sweep!` through it, from the first
+        ;; fenced write onwards, permanently, on every default-backing store.
+        ;; Checked here rather than in one backend's suite because every backend
+        ;; that filters its own enumeration has to get this right.
+        (testing "keys still enumerate after a fenced write"
+          (let [ks (<!! (k/keys store opts))]
+            (is (every? map? ks) "no artifact leaked in as a key")
+            (is (contains? (set (map :key ks)) k*)
+                "and the key that was written is there")))
+
         (testing "an unconditional write still works"
           (<!! (k/assoc store k* {:v 3} opts))
           (is (= {:v 3} (<!! (k/get store k* nil opts)))))
@@ -422,6 +436,13 @@
                                               {:expected-revision r0})))
                   "update-in is fenced too")
               (is (zero? @ran) "a rejected update must not run the caller's function")))
+
+          ;; See the sync arm: a backing's own bookkeeping must not be read back
+          ;; as a value, or `k/keys` and the GC that walks it break permanently.
+          (let [ks (<! (k/keys store))]
+            (is (every? map? ks) "keys still enumerate after a fenced write")
+            (is (contains? (set (map :key ks)) :cas-async)
+                "and the key that was written is there"))
 
           ;; A rejection must leave no trace on a key that never existed — an
           ;; empty blob is neither absent nor readable, which bricks the key.

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -88,6 +88,27 @@
               (<!! (k/assoc store ghost {:v 1} (assoc opts :expected-revision k/absent)))
               (is (= {:v 1} (<!! (k/get store ghost nil opts)))))))
 
+        ;; `:with-revision?` IS HALF THE PUBLIC SURFACE and had no coverage at
+        ;; all, which is how konserve's own memory store — the honest reference
+        ;; this suite is usually pointed at — came to accept the option and
+        ;; return the plain shape. A caller destructuring `[[old new] rev]` then
+        ;; binds the VALUE as the token and fences the next write on it.
+        (testing "a write reports the revision it produced, and that revision chains"
+          (let [res (<!! (k/assoc store k* {:v 4} (assoc opts :with-revision? true)))
+                [[_ new-val] rev] res]
+            (is (= {:v 4} new-val)
+                (str "the new VALUE belongs in the second slot, not the token: " (pr-str res)))
+            (is (some? rev) "and a revision beside it")
+            (is (= rev (<!! (k/revision store k* opts)))
+                "the reported revision must be the one that was stored")
+            (testing "so it can be handed straight back without a re-read"
+              (let [[[_ newer] rev2] (<!! (k/update-in store [k*] #(assoc % :v 5)
+                                                       (assoc opts :expected-revision rev
+                                                              :with-revision? true)))]
+                (is (= {:v 5} newer) "update-in reports the same shape")
+                (is (some? rev2))
+                (is (not= rev rev2) "and the revision moved")))))
+
         ;; ENUMERATION MUST SURVIVE A FENCED WRITE. A backing may leave
         ;; bookkeeping of its own behind — the default one takes its lock on a
         ;; `.cas` sidecar that persists — and anything not recognised as
@@ -436,6 +457,15 @@
                                               {:expected-revision r0})))
                   "update-in is fenced too")
               (is (zero? @ran) "a rejected update must not run the caller's function")))
+
+          ;; See the sync arm on why `:with-revision?` is part of the contract.
+          (let [res (<! (k/assoc store :cas-async {:v 4} {:with-revision? true}))
+                [[_ new-val] rev] res]
+            (is (= {:v 4} new-val)
+                (str "the new VALUE belongs in the second slot, not the token: " (pr-str res)))
+            (is (some? rev) "and a revision beside it")
+            (is (= rev (<! (k/revision store :cas-async)))
+                "the reported revision must be the one that was stored"))
 
           ;; See the sync arm: a backing's own bookkeeping must not be read back
           ;; as a value, or `k/keys` and the GC that walks it break permanently.

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -1,6 +1,7 @@
 (ns konserve.compliance-test
   (:require [clojure.core.async :refer [#?(:clj <!!) <! go]]
             [konserve.core :as k]
+            [konserve.impl.defaults]
             [konserve.utils :as utils]
             #?(:cljs [cljs.test :refer [is]])
             #?(:clj [clojure.test :refer [are is testing]])))
@@ -9,6 +10,63 @@
 
 #_(:clj (defn exception? [thing]
           (instance? Throwable thing)))
+
+#?(:clj
+   (defn conditional-write-compliance-test
+     "The `:expected-revision` contract, for any backend that claims to support it.
+
+      A backend that does NOT implement `PConditionalWrite` passes trivially — that
+      is the point of the capability: not supporting fencing is a legitimate state,
+      SILENTLY IGNORING a request for it is not. So the one thing checked for such a
+      store is that it refuses rather than writes.
+
+      Call this from your backend's test suite with a connected, empty store."
+     [store]
+     (doseq [opts [{:sync? false} {:sync? true}]
+             :let [<!! (if (:sync? opts) identity <!!)
+                   k*  (keyword (str "cas-" (if (:sync? opts) "sync" "async")))]]
+       (if-not (k/conditional-write? store)
+         (testing "a store without the capability REFUSES, it does not ignore"
+           (is (thrown? clojure.lang.ExceptionInfo
+                        (<!! (k/assoc store k* {:v 1} (assoc opts :expected-revision :anything))))))
+         (testing "conditional writes"
+           (testing "create-if-absent succeeds on a missing key"
+             (<!! (k/assoc store k* {:v 1} (assoc opts :expected-revision konserve.impl.defaults/absent)))
+             (is (= {:v 1} (<!! (k/get store k* nil opts)))))
+
+           (testing "create-if-absent is rejected once the key exists"
+             (is (thrown? clojure.lang.ExceptionInfo
+                          (<!! (k/assoc store k* {:v :no} (assoc opts :expected-revision konserve.impl.defaults/absent))))))
+
+           (let [r0 (<!! (k/revision store k* opts))]
+             (testing "a write on the revision we read succeeds and MOVES the revision"
+               (<!! (k/assoc store k* {:v 2} (assoc opts :expected-revision r0)))
+               (is (= {:v 2} (<!! (k/get store k* nil opts))))
+               (is (not= r0 (<!! (k/revision store k* opts)))))
+
+             (testing "the same revision a second time is rejected, and writes nothing"
+               (is (thrown? clojure.lang.ExceptionInfo
+                            (<!! (k/assoc store k* {:v :lost} (assoc opts :expected-revision r0)))))
+               (is (= {:v 2} (<!! (k/get store k* nil opts)))
+                   "the loser must not have overwritten the winner"))
+
+             (testing "update-in is fenced too, and up-fn does not run when rejected"
+               (let [ran (atom 0)]
+                 (is (thrown? clojure.lang.ExceptionInfo
+                              (<!! (k/update-in store [k*] (fn [v] (swap! ran inc) (assoc v :v :lost))
+                                                (assoc opts :expected-revision r0)))))
+                 (is (zero? @ran) "a rejected update must not run the caller's function"))))
+
+           (testing "an unconditional write still works"
+             (<!! (k/assoc store k* {:v 3} opts))
+             (is (= {:v 3} (<!! (k/get store k* nil opts)))))
+
+           (testing "multi-assoc refuses to be made conditional"
+             (when (utils/multi-key-capable? store)
+               (is (thrown? clojure.lang.ExceptionInfo
+                            (<!! (k/multi-assoc store {:cas-m1 1} (assoc opts :expected-revision :x)))))))))))
+
+   )
 
 #?(:clj
    (defn compliance-test [store]
@@ -111,7 +169,10 @@
                 :type :binary}
                {:key :foolog
                 :type :append-log}}
-             (->> list-keys (map #(clojure.core/dissoc % :last-write)) set)
+             ;; `:revision` is dropped for the same reason as `:last-write`: both
+             ;; are bookkeeping the store maintains, not part of what the caller
+             ;; stored, and neither is stable across the writes this test makes.
+             (->> list-keys (map #(clojure.core/dissoc % :last-write :revision)) set)
              true
              (every?
               (fn [{:keys [:last-write]}]

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [get get-in update update-in assoc assoc-in exists? dissoc keys])
   (:require [clojure.core.async :refer [chan put! poll!]]
             [hasch.core :as hasch]
-            [konserve.protocols :as protocols :refer [PConditionalWrite -conditional-write? -revision
+            [konserve.protocols :as protocols :refer [PConditionalWrite -conditional-write-domain -revision
                                                       -exists? -get-meta -get-in -assoc-in
                                                       -update-in -dissoc -bget -bassoc
                                                       -keys -multi-get -multi-assoc -multi-dissoc
@@ -292,6 +292,16 @@
                     a
                     not-found))))))
 
+(def absent
+  "The `:expected-revision` that means THE KEY MUST NOT EXIST — the create half of
+   a conditional write.
+
+   Re-exported from `konserve.impl.defaults`, which is where it is defined and
+   where it stays for backends. Callers should not have to require an `impl`
+   namespace to use a public contract, and every docstring here that tells you to
+   pass it would otherwise be pointing you into konserve's internals."
+  defaults/absent)
+
 (def conditional-write-domains
   "Conditional-write reach, weakest first. See `PConditionalWrite`."
   [:process :machine :global])
@@ -301,7 +311,7 @@
    `:global` — or nil if it has none."
   [store]
   (when (satisfies? PConditionalWrite store)
-    (-conditional-write? store)))
+    (-conditional-write-domain store)))
 
 (defn ^:private rank-domain!
   "Position of `domain` in `conditional-write-domains`, weakest first.
@@ -343,7 +353,7 @@
      (boolean (and have (>= (rank-domain! have) required))))))
 
 (defn revision
-  "The store's current revision token for `key`, or `konserve.impl.defaults/absent`
+  "The store's current revision token for `key`, or `konserve.core/absent`
    when the key does not exist.
 
    OPAQUE. Read it, hold it, hand it back as `:expected-revision` — do not order
@@ -356,7 +366,7 @@
                      {:type :konserve/conditional-write-unsupported :store (type store)})))
    (-revision store key opts)))
 
-(defn check-conditional-supported!*
+(defn check-conditional-supported!
   "Throw unless `store` can honour an `:expected-revision` in `opts`.
 
    Public because `konserve.cache` calls the write protocols DIRECTLY rather than
@@ -374,7 +384,7 @@
   (when (and (contains? opts :expected-revision)
              (nil? (:expected-revision opts)))
     (throw (ex-info (str ":expected-revision was nil, which is not a revision. Pass a token from "
-                         "konserve.core/revision, or konserve.impl.defaults/absent to require that "
+                         "konserve.core/revision, or konserve.core/absent to require that "
                          "the key does not exist. Writing unconditionally here would silently withhold "
                          "the guarantee that was asked for.")
                     {:type :konserve/invalid-expected-revision})))
@@ -417,7 +427,7 @@
   metadata form (cf. `assoc`'s `meta` map). `opts` stays last.
 
   `opts` may carry **`:expected-revision`** — a token from [[revision]], or
-  `konserve.impl.defaults/absent` for \"the key must not exist\". The update then
+  `konserve.core/absent` for \"the key must not exist\". The update then
   happens only if the stored revision is still that one, and otherwise throws
   `:konserve/revision-mismatch` having written nothing and WITHOUT running
   `up-fn`. Use it when the decision to update was made from an earlier read and
@@ -438,7 +448,7 @@
    (update-in store key-vec up-fn nil opts))
   ([store key-vec up-fn meta-up-fn opts]
    (log/trace :konserve/update-in {:key-vec key-vec})
-   (check-conditional-supported!* store opts)
+   (check-conditional-supported! store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
@@ -487,7 +497,7 @@
    FENCING (`opts`). `:expected-revision` makes the write CONDITIONAL: it lands
    only if the stored revision is still the one you pass, and otherwise raises
    `{:type :konserve/revision-mismatch}` having written nothing. Pass
-   `konserve.impl.defaults/absent` to mean: only if this key does not exist.
+   `konserve.core/absent` to mean: only if this key does not exist.
    `:with-revision? true` additionally reports the revision the write PRODUCED,
    which changes the result shape from `[old new]` to `[[old new] revision]`;
    hand that back as the next `:expected-revision` to chain fenced writes without
@@ -499,7 +509,7 @@
    (assoc-in store key-vec val nil opts))
   ([store key-vec val meta-up-fn opts]
    (log/trace :konserve/assoc-in {:key-vec key-vec})
-   (check-conditional-supported!* store opts)
+   (check-conditional-supported! store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
@@ -527,7 +537,7 @@
    FENCING (`opts`). `:expected-revision` makes the write CONDITIONAL: it lands
    only if the stored revision is still the one you pass, and otherwise raises
    `{:type :konserve/revision-mismatch}` having written nothing. Pass
-   `konserve.impl.defaults/absent` to mean: only if this key does not exist.
+   `konserve.core/absent` to mean: only if this key does not exist.
    `:with-revision? true` additionally reports the revision the write PRODUCED,
    which changes the result shape from `[old new]` to `[[old new] revision]`;
    hand that back as the next `:expected-revision` to chain fenced writes without
@@ -539,7 +549,7 @@
    (assoc store key val nil opts))
   ([store key val meta opts]
    (log/trace :konserve/assoc {:key key})
-   (check-conditional-supported!* store opts)
+   (check-conditional-supported! store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (maybe-go-locked
@@ -626,8 +636,14 @@
              :else                            kvs)]
     (zipmap ks (clojure.core/repeat meta))))
 
-(defn- refuse-conditional-multi! [opts]
-  (when (or (contains? opts :expected-revision) (contains? opts :expected-revisions))
+(defn- refuse-conditional-multi!
+  "Reject the fencing options on `multi-assoc`.
+
+   The plural `:expected-revisions` was checked here too, and no such option
+   exists anywhere in konserve — a guard against a key nobody defines guards
+   nothing, while reading as though a batch form had been considered and handled."
+  [opts]
+  (when (or (contains? opts :expected-revision) (contains? opts :with-revision?))
     (throw (ex-info (str "multi-assoc cannot be made conditional. Verifying every key and then writing "
                          "every key is not one atomic step on a store whose locks are per blob: another "
                          "writer can change a key after it was checked and before it was written. Fencing "

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -298,9 +298,10 @@
   ([store]
    (some? (conditional-write-domain store)))
   ([store required-domain]
-   (let [have (conditional-write-domain store)
-         rank #(.indexOf ^java.util.List conditional-write-domains %)]
-     (boolean (and have (>= (rank have) (rank required-domain)))))))
+   ;; Portable rank: `.indexOf` is a JVM method and this namespace is .cljc.
+   (let [rank (zipmap conditional-write-domains (range))
+         have (conditional-write-domain store)]
+     (boolean (and have (>= (rank have -1) (rank required-domain 0)))))))
 
 (defn revision
   "The store's current revision token for `key`, or `konserve.impl.defaults/absent`

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -303,6 +303,26 @@
   (when (satisfies? PConditionalWrite store)
     (-conditional-write? store)))
 
+(defn ^:private rank-domain!
+  "Position of `domain` in `conditional-write-domains`, weakest first.
+
+   RAISES on a domain that is not one of them rather than ranking it. The
+   comparison below used a default of 0, i.e. `:process`, so a typo — `:machien`,
+   a string `\"machine\"`, a nil out of a config — compared as the WEAKEST domain
+   and every store satisfied it. The one function whose job is to stop a caller
+   believing they are fenced answered true for a memory store."
+  [domain]
+  ;; The map is CALLED, not `get`-ed: this namespace shadows `clojure.core/get`
+  ;; with the store read, so `(get m k)` here is a konserve GET that returns a
+  ;; channel — which then failed to cast to a number, for every domain including
+  ;; the valid ones. `clojure.core/get` cannot be written out either, since this
+  ;; is .cljc and there it is `cljs.core/get`.
+  (or ((zipmap conditional-write-domains (range)) domain)
+      (throw (ex-info (str "Not a conditional-write domain: " (pr-str domain))
+                      {:type   :konserve/unknown-conditional-write-domain
+                       :domain domain
+                       :known  (vec conditional-write-domains)}))))
+
 (defn conditional-write?
   "Can this store make a write conditional on the revision the caller read, far
    enough for `required-domain`?
@@ -314,10 +334,13 @@
   ([store]
    (some? (conditional-write-domain store)))
   ([store required-domain]
-   ;; Portable rank: `.indexOf` is a JVM method and this namespace is .cljc.
-   (let [rank (zipmap conditional-write-domains (range))
-         have (conditional-write-domain store)]
-     (boolean (and have (>= (rank have -1) (rank required-domain 0)))))))
+   ;; `required-domain` is RANKED, not defaulted: a name that is not a domain is a
+   ;; mistake in the caller, and answering it is how a typo turns into a false
+   ;; assurance. `have` may legitimately be nil (no capability), which is simply
+   ;; below every domain.
+   (let [required (rank-domain! required-domain)
+         have     (conditional-write-domain store)]
+     (boolean (and have (>= (rank-domain! have) required))))))
 
 (defn revision
   "The store's current revision token for `key`, or `konserve.impl.defaults/absent`
@@ -340,6 +363,21 @@
    through this namespace, so it would otherwise bypass the check and silently
    ignore the option — the failure mode the capability exists to remove."
   [store opts]
+  ;; A NIL TOKEN IS NOT A REQUEST FOR AN UNCONDITIONAL WRITE. Every gate below
+  ;; this is a truthiness test, so a nil would sail past `check-revision!` and
+  ;; write unconditionally — while the caller believes they fenced. That is
+  ;; reachable through the front door: `revision` answers nil for a key whose
+  ;; metadata predates `:revision` (an upgraded store, or a migrated key), so the
+  ;; documented read-then-hand-it-back pattern would silently overwrite exactly
+  ;; the keys someone tries it on first. `absent` is the way to say "no value
+  ;; here"; nil is a mistake.
+  (when (and (contains? opts :expected-revision)
+             (nil? (:expected-revision opts)))
+    (throw (ex-info (str ":expected-revision was nil, which is not a revision. Pass a token from "
+                         "konserve.core/revision, or konserve.impl.defaults/absent to require that "
+                         "the key does not exist. Writing unconditionally here would silently withhold "
+                         "the guarantee that was asked for.")
+                    {:type :konserve/invalid-expected-revision})))
   (when (and (contains? opts :expected-revision)
              (not (conditional-write? store)))
     (throw (ex-info (str "This store cannot honour :expected-revision, so the conditional write was refused. "
@@ -347,8 +385,13 @@
                     {:type  :konserve/conditional-write-unsupported
                      :store (type store)}))))
 
-(defn- refuse-conditional-unsupported!
+(defn refuse-conditional-unsupported!
   "Reject `:expected-revision` on an operation that does not implement it.
+
+   Public for the same reason as [[check-conditional-supported!]]: `konserve.cache`
+   reimplements these entry points rather than delegating, so a check kept private
+   here is simply absent there — which is how `konserve.cache/dissoc` came to
+   DELETE a key whose conditional write `konserve.core/dissoc` refuses.
 
    Ignoring it is the one outcome that must never happen: the caller asked for a
    guarantee, and a silent unconditional write is the exact failure the whole
@@ -356,7 +399,13 @@
   [op opts]
   (when (contains? opts :expected-revision)
     (throw (ex-info (str op " cannot be made conditional; :expected-revision was refused rather than ignored.")
-                    {:type :konserve/conditional-write-unsupported :op op}))))
+                    {:type :konserve/conditional-write-unsupported :op op})))
+  ;; Same rule for `:with-revision?`. Dropping it is quieter but no safer: the
+  ;; caller destructures the revision-bearing shape, binds the value where the
+  ;; revision should be, and fences the NEXT write on garbage.
+  (when (contains? opts :with-revision?)
+    (throw (ex-info (str op " cannot report a revision; :with-revision? was refused rather than ignored.")
+                    {:type :konserve/with-revision-unsupported :op op}))))
 
 (defn update-in
   "Updates a position described by key-vec by applying up-fn and storing
@@ -396,7 +445,15 @@
                 store (first key-vec)
                 (let [base (partial meta-update (first key-vec) :edn)
                       mfn  (if meta-up-fn (fn [old] (meta-up-fn (base old))) base)
-                      [old-val new-val :as result] (<?- (-update-in store key-vec mfn up-fn opts))]
+                      result (<?- (-update-in store key-vec mfn up-fn opts))
+                      ;; `:with-revision?` makes the result `[[old new] revision]`
+                      ;; rather than `[old new]`, so destructuring it as the plain
+                      ;; shape put the REVISION TOKEN in the hook's `:value` — and
+                      ;; a hook consumer that replicates on `:value` (konserve-sync)
+                      ;; would replicate the token as the key's data. The hook
+                      ;; reports the value either way; the revision is the caller's
+                      ;; business, not the replica's.
+                      [old-val new-val] (if (:with-revision? opts) (first result) result)]
                   (invoke-write-hooks! store {:api-op :update-in
                                               :key (first key-vec)
                                               :key-vec key-vec

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -2,7 +2,8 @@
   (:refer-clojure :exclude [get get-in update update-in assoc assoc-in exists? dissoc keys])
   (:require [clojure.core.async :refer [chan put! poll!]]
             [hasch.core :as hasch]
-            [konserve.protocols :as protocols :refer [-exists? -get-meta -get-in -assoc-in
+            [konserve.protocols :as protocols :refer [PConditionalWrite -conditional-write? -revision
+                                                      -exists? -get-meta -get-in -assoc-in
                                                       -update-in -dissoc -bget -bassoc
                                                       -keys -multi-get -multi-assoc -multi-dissoc
                                                       -assoc-serializers -get-write-hooks -lock-free?]]
@@ -275,6 +276,60 @@
                     a
                     not-found))))))
 
+(def conditional-write-domains
+  "Conditional-write reach, weakest first. See `PConditionalWrite`."
+  [:process :machine :global])
+
+(defn conditional-write-domain
+  "How far this store's conditional writes reach — `:process`, `:machine`,
+   `:global` — or nil if it has none."
+  [store]
+  (when (satisfies? PConditionalWrite store)
+    (-conditional-write? store)))
+
+(defn conditional-write?
+  "Can this store make a write conditional on the revision the caller read, far
+   enough for `required-domain`?
+
+   Called WITHOUT a domain this asks only \"at all?\", which is the right question
+   for a caller that already knows its deployment. Pass the domain you actually
+   need — `:machine` for several processes on one host, `:global` for several
+   hosts — and let the store answer, rather than assuming a `true` covers you."
+  ([store]
+   (some? (conditional-write-domain store)))
+  ([store required-domain]
+   (let [have (conditional-write-domain store)
+         rank #(.indexOf ^java.util.List conditional-write-domains %)]
+     (boolean (and have (>= (rank have) (rank required-domain)))))))
+
+(defn revision
+  "The store's current revision token for `key`, or `konserve.impl.defaults/absent`
+   when the key does not exist.
+
+   OPAQUE. Read it, hold it, hand it back as `:expected-revision` — do not order
+   it, derive from it, or persist it as if it meant anything. Backends are free to
+   use whatever their storage gives them (a counter here, an ETag on S3)."
+  ([store key] (revision store key {:sync? false}))
+  ([store key opts]
+   (when-not (conditional-write? store)
+     (throw (ex-info "This store has no revisions to read: it cannot make a write conditional on one."
+                     {:type :konserve/conditional-write-unsupported :store (type store)})))
+   (-revision store key opts)))
+
+(defn check-conditional-supported!*
+  "Throw unless `store` can honour an `:expected-revision` in `opts`.
+
+   Public because `konserve.cache` calls the write protocols DIRECTLY rather than
+   through this namespace, so it would otherwise bypass the check and silently
+   ignore the option — the failure mode the capability exists to remove."
+  [store opts]
+  (when (and (contains? opts :expected-revision)
+             (not (conditional-write? store)))
+    (throw (ex-info (str "This store cannot honour :expected-revision, so the conditional write was refused. "
+                         "Writing it unconditionally would give back the very guarantee that was asked for.")
+                    {:type  :konserve/conditional-write-unsupported
+                     :store (type store)}))))
+
 (defn update-in
   "Updates a position described by key-vec by applying up-fn and storing
   the result atomically. Returns a vector [old new] of the previous
@@ -282,13 +337,26 @@
 
   The optional `meta-up-fn` (5-arity, before the trailing `opts`) is
   `(fn [built-meta] -> meta)`, transforming the value's default metadata — the general
-  metadata form (cf. `assoc`'s `meta` map). `opts` stays last."
+  metadata form (cf. `assoc`'s `meta` map). `opts` stays last.
+
+  `opts` may carry **`:expected-revision`** — a token from [[revision]], or
+  `konserve.impl.defaults/absent` for \"the key must not exist\". The update then
+  happens only if the stored revision is still that one, and otherwise throws
+  `:konserve/revision-mismatch` having written nothing and WITHOUT running
+  `up-fn`. Use it when the decision to update was made from an earlier read and
+  must not silently drift; plain `update-in` remains the tool for \"recompute from
+  whatever is current\", since `up-fn` already sees the current value.
+
+  THE REVISION IS PER KEY, NOT PER PATH. `[:k :a :b]` fences the whole `:k` blob,
+  not the `[:a :b]` position inside it — the blob is the unit of storage and of the
+  lock, so it cannot be otherwise."
   ([store key-vec up-fn]
    (update-in store key-vec up-fn nil {:sync? false}))
   ([store key-vec up-fn opts]
    (update-in store key-vec up-fn nil opts))
   ([store key-vec up-fn meta-up-fn opts]
    (log/trace :konserve/update-in {:key-vec key-vec})
+   (check-conditional-supported!* store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
@@ -331,6 +399,7 @@
    (assoc-in store key-vec val nil opts))
   ([store key-vec val meta-up-fn opts]
    (log/trace :konserve/assoc-in {:key-vec key-vec})
+   (check-conditional-supported!* store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
@@ -360,6 +429,7 @@
    (assoc store key val nil opts))
   ([store key val meta opts]
    (log/trace :konserve/assoc {:key key})
+   (check-conditional-supported!* store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (maybe-go-locked
@@ -446,6 +516,16 @@
              :else                            kvs)]
     (zipmap ks (clojure.core/repeat meta))))
 
+(defn- refuse-conditional-multi! [opts]
+  (when (or (contains? opts :expected-revision) (contains? opts :expected-revisions))
+    (throw (ex-info (str "multi-assoc cannot be made conditional. Verifying every key and then writing "
+                         "every key is not one atomic step on a store whose locks are per blob: another "
+                         "writer can change a key after it was checked and before it was written. Fencing "
+                         "it here would promise an atomicity the backend does not have. Content-addressed "
+                         "values — the usual reason to batch — cannot conflict anyway, since the same key "
+                         "means the same bytes.")
+                    {:type :konserve/conditional-multi-write-unsupported}))))
+
 (defn multi-assoc
   "Associates multiple key-value pairs with flat keys, as one batch. Atomically where the
   backend can (IndexedDB); ordered everywhere (see below), which is the weaker guarantee
@@ -493,6 +573,7 @@
    (multi-assoc store kvs nil opts))
   ([store kvs meta opts]
    (log/trace :konserve/multi-assoc {:key-count (count kvs)})
+   (refuse-conditional-multi! opts)
    (when-not (multi-key-capable? store)
      (throw (#?(:clj ex-info :cljs js/Error.) "Store does not support multi-key operations"
                                               #?(:clj {:store-type (type store)

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -388,6 +388,17 @@
                          "the key does not exist. Writing unconditionally here would silently withhold "
                          "the guarantee that was asked for.")
                     {:type :konserve/invalid-expected-revision})))
+  ;; `:with-revision?` is refused on the same terms. The read docstrings already
+  ;; said so and the code did not: a store with no domain happily handed back a
+  ;; token that no write of its own would ever accept.
+  (when (and (contains? opts :with-revision?)
+             (:with-revision? opts)
+             (not (conditional-write? store)))
+    (throw (ex-info (str "This store has no revisions to report, so :with-revision? was refused. "
+                         "Handing back a token no write on this store can honour would be worse "
+                         "than not offering one.")
+                    {:type  :konserve/with-revision-unsupported
+                     :store (type store)})))
   (when (and (contains? opts :expected-revision)
              (not (conditional-write? store)))
     (throw (ex-info (str "This store cannot honour :expected-revision, so the conditional write was refused. "

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -235,7 +235,15 @@
 
 (defn get-in
   "Returns the value stored described by key. Returns nil if the key
-   is not present, or the not-found value if supplied."
+   is not present, or the not-found value if supplied.
+
+   `opts` may carry **`:with-revision? true`**, which returns `[value revision]`
+   instead of `value`. That is one call rather than two for a fencing caller, and
+   not merely a convenience: reading the value and its revision separately can
+   straddle another writer's commit, leaving you fencing on a revision that never
+   belonged to the value you read. Pass the revision back as
+   `:expected-revision`. Refused by stores that cannot compare-and-set, and by
+   `konserve.cache` — a cached value carries no revision."
   ([store key-vec]
    (get-in store key-vec nil))
   ([store key-vec not-found]
@@ -250,7 +258,15 @@
 
 (defn get
   "Returns the value stored described by key. Returns nil if the key
-   is not present, or the not-found value if supplied."
+   is not present, or the not-found value if supplied.
+
+   `opts` may carry **`:with-revision? true`**, which returns `[value revision]`
+   instead of `value`. That is one call rather than two for a fencing caller, and
+   not merely a convenience: reading the value and its revision separately can
+   straddle another writer's commit, leaving you fencing on a revision that never
+   belonged to the value you read. Pass the revision back as
+   `:expected-revision`. Refused by stores that cannot compare-and-set, and by
+   `konserve.cache` — a cached value carries no revision."
   ([store key]
    (get store key nil))
   ([store key not-found]
@@ -331,6 +347,17 @@
                     {:type  :konserve/conditional-write-unsupported
                      :store (type store)}))))
 
+(defn- refuse-conditional-unsupported!
+  "Reject `:expected-revision` on an operation that does not implement it.
+
+   Ignoring it is the one outcome that must never happen: the caller asked for a
+   guarantee, and a silent unconditional write is the exact failure the whole
+   mechanism exists to remove. Refusing is recoverable; a lost update is not."
+  [op opts]
+  (when (contains? opts :expected-revision)
+    (throw (ex-info (str op " cannot be made conditional; :expected-revision was refused rather than ignored.")
+                    {:type :konserve/conditional-write-unsupported :op op}))))
+
 (defn update-in
   "Updates a position described by key-vec by applying up-fn and storing
   the result atomically. Returns a vector [old new] of the previous
@@ -347,6 +374,11 @@
   `up-fn`. Use it when the decision to update was made from an earlier read and
   must not silently drift; plain `update-in` remains the tool for \"recompute from
   whatever is current\", since `up-fn` already sees the current value.
+
+  **`:with-revision? true`** additionally reports the revision the update
+  PRODUCED, changing the result shape from `[old new]` to `[[old new] revision]`.
+  Hand that back as the next `:expected-revision` to chain fenced updates without
+  a re-read.
 
   THE REVISION IS PER KEY, NOT PER PATH. `[:k :a :b]` fences the whole `:k` blob,
   not the `[:a :b]` position inside it — the blob is the unit of storage and of the
@@ -393,7 +425,17 @@
   `(fn [built-meta] -> meta)` — it TRANSFORMS the value's default metadata (the built
   `{:key :type :last-write}`). This is the general form of `assoc`'s `meta` map (a map
   is just the merge-transform), exposed here because nested writes may derive metadata
-  from the built fields. `opts` stays last and purely runtime."
+  from the built fields. `opts` stays last and purely runtime.
+
+   FENCING (`opts`). `:expected-revision` makes the write CONDITIONAL: it lands
+   only if the stored revision is still the one you pass, and otherwise raises
+   `{:type :konserve/revision-mismatch}` having written nothing. Pass
+   `konserve.impl.defaults/absent` to mean: only if this key does not exist.
+   `:with-revision? true` additionally reports the revision the write PRODUCED,
+   which changes the result shape from `[old new]` to `[[old new] revision]`;
+   hand that back as the next `:expected-revision` to chain fenced writes without
+   a re-read. Both are REFUSED, not ignored, by a store that cannot
+   compare-and-set — see [[conditional-write?]] and [[conditional-write-domain]]."
   ([store key-vec val]
    (assoc-in store key-vec val nil {:sync? false}))
   ([store key-vec val opts]
@@ -423,7 +465,17 @@
    conflict, so `meta` is additive. Use `{:immutable? true}` to mark a content-
    addressed (write-once) value: it is recorded durably AND forwarded on the write-
    hook event, so a consumer (konserve-sync) can skip re-storing a value it already
-   has. `opts` stays last and purely runtime."
+   has. `opts` stays last and purely runtime.
+
+   FENCING (`opts`). `:expected-revision` makes the write CONDITIONAL: it lands
+   only if the stored revision is still the one you pass, and otherwise raises
+   `{:type :konserve/revision-mismatch}` having written nothing. Pass
+   `konserve.impl.defaults/absent` to mean: only if this key does not exist.
+   `:with-revision? true` additionally reports the revision the write PRODUCED,
+   which changes the result shape from `[old new]` to `[[old new] revision]`;
+   hand that back as the next `:expected-revision` to chain fenced writes without
+   a re-read. Both are REFUSED, not ignored, by a store that cannot
+   compare-and-set — see [[conditional-write?]] and [[conditional-write-domain]]."
   ([store key val]
    (assoc store key val nil {:sync? false}))
   ([store key val opts]
@@ -663,6 +715,7 @@
    (dissoc store key {:sync? false}))
   ([store key opts]
    (log/trace :konserve/dissoc {:key key})
+   (refuse-conditional-unsupported! "dissoc" opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (maybe-go-locked
@@ -719,6 +772,7 @@
    (append store key elem {:sync? false}))
   ([store key elem opts]
    (log/trace :konserve/append {:key key})
+   (refuse-conditional-unsupported! "append" opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (go-locked
@@ -829,6 +883,7 @@
    (bassoc store key val {:sync? false}))
   ([store key val opts]
    (log/trace :konserve/bassoc {:key key})
+   (refuse-conditional-unsupported! "bassoc" opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
                (maybe-go-locked

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -181,7 +181,7 @@
   ;; the compare and the write are one step for processes sharing this filesystem.
   ;; NOT further: the lock file is local, so nothing coordinates two machines, and
   ;; advisory locks over NFS are not dependable.
-  (-conditional-write? [_] :machine)
+  (-conditional-write-domain [_] :machine)
   PBackingStore
   (-create-blob [_this store-key env]
     (let [{:keys [sync?]} env

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -3,7 +3,7 @@
    [clojure.core.async :refer [go <!! chan close! put!]]
    [clojure.java.io :as io]
    [clojure.string :refer [includes? ends-with?]]
-   [konserve.impl.defaults :refer [update-blob connect-default-store key->store-key store-key->uuid-key normalize-store-config]]
+   [konserve.impl.defaults :as kd :refer [update-blob connect-default-store key->store-key store-key->uuid-key normalize-store-config]]
    [konserve.impl.storage-layout :refer [PBackingStore
                                          PBackingBlob -close
                                          PBackingLock header-size
@@ -701,7 +701,12 @@
            key)])))))
 
 (defn detect-old-file-schema
-  "Detect files using old storage schema for migration."
+  "Detect files using old storage schema for migration.
+
+   konserve's own bookkeeping is not a value in any layout, so it is skipped —
+   the fenced-write sidecar otherwise fell through to the `:else` arm and a store
+   with `:detect-old-file-schema? true` logged a phantom migration on every
+   connect, forever, with a count that never dropped."
   ([base] (detect-old-file-schema nil base))
   ([filesystem base]
    (reduce
@@ -710,7 +715,8 @@
         (cond
           (or
            (includes? store-key "data")
-           (ends-with? store-key ".ksv"))    old-list
+           (ends-with? store-key ".ksv")
+           (kd/internal-artifact? store-key)) old-list
           (re-find #"meta(?!\S)" store-key) (into old-list (detect-old-file-schema filesystem store-key))
           :else                             (into old-list [store-key]))))
     #{}

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -175,6 +175,13 @@
 (declare migrate-old-files migrate-file-v2 migrate-file-v1)
 
 (defrecord BackingFilestore [base detected-old-blobs ephemeral? filesystem]
+  konserve.protocols/PConditionalWrite
+  ;; :machine. `-get-lock` takes a java.nio FileLock, which the OS holds on behalf
+  ;; of the whole JVM against every other process that opens the same file — so
+  ;; the compare and the write are one step for processes sharing this filesystem.
+  ;; NOT further: the lock file is local, so nothing coordinates two machines, and
+  ;; advisory locks over NFS are not dependable.
+  (-conditional-write? [_] :machine)
   PBackingStore
   (-create-blob [_this store-key env]
     (let [{:keys [sync?]} env

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -7,12 +7,12 @@
    [konserve.serializers :refer [key->serializer]]
    [konserve.compressor :refer [get-compressor null-compressor]]
    [konserve.encryptor :refer [get-encryptor null-encryptor]]
-   [konserve.protocols :refer [PEDNKeyValueStore
+   [konserve.protocols :as protocols :refer [PEDNKeyValueStore
                                PBinaryKeyValueStore
                                -serialize -deserialize
                                PAssocSerializers
                                PKeyIterable
-                               PMultiKeySupport
+                               PMultiKeySupport PConditionalWrite -conditional-write? -revision
                                PMultiKeyEDNValueStore
                                PWriteHookStore]]
    #?(:clj [konserve.nio-helpers :as nio])
@@ -211,6 +211,27 @@
                             value     (fn-read bais-value)
                             _          (.close bais-value)]
                         [meta value]))
+        ;; Both segments, from the one pass the blob is already open for. The
+        ;; write path has always done this (`:write-edn` below); a READ needs it
+        ;; so a caller can obtain a value AND the revision it is at without a
+        ;; second round-trip — which on a remote store is an extra GET, and worse,
+        ;; is RACY: between reading the value and reading its revision another
+        ;; writer can move both, and the caller would fence against a revision
+        ;; that never belonged to the value it computed from.
+        :read-edn-meta #?(:cljs
+                          (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
+                                value (fn-read (<?- (-read-value blob meta-size env)))]
+                            [meta value])
+                          :clj
+                          (let [bais-meta  (ByteArrayInputStream.
+                                            (<?- (-read-meta blob meta-size env)))
+                                meta       (fn-read bais-meta)
+                                _          (.close bais-meta)
+                                bais-value (ByteArrayInputStream.
+                                            (<?- (-read-value blob meta-size env)))
+                                value      (fn-read bais-value)
+                                _          (.close bais-value)]
+                            [meta value]))
         :read-binary (<?- (-read-binary blob meta-size locked-cb env)))))))
 
 (defn delete-blob
@@ -251,6 +272,33 @@
   remote backends such as S3)."
   #?(:clj (Object.) :cljs (js-obj)))
 
+(def absent
+  "The `:expected-revision` that means THE KEY MUST NOT EXIST — the create half of
+   a conditional write. Distinct from `nil`, which means \"unconditional\": a
+   caller that passed nil for \"I read nothing there\" would silently get an
+   unconditional overwrite, which is the failure this whole mechanism exists to
+   remove."
+  ::absent)
+
+(defn check-revision!
+  "Throw unless the stored revision is the one the caller derived its value from.
+
+   `old-meta` is nil when the key does not exist. The comparison is `=` on an
+   OPAQUE token: for this backing it is an integer counter kept in the metadata,
+   for others it can be whatever their storage gives (an S3 ETag, a row version).
+   Callers must treat it as opaque and pass back what they read.
+
+   A key never written since revisions were introduced has no `:revision`, so it
+   reads as nil and a caller that read nil and passes nil back still matches."
+  [key expected old-meta]
+  (let [actual (if (nil? old-meta) absent (:revision old-meta))]
+    (when-not (= expected actual)
+      (throw (ex-info "Conditional write rejected: the stored revision is not the one this value was derived from."
+                      {:type     :konserve/revision-mismatch
+                       :key      key
+                       :expected expected
+                       :actual   actual})))))
+
 (defn get-lock [this store-key env]
   (async+sync
    (:sync? env)
@@ -284,16 +332,24 @@
 (defn io-operation
   "Read/Write blob. For better understanding use the flow-chart of konserve."
   [{:keys [backing]} serializers read-handlers write-handlers
-   {:keys [key-vec operation default-serializer sync? overwrite? config] :as env}]
+   {:keys [key-vec operation default-serializer sync? config expected-revision] :as env}]
   (async+sync
    sync? *default-sync-translation*
    (go-try-
     (let [key           (first  key-vec)
+          ;; A CONDITIONAL write has to see the old value to compare against it,
+          ;; so it cannot take the full-overwrite shortcut that skips the read.
+          ;; Cleared here rather than at every call site: `assoc` sets
+          ;; `:overwrite? true` for any top-level key, which is exactly the shape
+          ;; a fenced pointer write has.
+          overwrite?    (and (:overwrite? env) (nil? expected-revision))
+          env           (assoc env :overwrite? overwrite?)
           store-key     (key->store-key key)
           env           (assoc env :store-key store-key :header-size header-size)
           serializer    (get serializers default-serializer)
           migration-key (<?- (-migratable backing key store-key env))
-          read-op?      (or (= :read-edn operation) (= :read-binary operation) (= :read-meta operation))
+          read-op?      (or (= :read-edn operation) (= :read-binary operation) (= :read-meta operation)
+                            (= :read-edn-meta operation))
           write-op?     (or (= :write-edn operation) (= :write-binary operation))
           ;; A PReadMissSafe backing reports an absent key cleanly from the read
           ;; itself (an absent key throws store-key-not-found-ex), so the
@@ -365,7 +421,9 @@
                                   (or store-key-exists? (pos? attempt))
                                   (<?- (read-blob blob read-handlers serializers env))
                                   :else [nil nil])]
-                        (if write-op?
+                        (when expected-revision
+                        (check-revision! key expected-revision (first old)))
+                      (if write-op?
                           (<?- (update-blob backing store-key serializer write-handlers env old))
                           old))
                       (finally
@@ -374,6 +432,11 @@
                           (<?- (-release lock env)))
                         (<?- (-close blob env)))))
                   (catch #?(:clj Exception :cljs js/Error) e
+                    ;; DELIBERATELY not retried: `:konserve/revision-mismatch`.
+                    ;; That conflict belongs to the CALLER — retrying would re-run
+                    ;; `up-fn` against a value they never agreed to, which is the
+                    ;; silent drift `:expected-revision` exists to prevent. Only a
+                    ;; backend's own internal lock contention is retried here.
                     (if (and (pos? max-retries)
                              (= :optimistic-lock-conflict (:type (ex-data e)))
                              (< attempt max-retries))
@@ -508,7 +571,7 @@
             (<?- (-migratable backing key store-key env))
             false)))))
   (-get-in [this key-vec not-found opts]
-    (let [{:keys [sync?]} opts]
+    (let [{:keys [sync? with-revision?]} opts]
       (async+sync
        sync?
        *default-sync-translation*
@@ -520,7 +583,7 @@
         (let [a (<?-
                  (io-operation this serializers read-handlers write-handlers
                                {:key-vec key-vec
-                                :operation :read-edn
+                                :operation (if with-revision? :read-edn-meta :read-edn)
                                 :compressor compressor
                                 :encryptor encryptor
                                 :format    :data
@@ -532,9 +595,16 @@
                                 :not-found not-found-sentinel
                                 :msg       {:type :read-edn-error
                                             :key  key}}))]
-          (if (identical? a not-found-sentinel)
-            not-found
-            (clojure.core/get-in a (rest key-vec))))))))
+          (if with-revision?
+            ;; [value revision] — the absent key reports the absent sentinel as its
+            ;; revision, which is exactly what a create-if-absent write expects.
+            (if (identical? a not-found-sentinel)
+              [not-found absent]
+              (let [[meta value] a]
+                [(clojure.core/get-in value (rest key-vec)) (:revision meta)]))
+            (if (identical? a not-found-sentinel)
+              not-found
+              (clojure.core/get-in a (rest key-vec)))))))))
   (-get-meta [this key opts]
     (let [{:keys [sync?]} opts]
       (io-operation this serializers read-handlers write-handlers
@@ -551,7 +621,7 @@
                                  :key  key}})))
 
   (-assoc-in [this key-vec meta-up val opts]
-    (let [{:keys [sync?]} opts
+    (let [{:keys [sync? expected-revision]} opts
           key (first key-vec)]
       (io-operation this serializers read-handlers write-handlers
                     {:key-vec key-vec
@@ -566,11 +636,12 @@
                      :sync? sync?
                      :buffer-size buffer-size
                      :overwrite? (empty? (rest key-vec))
+                     :expected-revision expected-revision
                      :msg        {:type :write-edn-error
                                   :key  key}})))
 
   (-update-in [this key-vec meta-up up-fn opts]
-    (let [{:keys [sync?]} opts
+    (let [{:keys [sync? expected-revision]} opts
           key (first key-vec)]
       (io-operation this serializers read-handlers write-handlers
                     {:key-vec key-vec
@@ -584,6 +655,7 @@
                      :config     config
                      :sync? sync?
                      :buffer-size buffer-size
+                     :expected-revision expected-revision
                      :msg        {:type :write-edn-error
                                   :key  key}})))
   (-dissoc [_ key opts]
@@ -653,6 +725,23 @@
                   :sync? sync?
                   :buffer-size buffer-size
                   :msg {:type :read-all-keys-error}})))
+
+  PConditionalWrite
+  ;; The blob lock spans read-old and write (see `io-operation`), and it is an OS
+  ;; advisory lock on the filestore, so the compare-and-write is atomic across
+  ;; processes on one filesystem. NOT across machines: the lock file is local.
+  ;; A backing without `:lock-blob?` serializes nothing, so it cannot honour the
+  ;; contract and must say so.
+  (-conditional-write? [_]
+    ;; :machine, never further. The lock is an OS advisory lock on a file in this
+    ;; store's own directory, so it serializes processes that can see that file and
+    ;; nothing beyond. Without :lock-blob? nothing serializes read-old against
+    ;; write, so there is no domain at all.
+    (when (:lock-blob? config) :machine))
+  (-revision [this key opts]
+    (async+sync (:sync? opts) *default-sync-translation*
+                (go-try- (let [m (<?- (protocols/-get-meta this key opts))]
+                           (if (nil? m) absent (:revision m))))))
 
   PMultiKeySupport
   (-supports-multi-key? [_]

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -594,34 +594,44 @@
                                 ;; the race in the cleanup together.
                                 skip-blob? (and expected-revision (not exists-under-lock?))
                                 blob (when-not skip-blob?
-                                       (<?- (-create-blob backing store-key env)))
-                                lock (when (and blob (:lock-blob? config))
-                                       (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
-                                       (<?- (get-lock blob (first key-vec) env)))]
+                                       (<?- (-create-blob backing store-key env)))]
+                            ;; The value blob gets the same treatment as the
+                            ;; sidecar, one level down, and for the same reason: it
+                            ;; was opened in a `let` binding and closed in a
+                            ;; `finally` below the lock acquisition, so a `get-lock`
+                            ;; that threw — about a second of contention is enough —
+                            ;; leaked the handle. Measured one file descriptor per
+                            ;; failed attempt, which is a slow EMFILE for a process
+                            ;; that retries. Fixing this at the sidecar and not here
+                            ;; was an incomplete fix, not a different bug.
                             (try
-                              (let [old (cond
+                              (let [lock (when (and blob (:lock-blob? config))
+                                           (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
+                                           (<?- (get-lock blob (first key-vec) env)))]
+                                (try
+                                  (let [old (cond
                                           ;; A FENCED write decides from the existence
                                           ;; probe taken UNDER the lock, not from the
                                           ;; pre-lock one.
-                                          expected-revision
-                                          (if exists-under-lock?
-                                            (<?- (read-blob blob read-handlers serializers env))
-                                            [nil nil])
+                                              expected-revision
+                                              (if exists-under-lock?
+                                                (<?- (read-blob blob read-handlers serializers env))
+                                                [nil nil])
                                           ;; full overwrite never needs the old value
-                                          overwrite? [nil nil]
+                                              overwrite? [nil nil]
                                           ;; miss-safe non-overwrite write: no probe was done, so
                                           ;; read-first and treat an absent key as a fresh write.
-                                          skip-write-probe?
-                                          (try (<?- (read-blob blob read-handlers serializers env))
-                                               (catch #?(:clj Exception :cljs js/Error) e
-                                                 (if (store-key-not-found? e) [nil nil] (throw e))))
+                                              skip-write-probe?
+                                              (try (<?- (read-blob blob read-handlers serializers env))
+                                                   (catch #?(:clj Exception :cljs js/Error) e
+                                                     (if (store-key-not-found? e) [nil nil] (throw e))))
                                           ;; probe said the key exists (or this is a retry): read old
-                                          (or store-key-exists? (pos? attempt))
-                                          (<?- (read-blob blob read-handlers serializers env))
-                                          :else [nil nil])]
-                                (when expected-revision
-                                  (check-revision! key expected-revision (first old)))
-                                (if write-op?
+                                              (or store-key-exists? (pos? attempt))
+                                              (<?- (read-blob blob read-handlers serializers env))
+                                              :else [nil nil])]
+                                    (when expected-revision
+                                      (check-revision! key expected-revision (first old)))
+                                    (if write-op?
                                   ;; The meta is computed ONCE and the same value is both
                                   ;; written and reported. Calling the meta-fn a second time
                                   ;; to learn the revision was correct only while the
@@ -630,18 +640,19 @@
                                   ;; revision that had never been stored — and every chained
                                   ;; fenced write then failed against a head nobody else had
                                   ;; touched. Measured 60/60 wrong before this.
-                                  (let [new-meta (when (:with-revision? env)
-                                                   ((:up-fn-meta env) (first old)))
-                                        env      (cond-> env new-meta (assoc :up-fn-meta (constantly new-meta)))
-                                        res      (<?- (update-blob backing store-key serializer write-handlers env old))]
-                                    (if new-meta
-                                      [res (:revision new-meta)]
-                                      res))
-                                  old))
+                                      (let [new-meta (when (:with-revision? env)
+                                                       ((:up-fn-meta env) (first old)))
+                                            env      (cond-> env new-meta (assoc :up-fn-meta (constantly new-meta)))
+                                            res      (<?- (update-blob backing store-key serializer write-handlers env old))]
+                                        (if new-meta
+                                          [res (:revision new-meta)]
+                                          res))
+                                      old))
+                                  (finally
+                                    (when lock
+                                      (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
+                                      (<?- (-release lock env))))))
                               (finally
-                                (when lock
-                                  (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
-                                  (<?- (-release lock env)))
                                 (when blob (<?- (-close blob env))))))
                           (finally
                             (when cas-lock (<?- (-release cas-lock env))))))

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -419,7 +419,30 @@
         ;; genuinely stored nil still comes back as nil (the read succeeds),
         ;; distinct from the not-found sentinel.
         skip-read-probe?
-        (let [blob (<?- (-create-blob backing store-key env))
+        ;; A REVISION-BEARING READ takes the sidecar too, for two reasons.
+        ;;
+        ;; It makes the read ATOMIC against writers: the caller is reading a
+        ;; value and the token they will fence its successor on, and those two
+        ;; must come from the same state — reading them across another writer's
+        ;; rename would hand back a revision that never belonged to the value.
+        ;;
+        ;; And it makes the key FENCEABLE from the first read rather than the
+        ;; first write, which is what closes the residual window in the scheme
+        ;; described at `cas-blob` below: a caller that re-reads a pointer before
+        ;; each commit (datahike re-reads the branch head) has the sidecar in
+        ;; place before it ever issues a conditional write, so unconditional
+        ;; writers are excluded from that point on.
+        (let [cas-store-key (str store-key cas-lock-suffix)
+              ;; `:read-edn-meta` IS the revision-bearing read — `-get-in` selects
+              ;; that operation for `:with-revision? true` and does not forward the
+              ;; flag itself, so testing the operation is both correct and the only
+              ;; thing available here.
+              cas-blob (when (and (= :read-edn-meta operation) (:lock-blob? config))
+                         (<?- (-create-blob backing cas-store-key env)))
+              cas-lock (when cas-blob
+                         (log/trace :konserve/acquiring-cas-lock {:key key})
+                         (<?- (get-lock cas-blob (first key-vec) env)))
+              blob (<?- (-create-blob backing store-key env))
               lock (when (:lock-blob? config)
                      (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
                      (<?- (get-lock blob (first key-vec) env)))]
@@ -431,7 +454,10 @@
               (when (:lock-blob? config)
                 (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
                 (<?- (-release lock env)))
-              (<?- (-close blob env)))))
+              (<?- (-close blob env))
+              (when cas-lock
+                (<?- (-release cas-lock env))
+                (<?- (-close cas-blob env))))))
 
         (and (not store-key-exists?) migration-key)
         (<?- (-migrate backing migration-key key-vec serializer read-handlers write-handlers env))
@@ -464,8 +490,46 @@
                         ;; for mutable pointers (a branch head), of which there are
                         ;; a handful, not for the content-addressed values that make
                         ;; up the bulk of a store.
-                        cas-blob (when (and expected-revision (:lock-blob? config))
-                                   (<?- (-create-blob backing (str store-key cas-lock-suffix) env)))
+                        cas-store-key (str store-key cas-lock-suffix)
+                        ;; WHO TAKES THE SIDECAR. Every write to a FENCEABLE key,
+                        ;; not merely every fenced write — otherwise the lock
+                        ;; excludes the wrong set of writers and the guarantee is
+                        ;; not what `:machine` says.
+                        ;;
+                        ;; An unconditional write renames a NEW inode over this
+                        ;; key. A fenced write that opened the old inode before
+                        ;; taking its lock then holds a lock on a DETACHED file,
+                        ;; reads the pre-write value through it, compares the
+                        ;; revision against that, PASSES, and renames its own
+                        ;; result over the top. The fence does not merely fail to
+                        ;; exclude the other writer: it grants a false pass and
+                        ;; loses their committed value. (S3 does not have this
+                        ;; problem — If-Match is evaluated by S3 at write time, so
+                        ;; an intervening unconditional PUT correctly REJECTS the
+                        ;; fenced write. Without this the filestore would be
+                        ;; strictly weaker than S3 under the same API.)
+                        ;;
+                        ;; A key is fenceable once a sidecar exists for it, and
+                        ;; only fenced writes and revision-bearing reads create
+                        ;; one. So the cost stays where the original design put
+                        ;; it: mutable pointers, of which a store has a handful,
+                        ;; pay an extra file; the content-addressed values that
+                        ;; make up the bulk of a store pay one `exists?` probe
+                        ;; (~1us against a ~200us write) and no extra file at all.
+                        ;;
+                        ;; RESIDUAL, and it is worth stating: the FIRST fenced
+                        ;; write to a key can still race an unconditional one,
+                        ;; because that probe misses until the sidecar exists. It
+                        ;; is self-healing — once created, the hole is closed for
+                        ;; that key forever — and revision-bearing reads create it
+                        ;; too, so a reader that fences (datahike re-reads the
+                        ;; branch head before every commit) closes it before its
+                        ;; first write.
+                        cas-blob (when (and (:lock-blob? config)
+                                            (or (some? expected-revision)
+                                                (= :read-edn-meta operation)
+                                                (<?- (-blob-exists? backing cas-store-key env))))
+                                   (<?- (-create-blob backing cas-store-key env)))
                         cas-lock (when cas-blob
                                    (log/trace :konserve/acquiring-cas-lock {:key key})
                                    (<?- (get-lock cas-blob (first key-vec) env)))
@@ -536,9 +600,6 @@
                         (when (:lock-blob? config)
                           (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
                           (<?- (-release lock env)))
-                        (when cas-lock
-                          (<?- (-release cas-lock env))
-                          (<?- (-close cas-blob env)))
                         (<?- (-close blob env))
                         ;; A REJECTED fenced write must leave no trace. `-create-blob`
                         ;; creates the file before we can know whether the revision
@@ -551,16 +612,38 @@
                         ;; can never succeed on it again. The key is BRICKED by a
                         ;; conflict that was supposed to be harmless.
                         ;;
-                        ;; Deleted here, after the close, rather than in the catch:
-                        ;; unlinking an open file is fine on POSIX and fails on
-                        ;; Windows.
+                        ;; Deleted after the close but STILL UNDER THE SIDECAR
+                        ;; LOCK, which is the whole reason the release moved below
+                        ;; it. The delete is by PATH, so with the lock already
+                        ;; dropped it unlinked whatever happened to be at that
+                        ;; path — including a value another writer had just
+                        ;; renamed into place. A rejected write destroying a
+                        ;; committed one is far worse than the bricked blob this
+                        ;; cleanup exists to prevent; it showed up as 9 lost
+                        ;; writes in 4000 iterations of a natural race. Holding
+                        ;; the sidecar means no other write to this key can be
+                        ;; between our probe and this delete, because a fenceable
+                        ;; key's writers all take it (see above).
+                        ;;
+                        ;; Closing before deleting: unlinking an open file is fine
+                        ;; on POSIX and fails on Windows.
                         ;;
                         ;; Scoped to fenced writes because it is the only path that
                         ;; creates a blob it may then refuse to write; the
                         ;; unconditional paths write whatever they created.
                         (when @ghost?
                           (log/trace :konserve/removing-rejected-blob {:key key})
-                          (<?- (-delete-blob backing store-key env))))))
+                          ;; Never let cleanup REPLACE the outcome: the caller is
+                          ;; being handed a `:konserve/revision-mismatch` they can
+                          ;; retry on, and a NoSuchFileException thrown from here
+                          ;; would arrive in its place as an unrecognised IO error.
+                          (try (<?- (-delete-blob backing store-key env))
+                               (catch #?(:clj Exception :cljs js/Error) e
+                                 (log/warn :konserve/rejected-blob-cleanup-failed
+                                           {:key key :error e}))))
+                        (when cas-lock
+                          (<?- (-release cas-lock env))
+                          (<?- (-close cas-blob env))))))
                   (catch #?(:clj Exception :cljs js/Error) e
                     ;; DELIBERATELY not retried: `:konserve/revision-mismatch`.
                     ;; That conflict belongs to the CALLER — retrying would re-run

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -847,9 +847,25 @@
     ;; browser tabs they are fenced when nothing serializes them at all — precisely
     ;; the lie this capability exists to prevent. A backing that does not declare a
     ;; domain gets none, and `:expected-revision` is refused.
-    (when (:lock-blob? config)
-      (when (satisfies? protocols/PConditionalWrite backing)
-        (protocols/-conditional-write? backing))))
+    (let [declared (when (satisfies? protocols/PConditionalWrite backing)
+                     (protocols/-conditional-write? backing))]
+      ;; WHICH MECHANISM the domain rests on decides whether `:lock-blob?` can
+      ;; revoke it, and the domain itself says which:
+      ;;
+      ;; `:process`/`:machine` are produced HERE, by `io-operation` holding a lock
+      ;; across read-old and write. Without `:lock-blob?` there is no lock, the
+      ;; compare and the write stop being one step, and the claim is void however
+      ;; sincerely the backing makes it. So the flag revokes it.
+      ;;
+      ;; `:global` cannot be produced by a lock local to this machine, so a
+      ;; backing claiming it is fencing in its own storage layer (konserve-s3:
+      ;; If-Match, evaluated by S3) where konserve's lock is irrelevant. Revoking
+      ;; that on `:lock-blob?` would mean a flag about a lock nobody uses silently
+      ;; turning off the guarantee — konserve-s3's `-get-lock` IS a no-op, and it
+      ;; passes today only because it happens to set the flag anyway.
+      (if (= :global declared)
+        declared
+        (when (:lock-blob? config) declared))))
   (-revision [this key opts]
     (async+sync (:sync? opts) *default-sync-translation*
                 (go-try- (let [m (<?- (protocols/-get-meta this key opts))]

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -12,7 +12,7 @@
                                              -serialize -deserialize
                                              PAssocSerializers
                                              PKeyIterable
-                                             PMultiKeySupport PConditionalWrite -conditional-write-domain -revision
+                                             PMultiKeySupport PConditionalWrite
                                              PMultiKeyEDNValueStore
                                              PWriteHookStore]]
    #?(:clj [konserve.nio-helpers :as nio])

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -424,8 +424,16 @@
                         (when expected-revision
                         (check-revision! key expected-revision (first old)))
                       (if write-op?
-                          (<?- (update-blob backing store-key serializer write-handlers env old))
-                          old))
+                        (let [res (<?- (update-blob backing store-key serializer write-handlers env old))]
+                          (if (:with-revision? env)
+                            ;; The revision this write just created. Derived from the
+                            ;; SAME meta-fn the write used, so it is what landed —
+                            ;; and handing it back is what lets a caller chain fenced
+                            ;; writes without a read between them, which on a remote
+                            ;; store is the difference between one round-trip and two.
+                            [res (:revision ((:up-fn-meta env) (first old)))]
+                            res))
+                        old))
                       (finally
                         (when (:lock-blob? config)
                           (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
@@ -621,7 +629,7 @@
                                  :key  key}})))
 
   (-assoc-in [this key-vec meta-up val opts]
-    (let [{:keys [sync? expected-revision]} opts
+    (let [{:keys [sync? expected-revision with-revision?]} opts
           key (first key-vec)]
       (io-operation this serializers read-handlers write-handlers
                     {:key-vec key-vec
@@ -637,6 +645,7 @@
                      :buffer-size buffer-size
                      :overwrite? (empty? (rest key-vec))
                      :expected-revision expected-revision
+                     :with-revision? with-revision?
                      :msg        {:type :write-edn-error
                                   :key  key}})))
 
@@ -733,11 +742,16 @@
   ;; A backing without `:lock-blob?` serializes nothing, so it cannot honour the
   ;; contract and must say so.
   (-conditional-write? [_]
-    ;; :machine, never further. The lock is an OS advisory lock on a file in this
-    ;; store's own directory, so it serializes processes that can see that file and
-    ;; nothing beyond. Without :lock-blob? nothing serializes read-old against
-    ;; write, so there is no domain at all.
-    (when (:lock-blob? config) :machine))
+    ;; ASK THE BACKING, do not infer from `:lock-blob?`. That flag says a lock is
+    ;; requested, not that one exists: konserve's IndexedDB backing sets it and
+    ;; implements `-get-lock` as a NO-OP ("the alternative is to overwrite
+    ;; defaults/update-blob"), so inferring the domain from the flag would tell two
+    ;; browser tabs they are fenced when nothing serializes them at all — precisely
+    ;; the lie this capability exists to prevent. A backing that does not declare a
+    ;; domain gets none, and `:expected-revision` is refused.
+    (when (:lock-blob? config)
+      (when (satisfies? protocols/PConditionalWrite backing)
+        (protocols/-conditional-write? backing))))
   (-revision [this key opts]
     (async+sync (:sync? opts) *default-sync-translation*
                 (go-try- (let [m (<?- (protocols/-get-meta this key opts))]

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -411,7 +411,23 @@
                             skip-write-probe?)
           store-key-exists? (when-not skip-exists?
                               (<?- (-blob-exists? backing store-key env)))
-          max-retries (get-in config [:optimistic-locking-retries] 0)]
+          max-retries (get-in config [:optimistic-locking-retries] 0)
+          ;; WHO NEEDS THE SIDECAR AT ALL. Only a backing whose fence IS konserve's
+          ;; lock — the compare-and-write in this function, which reaches
+          ;; `:process` or `:machine`. A backing that declares `:global` fences in
+          ;; its own storage layer (konserve-s3: If-Match, evaluated by S3) and its
+          ;; `-get-lock` is a no-op, so a sidecar would buy nothing; a backing that
+          ;; declares no domain refuses `:expected-revision` outright, so there is
+          ;; nothing to protect.
+          ;;
+          ;; This is not only tidiness. The probe below is an existence check, and
+          ;; on a `PReadMissSafe` backing that is exactly the round trip the whole
+          ;; read-miss-safe design exists to remove — a billed HEAD on every write
+          ;; to S3, and a `.getKey` transaction on every write to IndexedDB.
+          lock-based-fencing?
+          (and (:lock-blob? config)
+               (satisfies? protocols/PConditionalWrite backing)
+               (contains? #{:process :machine} (protocols/-conditional-write? backing)))]
       (cond
         ;; Read-first (PReadMissSafe): no existence probe — read the blob and
         ;; treat an absent key (store-key-not-found-ex) as the caller's
@@ -437,7 +453,7 @@
               ;; that operation for `:with-revision? true` and does not forward the
               ;; flag itself, so testing the operation is both correct and the only
               ;; thing available here.
-              cas-blob (when (and (= :read-edn-meta operation) (:lock-blob? config))
+              cas-blob (when (and (= :read-edn-meta operation) lock-based-fencing?)
                          (<?- (-create-blob backing cas-store-key env)))
               cas-lock (when cas-blob
                          (log/trace :konserve/acquiring-cas-lock {:key key})
@@ -525,7 +541,7 @@
                         ;; too, so a reader that fences (datahike re-reads the
                         ;; branch head before every commit) closes it before its
                         ;; first write.
-                        cas-blob (when (and (:lock-blob? config)
+                        cas-blob (when (and lock-based-fencing?
                                             (or (some? expected-revision)
                                                 (= :read-edn-meta operation)
                                                 (<?- (-blob-exists? backing cas-store-key env))))

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -12,7 +12,7 @@
                                              -serialize -deserialize
                                              PAssocSerializers
                                              PKeyIterable
-                                             PMultiKeySupport PConditionalWrite -conditional-write? -revision
+                                             PMultiKeySupport PConditionalWrite -conditional-write-domain -revision
                                              PMultiKeyEDNValueStore
                                              PWriteHookStore]]
    #?(:clj [konserve.nio-helpers :as nio])
@@ -427,7 +427,7 @@
           lock-based-fencing?
           (and (:lock-blob? config)
                (satisfies? protocols/PConditionalWrite backing)
-               (contains? #{:process :machine} (protocols/-conditional-write? backing)))]
+               (contains? #{:process :machine} (protocols/-conditional-write-domain backing)))]
       (cond
         ;; Read-first (PReadMissSafe): no existence probe — read the blob and
         ;; treat an absent key (store-key-not-found-ex) as the caller's
@@ -967,7 +967,7 @@
   ;; processes on one filesystem. NOT across machines: the lock file is local.
   ;; A backing without `:lock-blob?` serializes nothing, so it cannot honour the
   ;; contract and must say so.
-  (-conditional-write? [_]
+  (-conditional-write-domain [_]
     ;; ASK THE BACKING, do not infer from `:lock-blob?`. That flag says a lock is
     ;; requested, not that one exists: konserve's IndexedDB backing sets it and
     ;; implements `-get-lock` as a NO-OP ("the alternative is to overwrite
@@ -976,7 +976,7 @@
     ;; the lie this capability exists to prevent. A backing that does not declare a
     ;; domain gets none, and `:expected-revision` is refused.
     (let [declared (when (satisfies? protocols/PConditionalWrite backing)
-                     (protocols/-conditional-write? backing))]
+                     (protocols/-conditional-write-domain backing))]
       ;; WHICH MECHANISM the domain rests on decides whether `:lock-blob?` can
       ;; revoke it, and the domain itself says which:
       ;;

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -545,121 +545,108 @@
                                             (or (some? expected-revision)
                                                 (= :read-edn-meta operation)
                                                 (<?- (-blob-exists? backing cas-store-key env))))
-                                   (<?- (-create-blob backing cas-store-key env)))
-                        cas-lock (when cas-blob
-                                   (log/trace :konserve/acquiring-cas-lock {:key key})
-                                   (<?- (get-lock cas-blob (first key-vec) env)))
-                        ;; Re-probed HERE, under the cas lock and BEFORE the blob
-                        ;; is opened, because `-create-blob` creates the file: after
-                        ;; it, "does this key exist" can no longer be asked. The
-                        ;; pre-lock probe is not evidence either — a competing
-                        ;; create can land between it and the lock, and trusting it
-                        ;; would let a create-if-absent see ::absent and overwrite
-                        ;; the other create.
-                        exists-under-lock? (when expected-revision
-                                             (<?- (-blob-exists? backing store-key env)))
-                        ;; See the `finally` below: set when a FENCED write to a
-                        ;; key that did not exist fails, so the empty blob
-                        ;; `-create-blob` just made can be removed again.
-                        ghost? (volatile! false)
-                        blob (<?- (-create-blob backing store-key env))
-                        lock   (when (:lock-blob? config)
-                                 (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
-                                 (<?- (get-lock blob (first key-vec) env)))]
+                                   (<?- (-create-blob backing cas-store-key env)))]
+                    ;; THREE NESTED try/finally, one per thing acquired, because a
+                    ;; `let` binding that throws skips every `finally` written
+                    ;; below it. The sidecar used to be taken up here and released
+                    ;; in the innermost `finally`, so anything that threw in
+                    ;; between — an IOException opening the value blob, the
+                    ;; existence probe, `get-lock` giving up after ~1s of
+                    ;; contention — leaked a `FileLock`. That lock is held by the
+                    ;; OS on behalf of the whole JVM, so ONE transient error made
+                    ;; the key unreadable and unwritable for every process on the
+                    ;; machine until this one exited. Reads take the sidecar too,
+                    ;; so a branch head would simply stop responding.
                     (try
-                      (let [old (cond
-                                  ;; A FENCED write decides from the existence
-                                  ;; probe taken UNDER the lock, not from the
-                                  ;; pre-lock one. Reading unconditionally is wrong:
-                                  ;; `-create-blob` has just created an empty file
-                                  ;; for a missing key, and reading THAT raises a
-                                  ;; header-size error rather than not-found.
-                                  expected-revision
-                                  (if exists-under-lock?
-                                    (<?- (read-blob blob read-handlers serializers env))
-                                    [nil nil])
-                                  ;; full overwrite never needs the old value
-                                  overwrite? [nil nil]
-                                  ;; miss-safe non-overwrite write: no probe was done, so
-                                  ;; read-first and treat an absent key as a fresh write.
-                                  skip-write-probe?
-                                  (try (<?- (read-blob blob read-handlers serializers env))
-                                       (catch #?(:clj Exception :cljs js/Error) e
-                                         (if (store-key-not-found? e) [nil nil] (throw e))))
-                                  ;; probe said the key exists (or this is a retry): read old
-                                  (or store-key-exists? (pos? attempt))
-                                  (<?- (read-blob blob read-handlers serializers env))
-                                  :else [nil nil])]
-                        (when expected-revision
-                          (check-revision! key expected-revision (first old)))
-                        (if write-op?
-                          ;; The meta is computed ONCE and the same value is both
-                          ;; written and reported. Calling the meta-fn a second time
-                          ;; to learn the revision was correct only while the
-                          ;; revision was a counter derived from `old`; a minted
-                          ;; token differs on every call, so the caller was handed a
-                          ;; revision that had never been stored — and every chained
-                          ;; fenced write then failed against a head nobody else had
-                          ;; touched. Measured 60/60 wrong before this.
-                          (let [new-meta (when (:with-revision? env)
-                                           ((:up-fn-meta env) (first old)))
-                                env      (cond-> env new-meta (assoc :up-fn-meta (constantly new-meta)))
-                                res      (<?- (update-blob backing store-key serializer write-handlers env old))]
-                            (if new-meta
-                              [res (:revision new-meta)]
-                              res))
-                          old))
-                      (catch #?(:clj Exception :cljs js/Error) e
-                        (vreset! ghost? (and expected-revision (not exists-under-lock?)))
-                        (throw e))
+                      (let [cas-lock (when cas-blob
+                                       (log/trace :konserve/acquiring-cas-lock {:key key})
+                                       (<?- (get-lock cas-blob (first key-vec) env)))]
+                        (try
+                          ;; Probed HERE, under the cas lock, because `-create-blob`
+                          ;; creates the file: after it, "does this key exist" can no
+                          ;; longer be asked. The pre-lock probe is not evidence
+                          ;; either — a competing create can land between it and the
+                          ;; lock, and trusting it would let a create-if-absent see
+                          ;; ::absent and overwrite the other create.
+                          (let [exists-under-lock? (when expected-revision
+                                                     (<?- (-blob-exists? backing store-key env)))
+                                ;; NOTHING TO READ MEANS NOTHING TO CREATE. A fenced
+                                ;; write to a key that does not exist either fails its
+                                ;; check (no revision to match) or is a create, and
+                                ;; `update-blob` makes its own blob either way — so
+                                ;; opening this one would only produce an empty file
+                                ;; we might never write.
+                                ;;
+                                ;; That empty file was the "ghost", and the cleanup
+                                ;; written to remove it deleted BY PATH: on a backing
+                                ;; that takes no sidecar (every `:global` one, where
+                                ;; `lock-based-fencing?` is false) it ran unlocked and
+                                ;; unlinked whatever was at the path — which is the
+                                ;; winner's value in an ordinary create-if-absent
+                                ;; race. Reproduced against MinIO: 10 of 10 keys, one
+                                ;; peer told its fenced write SUCCEEDED and the key
+                                ;; then missing. Worse on S3 than on a filestore,
+                                ;; because there `-create-blob` writes nothing
+                                ;; remotely, so there was never a ghost to collect and
+                                ;; the delete was pure destruction.
+                                ;;
+                                ;; Not creating it retires the ghost, the cleanup, and
+                                ;; the race in the cleanup together.
+                                skip-blob? (and expected-revision (not exists-under-lock?))
+                                blob (when-not skip-blob?
+                                       (<?- (-create-blob backing store-key env)))
+                                lock (when (and blob (:lock-blob? config))
+                                       (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
+                                       (<?- (get-lock blob (first key-vec) env)))]
+                            (try
+                              (let [old (cond
+                                          ;; A FENCED write decides from the existence
+                                          ;; probe taken UNDER the lock, not from the
+                                          ;; pre-lock one.
+                                          expected-revision
+                                          (if exists-under-lock?
+                                            (<?- (read-blob blob read-handlers serializers env))
+                                            [nil nil])
+                                          ;; full overwrite never needs the old value
+                                          overwrite? [nil nil]
+                                          ;; miss-safe non-overwrite write: no probe was done, so
+                                          ;; read-first and treat an absent key as a fresh write.
+                                          skip-write-probe?
+                                          (try (<?- (read-blob blob read-handlers serializers env))
+                                               (catch #?(:clj Exception :cljs js/Error) e
+                                                 (if (store-key-not-found? e) [nil nil] (throw e))))
+                                          ;; probe said the key exists (or this is a retry): read old
+                                          (or store-key-exists? (pos? attempt))
+                                          (<?- (read-blob blob read-handlers serializers env))
+                                          :else [nil nil])]
+                                (when expected-revision
+                                  (check-revision! key expected-revision (first old)))
+                                (if write-op?
+                                  ;; The meta is computed ONCE and the same value is both
+                                  ;; written and reported. Calling the meta-fn a second time
+                                  ;; to learn the revision was correct only while the
+                                  ;; revision was a counter derived from `old`; a minted
+                                  ;; token differs on every call, so the caller was handed a
+                                  ;; revision that had never been stored — and every chained
+                                  ;; fenced write then failed against a head nobody else had
+                                  ;; touched. Measured 60/60 wrong before this.
+                                  (let [new-meta (when (:with-revision? env)
+                                                   ((:up-fn-meta env) (first old)))
+                                        env      (cond-> env new-meta (assoc :up-fn-meta (constantly new-meta)))
+                                        res      (<?- (update-blob backing store-key serializer write-handlers env old))]
+                                    (if new-meta
+                                      [res (:revision new-meta)]
+                                      res))
+                                  old))
+                              (finally
+                                (when lock
+                                  (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
+                                  (<?- (-release lock env)))
+                                (when blob (<?- (-close blob env))))))
+                          (finally
+                            (when cas-lock (<?- (-release cas-lock env))))))
                       (finally
-                        (when (:lock-blob? config)
-                          (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
-                          (<?- (-release lock env)))
-                        (<?- (-close blob env))
-                        ;; A REJECTED fenced write must leave no trace. `-create-blob`
-                        ;; creates the file before we can know whether the revision
-                        ;; matches, so a conflict — the most ordinary outcome there
-                        ;; is — would otherwise leave a zero-length blob behind for a
-                        ;; key that never existed. That is worse than the write
-                        ;; failing: `read-blob` on an empty file raises a header-size
-                        ;; error rather than reporting not-found, so the key is not
-                        ;; missing and not readable, and `:expected-revision absent`
-                        ;; can never succeed on it again. The key is BRICKED by a
-                        ;; conflict that was supposed to be harmless.
-                        ;;
-                        ;; Deleted after the close but STILL UNDER THE SIDECAR
-                        ;; LOCK, which is the whole reason the release moved below
-                        ;; it. The delete is by PATH, so with the lock already
-                        ;; dropped it unlinked whatever happened to be at that
-                        ;; path — including a value another writer had just
-                        ;; renamed into place. A rejected write destroying a
-                        ;; committed one is far worse than the bricked blob this
-                        ;; cleanup exists to prevent; it showed up as 9 lost
-                        ;; writes in 4000 iterations of a natural race. Holding
-                        ;; the sidecar means no other write to this key can be
-                        ;; between our probe and this delete, because a fenceable
-                        ;; key's writers all take it (see above).
-                        ;;
-                        ;; Closing before deleting: unlinking an open file is fine
-                        ;; on POSIX and fails on Windows.
-                        ;;
-                        ;; Scoped to fenced writes because it is the only path that
-                        ;; creates a blob it may then refuse to write; the
-                        ;; unconditional paths write whatever they created.
-                        (when @ghost?
-                          (log/trace :konserve/removing-rejected-blob {:key key})
-                          ;; Never let cleanup REPLACE the outcome: the caller is
-                          ;; being handed a `:konserve/revision-mismatch` they can
-                          ;; retry on, and a NoSuchFileException thrown from here
-                          ;; would arrive in its place as an unrecognised IO error.
-                          (try (<?- (-delete-blob backing store-key env))
-                               (catch #?(:clj Exception :cljs js/Error) e
-                                 (log/warn :konserve/rejected-blob-cleanup-failed
-                                           {:key key :error e}))))
-                        (when cas-lock
-                          (<?- (-release cas-lock env))
-                          (<?- (-close cas-blob env))))))
+                        (when cas-blob (<?- (-close cas-blob env))))))
                   (catch #?(:clj Exception :cljs js/Error) e
                     ;; DELIBERATELY not retried: `:konserve/revision-mismatch`.
                     ;; That conflict belongs to the CALLER — retrying would re-run

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -8,13 +8,13 @@
    [konserve.compressor :refer [get-compressor null-compressor]]
    [konserve.encryptor :refer [get-encryptor null-encryptor]]
    [konserve.protocols :as protocols :refer [PEDNKeyValueStore
-                               PBinaryKeyValueStore
-                               -serialize -deserialize
-                               PAssocSerializers
-                               PKeyIterable
-                               PMultiKeySupport PConditionalWrite -conditional-write? -revision
-                               PMultiKeyEDNValueStore
-                               PWriteHookStore]]
+                                             PBinaryKeyValueStore
+                                             -serialize -deserialize
+                                             PAssocSerializers
+                                             PKeyIterable
+                                             PMultiKeySupport PConditionalWrite -conditional-write? -revision
+                                             PMultiKeyEDNValueStore
+                                             PWriteHookStore]]
    #?(:clj [konserve.nio-helpers :as nio])
    [konserve.impl.storage-layout :refer [-streaming-binary-write? -atomic-move -create-store
                                          -copy -create-blob -delete-blob -blob-exists?
@@ -291,6 +291,14 @@
    A key never written since revisions were introduced has no `:revision`, so it
    reads as nil and a caller that read nil and passes nil back still matches."
   [key expected old-meta]
+  (when (and (some? old-meta) (not (contains? old-meta :revision)))
+    ;; Written before revisions existed. There is no token to compare, so there
+    ;; is no way to tell whether it changed — and answering "unchanged" would let
+    ;; the caller overwrite a value it never saw. Refuse; one unconditional write
+    ;; gives the key a revision and it is fenceable from then on.
+    (throw (ex-info "This value predates revisions, so a conditional write cannot be evaluated against it. Write it once unconditionally to give it a revision."
+                    {:type :konserve/revision-unavailable
+                     :key  key})))
   (let [actual (if (nil? old-meta) absent (:revision old-meta))]
     (when-not (= expected actual)
       (throw (ex-info "Conditional write rejected: the stored revision is not the one this value was derived from."
@@ -403,12 +411,63 @@
         (loop [attempt 0]
           (let [result
                 (try
-                  (let [blob (<?- (-create-blob backing store-key env))
+                  (let [;; A FENCED write serializes on a SIDECAR whose inode never
+                        ;; moves, acquired BEFORE the blob is even opened.
+                        ;;
+                        ;; The blob lock alone cannot do this. It is held on an
+                        ;; INODE, and a non-in-place write replaces the file by
+                        ;; rename — so a writer that opened the blob, waited for the
+                        ;; lock, and found the file renamed underneath it holds a
+                        ;; lock on an orphan and reads stale metadata. Its compare
+                        ;; then passes against content that already changed.
+                        ;; Reproduced exactly that way from two JVMs: both writers
+                        ;; fenced on one revision, both succeeded, the first write
+                        ;; was lost.
+                        ;;
+                        ;; Writing IN PLACE would also keep the inode stable, and
+                        ;; was tried — but it gives up the atomic rename, and a torn
+                        ;; write to a mutable POINTER is a corrupt database. That is
+                        ;; a worse failure than the race, so the pointer keeps its
+                        ;; rename and the exclusion moves to a file that has none.
+                        ;;
+                        ;; One extra object per FENCED key, not per key: fencing is
+                        ;; for mutable pointers (a branch head), of which there are
+                        ;; a handful, not for the content-addressed values that make
+                        ;; up the bulk of a store.
+                        cas-blob (when (and expected-revision (:lock-blob? config))
+                                   (<?- (-create-blob backing (str store-key ".cas") env)))
+                        cas-lock (when cas-blob
+                                   (log/trace :konserve/acquiring-cas-lock {:key key})
+                                   (<?- (get-lock cas-blob (first key-vec) env)))
+                        ;; Re-probed HERE, under the cas lock and BEFORE the blob
+                        ;; is opened, because `-create-blob` creates the file: after
+                        ;; it, "does this key exist" can no longer be asked. The
+                        ;; pre-lock probe is not evidence either — a competing
+                        ;; create can land between it and the lock, and trusting it
+                        ;; would let a create-if-absent see ::absent and overwrite
+                        ;; the other create.
+                        exists-under-lock? (when expected-revision
+                                             (<?- (-blob-exists? backing store-key env)))
+                        ;; See the `finally` below: set when a FENCED write to a
+                        ;; key that did not exist fails, so the empty blob
+                        ;; `-create-blob` just made can be removed again.
+                        ghost? (volatile! false)
+                        blob (<?- (-create-blob backing store-key env))
                         lock   (when (:lock-blob? config)
                                  (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
                                  (<?- (get-lock blob (first key-vec) env)))]
                     (try
                       (let [old (cond
+                                  ;; A FENCED write decides from the existence
+                                  ;; probe taken UNDER the lock, not from the
+                                  ;; pre-lock one. Reading unconditionally is wrong:
+                                  ;; `-create-blob` has just created an empty file
+                                  ;; for a missing key, and reading THAT raises a
+                                  ;; header-size error rather than not-found.
+                                  expected-revision
+                                  (if exists-under-lock?
+                                    (<?- (read-blob blob read-handlers serializers env))
+                                    [nil nil])
                                   ;; full overwrite never needs the old value
                                   overwrite? [nil nil]
                                   ;; miss-safe non-overwrite write: no probe was done, so
@@ -422,23 +481,56 @@
                                   (<?- (read-blob blob read-handlers serializers env))
                                   :else [nil nil])]
                         (when expected-revision
-                        (check-revision! key expected-revision (first old)))
-                      (if write-op?
-                        (let [res (<?- (update-blob backing store-key serializer write-handlers env old))]
-                          (if (:with-revision? env)
-                            ;; The revision this write just created. Derived from the
-                            ;; SAME meta-fn the write used, so it is what landed —
-                            ;; and handing it back is what lets a caller chain fenced
-                            ;; writes without a read between them, which on a remote
-                            ;; store is the difference between one round-trip and two.
-                            [res (:revision ((:up-fn-meta env) (first old)))]
-                            res))
-                        old))
+                          (check-revision! key expected-revision (first old)))
+                        (if write-op?
+                          ;; The meta is computed ONCE and the same value is both
+                          ;; written and reported. Calling the meta-fn a second time
+                          ;; to learn the revision was correct only while the
+                          ;; revision was a counter derived from `old`; a minted
+                          ;; token differs on every call, so the caller was handed a
+                          ;; revision that had never been stored — and every chained
+                          ;; fenced write then failed against a head nobody else had
+                          ;; touched. Measured 60/60 wrong before this.
+                          (let [new-meta (when (:with-revision? env)
+                                           ((:up-fn-meta env) (first old)))
+                                env      (cond-> env new-meta (assoc :up-fn-meta (constantly new-meta)))
+                                res      (<?- (update-blob backing store-key serializer write-handlers env old))]
+                            (if new-meta
+                              [res (:revision new-meta)]
+                              res))
+                          old))
+                      (catch #?(:clj Exception :cljs js/Error) e
+                        (vreset! ghost? (and expected-revision (not exists-under-lock?)))
+                        (throw e))
                       (finally
                         (when (:lock-blob? config)
                           (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
                           (<?- (-release lock env)))
-                        (<?- (-close blob env)))))
+                        (when cas-lock
+                          (<?- (-release cas-lock env))
+                          (<?- (-close cas-blob env)))
+                        (<?- (-close blob env))
+                        ;; A REJECTED fenced write must leave no trace. `-create-blob`
+                        ;; creates the file before we can know whether the revision
+                        ;; matches, so a conflict — the most ordinary outcome there
+                        ;; is — would otherwise leave a zero-length blob behind for a
+                        ;; key that never existed. That is worse than the write
+                        ;; failing: `read-blob` on an empty file raises a header-size
+                        ;; error rather than reporting not-found, so the key is not
+                        ;; missing and not readable, and `:expected-revision absent`
+                        ;; can never succeed on it again. The key is BRICKED by a
+                        ;; conflict that was supposed to be harmless.
+                        ;;
+                        ;; Deleted here, after the close, rather than in the catch:
+                        ;; unlinking an open file is fine on POSIX and fails on
+                        ;; Windows.
+                        ;;
+                        ;; Scoped to fenced writes because it is the only path that
+                        ;; creates a blob it may then refuse to write; the
+                        ;; unconditional paths write whatever they created.
+                        (when @ghost?
+                          (log/trace :konserve/removing-rejected-blob {:key key})
+                          (<?- (-delete-blob backing store-key env))))))
                   (catch #?(:clj Exception :cljs js/Error) e
                     ;; DELIBERATELY not retried: `:konserve/revision-mismatch`.
                     ;; That conflict belongs to the CALLER — retrying would re-run
@@ -650,7 +742,12 @@
                                   :key  key}})))
 
   (-update-in [this key-vec meta-up up-fn opts]
-    (let [{:keys [sync? expected-revision]} opts
+    ;; `:with-revision?` is forwarded here for the same reason as in `-assoc-in`:
+    ;; a caller that fences with `:expected-revision` needs the revision its write
+    ;; PRODUCED in order to chain the next one. Omitting it here meant `update-in`
+    ;; silently answered with the plain `[old new]` shape however the caller
+    ;; asked, so a chained fenced update-in had nothing to fence against.
+    (let [{:keys [sync? expected-revision with-revision?]} opts
           key (first key-vec)]
       (io-operation this serializers read-handlers write-handlers
                     {:key-vec key-vec
@@ -665,6 +762,7 @@
                      :sync? sync?
                      :buffer-size buffer-size
                      :expected-revision expected-revision
+                     :with-revision? with-revision?
                      :msg        {:type :write-edn-error
                                   :key  key}})))
   (-dissoc [_ key opts]

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -280,6 +280,36 @@
    remove."
   ::absent)
 
+(def ^:const cas-lock-suffix
+  "Suffix of the sidecar blob a FENCED write takes its lock on.
+
+   Its own blob rather than the value's because a lock lives on an INODE, and the
+   write replaces the value blob by rename — which orphans a lock taken on it, so
+   two writers could each hold a lock on a different inode and both believe they
+   were serialized. The sidecar is never renamed, so it is a stable thing to lock.
+
+   It therefore PERSISTS after the write, and must be recognised as konserve's own
+   bookkeeping wherever store keys are enumerated. See `internal-artifact?`."
+  ".cas")
+
+(defn internal-artifact?
+  "Is `store-key` konserve's own bookkeeping rather than a stored value?
+
+   `.new` and `.backup` are transient write artifacts; `.cas` is the fenced-write
+   lock sidecar, which is permanent.
+
+   This matters more than it looks. An unrecognised name falls through to
+   `-handle-foreign-key`, whose job is to migrate a value written in an older
+   layout — so the sidecar was read as if it were a value, and `k/keys` (and
+   `konserve.gc/sweep!` through it) THREW from the first fenced write onwards, on
+   every default-backing store, permanently: the file is not transient and
+   `dissoc`ing the key does not remove it. Backends that filter enumeration
+   themselves must include this suffix too."
+  [store-key]
+  (or (ends-with? store-key ".new")
+      (ends-with? store-key ".backup")
+      (ends-with? store-key cas-lock-suffix)))
+
 (defn check-revision!
   "Throw unless the stored revision is the one the caller derived its value from.
 
@@ -435,7 +465,7 @@
                         ;; a handful, not for the content-addressed values that make
                         ;; up the bulk of a store.
                         cas-blob (when (and expected-revision (:lock-blob? config))
-                                   (<?- (-create-blob backing (str store-key ".cas") env)))
+                                   (<?- (-create-blob backing (str store-key cas-lock-suffix) env)))
                         cas-lock (when cas-blob
                                    (log/trace :konserve/acquiring-cas-lock {:key key})
                                    (<?- (get-lock cas-blob (first key-vec) env)))
@@ -567,8 +597,7 @@
              [store-key & store-keys] store-keys]
         (if store-key
           (cond
-            (or (ends-with? store-key ".new")
-                (ends-with? store-key ".backup"))
+            (internal-artifact? store-key)
             (recur keys store-keys)
 
             (ends-with? store-key ".ksv")
@@ -869,7 +898,28 @@
   (-revision [this key opts]
     (async+sync (:sync? opts) *default-sync-translation*
                 (go-try- (let [m (<?- (protocols/-get-meta this key opts))]
-                           (if (nil? m) absent (:revision m))))))
+                           (cond
+                             (nil? m) absent
+                             ;; A KEY WITH NO REVISION MUST NOT ANSWER nil. Every
+                             ;; value written by this version has one, but a store
+                             ;; upgraded from an earlier konserve does not, and
+                             ;; neither does a key rebuilt by `migrate-file-v1`.
+                             ;; Handing back nil looked like a token and was then
+                             ;; accepted as one — nil is falsy, so it sailed past
+                             ;; every conditional gate and wrote UNCONDITIONALLY,
+                             ;; while the caller believed they had fenced. That is
+                             ;; the documented read-then-hand-it-back pattern
+                             ;; silently overwriting exactly the keys someone would
+                             ;; try it on first. Refuse instead: rewrite the key
+                             ;; once (an ordinary write mints a revision) and fence
+                             ;; from there.
+                             (nil? (:revision m))
+                             (throw (ex-info (str "This key has no revision: it was written before konserve "
+                                                  "recorded them, so there is nothing to fence against. Write "
+                                                  "it once unconditionally to mint one.")
+                                             {:type :konserve/revision-unavailable
+                                              :key  key}))
+                             :else (:revision m))))))
 
   PMultiKeySupport
   (-supports-multi-key? [_]

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -412,22 +412,26 @@
           store-key-exists? (when-not skip-exists?
                               (<?- (-blob-exists? backing store-key env)))
           max-retries (get-in config [:optimistic-locking-retries] 0)
-          ;; WHO NEEDS THE SIDECAR AT ALL. Only a backing whose fence IS konserve's
-          ;; lock — the compare-and-write in this function, which reaches
-          ;; `:process` or `:machine`. A backing that declares `:global` fences in
-          ;; its own storage layer (konserve-s3: If-Match, evaluated by S3) and its
-          ;; `-get-lock` is a no-op, so a sidecar would buy nothing; a backing that
-          ;; declares no domain refuses `:expected-revision` outright, so there is
-          ;; nothing to protect.
+          ;; WHO NEEDS THE SIDECAR AT ALL. Only a backing that does NOT fence
+          ;; itself, and therefore needs konserve to provide the mechanism: the
+          ;; compare-and-write in this function, made atomic by a lock.
           ;;
-          ;; This is not only tidiness. The probe below is an existence check, and
-          ;; on a `PReadMissSafe` backing that is exactly the round trip the whole
-          ;; read-miss-safe design exists to remove — a billed HEAD on every write
-          ;; to S3, and a `.getKey` transaction on every write to IndexedDB.
+          ;; Asked as a mechanism question, not inferred from the domain. The
+          ;; domain says how far a guarantee reaches, which is a different thing
+          ;; from who evaluates it — see `PSelfConditionalWrite`, where the cases
+          ;; that broke the old inference are written out.
+          ;;
+          ;; The cost of getting this wrong is not only tidiness. The probe below
+          ;; is an existence check, and on a `PReadMissSafe` backing that is
+          ;; exactly the round trip the read-miss-safe design exists to remove — a
+          ;; billed HEAD on every write to S3, a `.getKey` transaction on every
+          ;; write to IndexedDB — plus a sidecar blob written into a storage layer
+          ;; that has no use for one.
           lock-based-fencing?
           (and (:lock-blob? config)
                (satisfies? protocols/PConditionalWrite backing)
-               (contains? #{:process :machine} (protocols/-conditional-write-domain backing)))]
+               (some? (protocols/-conditional-write-domain backing))
+               (not (satisfies? protocols/PSelfConditionalWrite backing)))]
       (cond
         ;; Read-first (PReadMissSafe): no existence probe — read the blob and
         ;; treat an absent key (store-key-not-found-ex) as the caller's
@@ -960,36 +964,27 @@
                   :msg {:type :read-all-keys-error}})))
 
   PConditionalWrite
-  ;; The blob lock spans read-old and write (see `io-operation`), and it is an OS
-  ;; advisory lock on the filestore, so the compare-and-write is atomic across
-  ;; processes on one filesystem. NOT across machines: the lock file is local.
-  ;; A backing without `:lock-blob?` serializes nothing, so it cannot honour the
-  ;; contract and must say so.
   (-conditional-write-domain [_]
     ;; ASK THE BACKING, do not infer from `:lock-blob?`. That flag says a lock is
     ;; requested, not that one exists: konserve's IndexedDB backing sets it and
     ;; implements `-get-lock` as a NO-OP ("the alternative is to overwrite
-    ;; defaults/update-blob"), so inferring the domain from the flag would tell two
+    ;; defaults/update-blob"), so inferring a domain from the flag would tell two
     ;; browser tabs they are fenced when nothing serializes them at all — precisely
     ;; the lie this capability exists to prevent. A backing that does not declare a
     ;; domain gets none, and `:expected-revision` is refused.
     (let [declared (when (satisfies? protocols/PConditionalWrite backing)
                      (protocols/-conditional-write-domain backing))]
-      ;; WHICH MECHANISM the domain rests on decides whether `:lock-blob?` can
-      ;; revoke it, and the domain itself says which:
+      ;; `:lock-blob?` can revoke a claim that RESTS on konserve's lock, and only
+      ;; such a claim. Without the flag there is no lock, the compare and the write
+      ;; stop being one step, and the claim is void however sincerely it is made.
       ;;
-      ;; `:process`/`:machine` are produced HERE, by `io-operation` holding a lock
-      ;; across read-old and write. Without `:lock-blob?` there is no lock, the
-      ;; compare and the write stop being one step, and the claim is void however
-      ;; sincerely the backing makes it. So the flag revokes it.
-      ;;
-      ;; `:global` cannot be produced by a lock local to this machine, so a
-      ;; backing claiming it is fencing in its own storage layer (konserve-s3:
-      ;; If-Match, evaluated by S3) where konserve's lock is irrelevant. Revoking
-      ;; that on `:lock-blob?` would mean a flag about a lock nobody uses silently
-      ;; turning off the guarantee — konserve-s3's `-get-lock` IS a no-op, and it
-      ;; passes today only because it happens to set the flag anyway.
-      (if (= :global declared)
+      ;; A backing that fences ITSELF keeps its domain whatever the flag says: the
+      ;; flag is about a lock it never uses. That used to be decided by testing the
+      ;; domain for `:global`, which held only because the one self-fencing backing
+      ;; happened to be global — see `PSelfConditionalWrite` for the stores that
+      ;; fence themselves without reaching that far, which the old test would have
+      ;; silently disarmed.
+      (if (satisfies? protocols/PSelfConditionalWrite backing)
         declared
         (when (:lock-blob? config) declared))))
   (-revision [this key opts]

--- a/src/konserve/memory.cljc
+++ b/src/konserve/memory.cljc
@@ -75,21 +75,6 @@
   (-assoc-in [this key-vec meta val opts]
     (-update-in this key-vec meta (fn [_] val) (assoc opts :overwrite? true)))
 
-  PConditionalWrite
-  ;; A single `swap!` carries both the comparison and the write, so this holds
-  ;; for every thread sharing the atom. It says nothing across processes, but a
-  ;; memory store has no across-processes to speak of.
-  (-conditional-write? [_]
-    ;; :process. The compare and the write are one `swap!`, which covers every
-    ;; thread sharing this atom and says nothing about anyone else — a memory
-    ;; store has no anyone else.
-    :process)
-  (-revision [_ key opts]
-    (async+sync (:sync? opts)
-                {go do}
-                (go (if-let [[meta _] (get @state key)]
-                      (:revision meta)
-                      kd/absent))))
   (-dissoc [_ key opts]
     (let [{:keys [sync?]} opts]
       (async+sync sync?
@@ -102,6 +87,20 @@
                           (swap! state dissoc key)
                           true)
                         false))))))
+
+  PConditionalWrite
+  ;; :process. The compare and the write are one `swap!`, which covers every
+  ;; thread sharing this atom and says nothing about anyone else — a memory store
+  ;; has no anyone else. Placed AFTER PEDNKeyValueStore's methods on purpose:
+  ;; splitting a protocol's methods around another marker is silently tolerated on
+  ;; the JVM and is a compile warning in ClojureScript, which is how this was found.
+  (-conditional-write? [_] :process)
+  (-revision [_ key opts]
+    (async+sync (:sync? opts)
+                {go do}
+                (go (if-let [[meta _] (get @state key)]
+                      (:revision meta)
+                      kd/absent))))
   PBinaryKeyValueStore
   (-bget [_ key locked-cb opts]
     (let [{:keys [sync?]} opts]

--- a/src/konserve/memory.cljc
+++ b/src/konserve/memory.cljc
@@ -29,13 +29,22 @@
                    <! do}
                   (go  (if (get @state key false) true false)))))
   (-get-in [_ key-vec not-found opts]
-    (let [{:keys [sync?]} opts]
+    (let [{:keys [sync? with-revision?]} opts]
       (async+sync sync?
                   {go do
                    <! do}
-                  (go (if-let [a (second (get @state (first key-vec)))]
-                        (get-in a (rest key-vec) not-found)
-                        not-found)))))
+                  (go (let [entry (get @state (first key-vec))
+                            v     (if-let [a (second entry)]
+                                    (get-in a (rest key-vec) not-found)
+                                    not-found)]
+                        ;; `:with-revision?` is part of the contract, not an
+                        ;; optimisation: a caller written against it destructures
+                        ;; `[value revision]`, and returning a bare value here
+                        ;; makes portable code throw on `nth` — or, worse, silently
+                        ;; fence on nil when this store is a tiered frontend.
+                        (if with-revision?
+                          [v (if entry (:revision (first entry)) kd/absent)]
+                          v))))))
   (-get-meta [_ key opts]
     (let [{:keys [sync?]} opts]
       (async+sync sync?
@@ -46,9 +55,16 @@
       (async+sync sync?
                   {go do}
                   (go
-                    (let [[fkey & rkey] key-vec
-                          update-atom
-                          (fn [store]
+                    ;; The rejection must arrive AS A VALUE on this channel. This
+                    ;; store uses a plain `go`, not `go-try-`, so a throw from
+                    ;; `check-revision!` would escape to the async thread's uncaught
+                    ;; handler and close the channel EMPTY — an async caller could
+                    ;; not tell a rejected fence from a successful write, and the
+                    ;; error would surface only as noise in the log.
+                    (try
+                      (let [[fkey & rkey] key-vec
+                            update-atom
+                            (fn [store]
                             ;; The compare and the write are one `swap!`, so they
                             ;; are atomic against other threads in this JVM —
                             ;; which is the whole of a memory store's world. The
@@ -56,22 +72,30 @@
                             ;; it before would let another writer land between the
                             ;; comparison and the update, which is the very race
                             ;; this exists to prevent.
-                            (swap! store
-                                   (fn [old]
-                                     (when expected-revision
-                                       (kd/check-revision! fkey expected-revision
-                                                           (first (get old fkey))))
-                                     (update old fkey
-                                             (fn [[meta data]]
-                                               [(meta-up-fn meta)
-                                                (if rkey
-                                                  (update-in data rkey up-fn)
-                                                  (up-fn data))])))))
-                          [_ old-val] (get @state fkey)
-                          {[_ new-val] fkey} (update-atom state)]
-                      (if overwrite?
-                        [nil new-val]
-                        [old-val new-val]))))))
+                              (swap! store
+                                     (fn [old]
+                                       (when expected-revision
+                                         (kd/check-revision! fkey expected-revision
+                                                             (first (get old fkey))))
+                                       (update old fkey
+                                               (fn [[meta data]]
+                                                 [(meta-up-fn meta)
+                                                  (if rkey
+                                                    (update-in data rkey up-fn)
+                                                    (up-fn data))])))))
+                            [_ old-val] (get @state fkey)
+                            {[_ new-val] fkey} (update-atom state)]
+                        (if overwrite?
+                          [nil new-val]
+                          [old-val new-val]))
+                      ;; The two arms report differently, and both must be honoured:
+                      ;; a SYNC caller expects a throw, an ASYNC caller expects the
+                      ;; error as a value on the channel (throwing there escapes to
+                      ;; the async thread and closes the channel empty). `async+sync`
+                      ;; collapses the `go` to a `do` for the sync arm, so one catch
+                      ;; serves both only if it rethrows there.
+                      (catch #?(:clj Exception :cljs js/Error) e
+                        (if sync? (throw e) e)))))))
   (-assoc-in [this key-vec meta val opts]
     (-update-in this key-vec meta (fn [_] val) (assoc opts :overwrite? true)))
 

--- a/src/konserve/memory.cljc
+++ b/src/konserve/memory.cljc
@@ -3,7 +3,7 @@
    Does not support serialization."
   (:require [clojure.core.async :as async :refer [go <!]]
             [konserve.impl.defaults :as kd]
-            [konserve.protocols :refer [PConditionalWrite -conditional-write? -revision
+            [konserve.protocols :refer [PConditionalWrite -conditional-write-domain -revision
                                         PEDNKeyValueStore -update-in
                                         PBinaryKeyValueStore PKeyIterable
                                         PMultiKeyEDNValueStore PMultiKeySupport
@@ -118,7 +118,7 @@
   ;; has no anyone else. Placed AFTER PEDNKeyValueStore's methods on purpose:
   ;; splitting a protocol's methods around another marker is silently tolerated on
   ;; the JVM and is a compile warning in ClojureScript, which is how this was found.
-  (-conditional-write? [_] :process)
+  (-conditional-write-domain [_] :process)
   (-revision [_ key opts]
     (async+sync (:sync? opts)
                 {go do}

--- a/src/konserve/memory.cljc
+++ b/src/konserve/memory.cljc
@@ -51,7 +51,7 @@
                   {go do}
                   (go (first (get @state key))))))
   (-update-in [_ key-vec meta-up-fn up-fn opts]
-    (let [{:keys [sync? overwrite? expected-revision]} opts]
+    (let [{:keys [sync? overwrite? expected-revision with-revision?]} opts]
       (async+sync sync?
                   {go do}
                   (go
@@ -84,10 +84,22 @@
                                                     (update-in data rkey up-fn)
                                                     (up-fn data))])))))
                             [_ old-val] (get @state fkey)
-                            {[_ new-val] fkey} (update-atom state)]
-                        (if overwrite?
-                          [nil new-val]
-                          [old-val new-val]))
+                            {[new-meta new-val] fkey} (update-atom state)
+                            res (if overwrite? [nil new-val] [old-val new-val])]
+                        ;; `:with-revision?` reports the revision this write
+                        ;; PRODUCED, so a caller can chain a fenced write without a
+                        ;; re-read. It was destructured nowhere here, so this store
+                        ;; — konserve's own reference implementation, which declares
+                        ;; `:process` and passes the contract — accepted the option
+                        ;; and returned the plain shape. A caller destructuring
+                        ;; `[[old new] rev]` got the VALUE bound as the token and
+                        ;; fenced the next write on it, and `k/update-in` threw
+                        ;; `nth not supported on this type` outright. Accepted and
+                        ;; silently dropped is the exact failure this whole
+                        ;; mechanism exists to remove.
+                        (if with-revision?
+                          [res (:revision new-meta)]
+                          res))
                       ;; The two arms report differently, and both must be honoured:
                       ;; a SYNC caller expects a throw, an ASYNC caller expects the
                       ;; error as a value on the channel (throwing there escapes to

--- a/src/konserve/memory.cljc
+++ b/src/konserve/memory.cljc
@@ -20,6 +20,28 @@
   memory-store-registry
   (atom {}))
 
+(defn- atomic!
+  "Run `f` with exclusive access to `state`.
+
+   `swap!` is not enough for `-update-in`. It RETRIES its function whenever the
+   atom changed underneath, so a conflict arriving mid-flight ran the caller's
+   `up-fn` and only THEN rejected — while konserve promises that a rejected
+   update does not run it at all, and this store is the reference the compliance
+   suite is pointed at. A monitor makes read, check, apply and write one step, so
+   `up-fn` runs exactly once and never on a rejection.
+
+   EVERY mutation takes it, not only the fenced ones: mixing a monitor with bare
+   `swap!`s elsewhere would let another write land between this one's read and
+   write and be silently overwritten, which is the race the monitor was added to
+   remove.
+
+   `:process` is exactly what this store claims — atomic against other threads in
+   this runtime, which two store objects sharing one state atom are — so this is
+   the honest way to provide it. ClojureScript needs no lock: a synchronous block
+   cannot be interrupted there."
+  [state f]
+  #?(:clj (locking state (f)) :cljs (f)))
+
 (defrecord MemoryStore [state read-handlers write-handlers locks write-hooks]
   PEDNKeyValueStore
   (-exists? [_ key opts]
@@ -63,28 +85,28 @@
                     ;; error would surface only as noise in the log.
                     (try
                       (let [[fkey & rkey] key-vec
-                            update-atom
-                            (fn [store]
-                            ;; The compare and the write are one `swap!`, so they
-                            ;; are atomic against other threads in this JVM —
-                            ;; which is the whole of a memory store's world. The
-                            ;; check lives INSIDE the swap fn deliberately: doing
-                            ;; it before would let another writer land between the
-                            ;; comparison and the update, which is the very race
-                            ;; this exists to prevent.
-                              (swap! store
-                                     (fn [old]
-                                       (when expected-revision
-                                         (kd/check-revision! fkey expected-revision
-                                                             (first (get old fkey))))
-                                       (update old fkey
-                                               (fn [[meta data]]
-                                                 [(meta-up-fn meta)
-                                                  (if rkey
-                                                    (update-in data rkey up-fn)
-                                                    (up-fn data))])))))
-                            [_ old-val] (get @state fkey)
-                            {[new-meta new-val] fkey} (update-atom state)
+                            ;; Read, check, apply and write as ONE step. The old
+                            ;; value is read in here too: taken outside, it could
+                            ;; be from before another writer's update and reported
+                            ;; as this call's `old`.
+                            [old-val new-meta new-val]
+                            (atomic! state
+                                     (fn []
+                                       (let [old @state
+                                             [_ prev-val] (get old fkey)]
+                                         (when expected-revision
+                                           (kd/check-revision! fkey expected-revision
+                                                               (first (get old fkey))))
+                                         (let [next-state
+                                               (update old fkey
+                                                       (fn [[meta data]]
+                                                         [(meta-up-fn meta)
+                                                          (if rkey
+                                                            (update-in data rkey up-fn)
+                                                            (up-fn data))]))
+                                               [nm nv] (get next-state fkey)]
+                                           (reset! state next-state)
+                                           [prev-val nm nv]))))
                             res (if overwrite? [nil new-val] [old-val new-val])]
                         ;; `:with-revision?` reports the revision this write
                         ;; PRODUCED, so a caller can chain a fenced write without a
@@ -120,7 +142,7 @@
                     (let [v (get @state key ::not-found)]
                       (if (not= v ::not-found)
                         (do
-                          (swap! state dissoc key)
+                          (atomic! state (fn [] (swap! state dissoc key)))
                           true)
                         false))))))
 
@@ -165,11 +187,13 @@
                   {go do
                    <! do}
                   (go
-                    (swap! state
-                           (fn [old]
-                             (update old key
-                                     (fn [[meta _data]]
-                                       [(meta-up-fn meta) input]))))
+                    (atomic! state
+                             (fn []
+                               (swap! state
+                                      (fn [old]
+                                        (update old key
+                                                (fn [[meta _data]]
+                                                  [(meta-up-fn meta) input]))))))
                     true))))
   PAssocSerializers ;; no serializers needed for memory
   (-assoc-serializers [this _serializers] this)
@@ -191,14 +215,16 @@
                   {go do}
                   (go
                     ;; Use an atomic update on the state atom to ensure all key-val pairs are updated atomically
-                    (swap! state
-                           (fn [old-state]
-                             (reduce (fn [acc [key val]]
-                                       (update acc key
-                                               (fn [[meta _data]]
-                                                 [(meta-up-fn key :edn meta) val])))
-                                     old-state
-                                     kvs)))
+                    (atomic! state
+                             (fn []
+                               (swap! state
+                                      (fn [old-state]
+                                        (reduce (fn [acc [key val]]
+                                                  (update acc key
+                                                          (fn [[meta _data]]
+                                                            [(meta-up-fn key :edn meta) val])))
+                                                old-state
+                                                kvs)))))
                     ;; Return a map of keys to success status
                     (into {} (map (fn [[k _]] [k true]) kvs))))))
 
@@ -208,9 +234,11 @@
                   {go do}
                   (go
                     ;; Atomically swap state and capture old value to avoid race conditions
-                    (let [[old-state _new-state] (swap-vals! state
-                                                             (fn [s]
-                                                               (apply dissoc s keys)))]
+                    (let [[old-state _new-state] (atomic! state
+                                                          (fn []
+                                                            (swap-vals! state
+                                                                        (fn [s]
+                                                                          (apply dissoc s keys)))))]
                       ;; Check existence against the actual old state we swapped from
                       (into {} (map (fn [k]
                                       [k (contains? old-state k)])

--- a/src/konserve/memory.cljc
+++ b/src/konserve/memory.cljc
@@ -2,7 +2,9 @@
   "Address globally aggregated immutable key-value store(s).
    Does not support serialization."
   (:require [clojure.core.async :as async :refer [go <!]]
-            [konserve.protocols :refer [PEDNKeyValueStore -update-in
+            [konserve.impl.defaults :as kd]
+            [konserve.protocols :refer [PConditionalWrite -conditional-write? -revision
+                                        PEDNKeyValueStore -update-in
                                         PBinaryKeyValueStore PKeyIterable
                                         PMultiKeyEDNValueStore PMultiKeySupport
                                         PAssocSerializers PWriteHookStore]]
@@ -40,15 +42,25 @@
                   {go do}
                   (go (first (get @state key))))))
   (-update-in [_ key-vec meta-up-fn up-fn opts]
-    (let [{:keys [sync? overwrite?]} opts]
+    (let [{:keys [sync? overwrite? expected-revision]} opts]
       (async+sync sync?
                   {go do}
                   (go
                     (let [[fkey & rkey] key-vec
                           update-atom
                           (fn [store]
+                            ;; The compare and the write are one `swap!`, so they
+                            ;; are atomic against other threads in this JVM —
+                            ;; which is the whole of a memory store's world. The
+                            ;; check lives INSIDE the swap fn deliberately: doing
+                            ;; it before would let another writer land between the
+                            ;; comparison and the update, which is the very race
+                            ;; this exists to prevent.
                             (swap! store
                                    (fn [old]
+                                     (when expected-revision
+                                       (kd/check-revision! fkey expected-revision
+                                                           (first (get old fkey))))
                                      (update old fkey
                                              (fn [[meta data]]
                                                [(meta-up-fn meta)
@@ -62,6 +74,22 @@
                         [old-val new-val]))))))
   (-assoc-in [this key-vec meta val opts]
     (-update-in this key-vec meta (fn [_] val) (assoc opts :overwrite? true)))
+
+  PConditionalWrite
+  ;; A single `swap!` carries both the comparison and the write, so this holds
+  ;; for every thread sharing the atom. It says nothing across processes, but a
+  ;; memory store has no across-processes to speak of.
+  (-conditional-write? [_]
+    ;; :process. The compare and the write are one `swap!`, which covers every
+    ;; thread sharing this atom and says nothing about anyone else — a memory
+    ;; store has no anyone else.
+    :process)
+  (-revision [_ key opts]
+    (async+sync (:sync? opts)
+                {go do}
+                (go (if-let [[meta _] (get @state key)]
+                      (:revision meta)
+                      kd/absent))))
   (-dissoc [_ key opts]
     (let [{:keys [sync?]} opts]
       (async+sync sync?

--- a/src/konserve/node_filestore.cljs
+++ b/src/konserve/node_filestore.cljs
@@ -9,6 +9,7 @@
             [konserve.encryptor]
             [konserve.impl.defaults :as defaults]
             [konserve.impl.storage-layout :as storage-layout]
+            [konserve.protocols :as protocols]
             [konserve.serializers]
             [konserve.store :as store]
             [konserve.utils :refer-macros [with-promise]]
@@ -514,6 +515,12 @@
 
 (defrecord NodejsBackingFilestore
            [base detected-old-blobs ephemeral?]
+  protocols/PConditionalWrite
+  ;; :machine. `_lock` opens an exclusive `.lock` FILE, so a second process
+  ;; attempting the same path fails and the compare-and-write is one step for
+  ;; processes on this filesystem. Not beyond it.
+  (-conditional-write? [_] :machine)
+
   storage-layout/PBackingStore
   (-create-blob [_this store-key env]
     (let [store-path (path.join base store-key)]

--- a/src/konserve/node_filestore.cljs
+++ b/src/konserve/node_filestore.cljs
@@ -519,7 +519,7 @@
   ;; :machine. `_lock` opens an exclusive `.lock` FILE, so a second process
   ;; attempting the same path fails and the compare-and-write is one step for
   ;; processes on this filesystem. Not beyond it.
-  (-conditional-write? [_] :machine)
+  (-conditional-write-domain [_] :machine)
 
   storage-layout/PBackingStore
   (-create-blob [_this store-key env]

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -71,8 +71,16 @@
    this must REFUSE `:expected-revision`, not ignore it. Silently degrading to an
    unconditional write is worse than having no fencing at all: the caller has
    asked for a guarantee, and would get a knob that reads as handled."
-  (-conditional-write? [this]
-    "How far this store's conditional writes actually reach, or nil for not at all:
+  (-conditional-write-domain [this]
+    "How far this store's conditional writes actually reach, or nil for not at all.
+
+     Named for what it RETURNS. It was `-conditional-write?` for a while, which
+     reads as a predicate to every backend author who has to implement it — and a
+     domain answered as if it were a boolean is the precise confusion this whole
+     protocol exists to prevent. `konserve.core/conditional-write?` keeps the `?`,
+     because that one really is a predicate: it compares a domain you need against
+     the domain a store has.
+
 
        nil       cannot compare-and-write; `:expected-revision` is REFUSED
        :process  atomic against other threads in this runtime  (memory: one `swap!`)

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -88,7 +88,20 @@
      the capability exists to prevent, one level finer: appearing fenced without
      being fenced.
 
-     Ordered weakest-first, so a caller can state the domain it needs and compare.")
+     Ordered weakest-first, so a caller can state the domain it needs and compare.
+
+     WHAT A DOMAIN CLAIMS IS A MECHANISM, not an intention. konserve's default
+     backing enforces the comparison in `konserve.impl.defaults/io-operation`:
+     read the stored revision and write the new value while holding a local lock.
+     That is genuinely atomic against threads (`:process`) and, with an OS
+     advisory lock on the blob, against processes on the host (`:machine`) — and
+     it cannot reach further, because nothing in it is visible to another
+     machine. A store that answers `:global` therefore does NOT get there through
+     `io-operation`; it must implement the comparison in its own storage layer,
+     where the guarantee actually lives — konserve-s3 does it with a conditional
+     PUT (`If-Match` on the object's ETag), which S3 evaluates. Answering
+     `:global` while relying on the default compare would be the exact failure
+     this protocol exists to prevent, written one layer down.")
   (-revision [this key opts]
     "The token to hand back as `:expected-revision`, or the absent sentinel.
 

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -64,6 +64,41 @@
   (-set-write-hooks! [this hooks-atom]
     "Set the write-hooks atom. Returns the modified store."))
 
+(defprotocol PConditionalWrite
+  "Stores that can make a write conditional on the revision the caller read.
+
+   The point of the capability being explicit is that a store which CANNOT do
+   this must REFUSE `:expected-revision`, not ignore it. Silently degrading to an
+   unconditional write is worse than having no fencing at all: the caller has
+   asked for a guarantee, and would get a knob that reads as handled."
+  (-conditional-write? [this]
+    "How far this store's conditional writes actually reach, or nil for not at all:
+
+       nil       cannot compare-and-write; `:expected-revision` is REFUSED
+       :process  atomic against other threads in this runtime  (memory: one `swap!`)
+       :machine  atomic against other processes on this host   (filestore: an OS
+                 advisory lock — and NOT across NFS or any network filesystem,
+                 where advisory locks are unreliable)
+       :global   atomic against every writer anywhere          (S3: If-Match)
+
+     A DOMAIN rather than a boolean because the API is uniform and the guarantee is
+     not. `true` would let a caller planning to run two processes against a memory
+     store — or two machines against a filestore — believe they are fenced when they
+     are only serialized against a narrower set of writers. That is the same failure
+     the capability exists to prevent, one level finer: appearing fenced without
+     being fenced.
+
+     Ordered weakest-first, so a caller can state the domain it needs and compare.")
+  (-revision [this key opts]
+    "The token to hand back as `:expected-revision`, or the absent sentinel.
+
+     Its OWN function rather than a field of `-get-meta`, because the two can
+     disagree: a tiered store answers metadata from whichever tier its read-policy
+     names, while the conditional write is evaluated by the tier that owns the
+     durable value. Reading the revision from the frontend and comparing it
+     against the backend's compares two independent counters, which is worse than
+     not comparing at all. This function always resolves to the tier that decides."))
+
 (defprotocol PLockFreeStore
   "Protocol for stores that handle concurrency internally (e.g., MVCC backends like LMDB).
    These stores don't need application-level locking for read/write operations."

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -135,6 +135,16 @@
      It requires a writer that does not fence, which is the premise already
      broken.
 
+     PREFER YOUR OWN STORAGE LAYER. The sidecar konserve's default backing uses
+     to reach `:machine` is a filesystem fallback — POSIX has no
+     compare-and-rename — and it costs an extra blob open and lock per write to a
+     fenced key. A store with a native conditional operation (SQL row version,
+     Redis WATCH, a DynamoDB ConditionExpression, GCS generation match, S3
+     If-Match) should implement the comparison there instead: no extra round
+     trips, and a stronger reach. The sidecar work is gated on a backing
+     declaring `:process`/`:machine`, so backings that declare nothing or
+     `:global` pay nothing for it.
+
      WHAT A DOMAIN CLAIMS IS A MECHANISM, not an intention. konserve's default
      backing enforces the comparison in `konserve.impl.defaults/io-operation`:
      read the stored revision and write the new value while holding a local lock.

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -111,11 +111,21 @@
      existence probe.
 
      The residual, stated because a fence with an unstated hole is worse than no
-     fence: the FIRST such write or read on a key can still race an unconditional
-     write, since there is nothing to lock until the sidecar exists. It is
-     self-healing — once created the key is covered for good — and a caller that
-     re-reads a pointer before writing it (which is what fencing implies) creates
-     it on that read, before its first conditional write.
+     fence: until a key has a sidecar there is nothing to lock, so its FIRST
+     fenced write can race an unconditional one. Two consequences worth being
+     exact about, because the obvious reading is too kind:
+
+       - It is CREATE-IF-ABSENT that is exposed, always. A revision-bearing read
+         creates the sidecar only for a key that exists, so a key being created
+         for the first time — every branch head, once — has no sidecar until the
+         write that makes it.
+       - In that window the loser can lose more than the race. Two writers that
+         both believe the key absent can both proceed, and the one that is
+         rejected has already been told nothing about the other's value.
+
+     After that first write the key is covered for good, and a caller that
+     re-reads an existing pointer before writing it (which is what fencing
+     implies) has the sidecar in place before every later write.
 
      WHAT A DOMAIN CLAIMS IS A MECHANISM, not an intention. konserve's default
      backing enforces the comparison in `konserve.impl.defaults/io-operation`:

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -110,22 +110,30 @@
      a revision-bearing read touches it; keys that are never fenced pay only an
      existence probe.
 
-     The residual, stated because a fence with an unstated hole is worse than no
-     fence: until a key has a sidecar there is nothing to lock, so its FIRST
-     fenced write can race an unconditional one. Two consequences worth being
-     exact about, because the obvious reading is too kind:
+     WHO IS EXCLUDED, and the limit that is not konserve's to fix. Conditional
+     writes are optimistic concurrency control, so they order writers that
+     PARTICIPATE. A writer that issues an unconditional write overwrites whatever
+     is there, and no scheme prevents that — not S3's If-Match, not a row-version
+     column, not this. Fencing a store means every writer to that key fences.
 
-       - It is CREATE-IF-ABSENT that is exposed, always. A revision-bearing read
-         creates the sidecar only for a key that exists, so a key being created
-         for the first time — every branch head, once — has no sidecar until the
-         write that makes it.
-       - In that window the loser can lose more than the race. Two writers that
-         both believe the key absent can both proceed, and the one that is
-         rejected has already been told nothing about the other's value.
+     Given that, konserve serialises correctly from the very first write: two
+     conditional writers racing a key with no sidecar both open the same
+     `<key>.cas` (created, not created-anew), so they take the same lock and one
+     is rejected.
 
-     After that first write the key is covered for good, and a caller that
-     re-reads an existing pointer before writing it (which is what fencing
-     implies) has the sidecar in place before every later write.
+     Where konserve goes FURTHER than the premise requires: once a key has a
+     sidecar, unconditional writers take it too, so they are ordered against
+     fenced ones rather than merely winning by luck. S3 cannot offer that — a
+     non-participant there is beyond reach entirely.
+
+     The gap between those two, stated because it is the one case that behaves
+     worse than S3 rather than better: a key that has no sidecar YET, being
+     written by a non-participant at the same moment as its first conditional
+     write. S3 would reject the conditional writer (its ETag moved); here the
+     conditional writer can read the value the non-participant just replaced,
+     compare against that, pass, and overwrite it. Both are told they succeeded.
+     It requires a writer that does not fence, which is the premise already
+     broken.
 
      WHAT A DOMAIN CLAIMS IS A MECHANISM, not an intention. konserve's default
      backing enforces the comparison in `konserve.impl.defaults/io-operation`:

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -64,6 +64,41 @@
   (-set-write-hooks! [this hooks-atom]
     "Set the write-hooks atom. Returns the modified store."))
 
+(defprotocol PSelfConditionalWrite
+  "Marker: THIS backing evaluates the precondition itself.
+
+   REACH AND MECHANISM ARE DIFFERENT QUESTIONS, and `-conditional-write-domain`
+   answers only the first. How far a guarantee extends is a property of the
+   deployment; WHO compares the revision is a property of the implementation, and
+   one does not follow from the other. Implement this when your storage layer
+   evaluates the condition — a conditional PUT, `UPDATE ... WHERE revision = ?`,
+   a `ConditionExpression`, a write transaction — whatever its reach.
+
+   Without it, konserve's default backing provides the mechanism instead: it
+   compares and writes while holding a lock, on a sidecar blob (see
+   `konserve.impl.defaults/cas-lock-suffix`), because a filesystem offers no
+   compare-and-rename. Say so by NOT implementing this marker, which is what both
+   filestores do.
+
+   Why a marker and not an inference from the domain. konserve used to treat
+   `:process`/`:machine` as meaning it wants konserve's lock, and `:global` as
+   meaning it fences itself — sound in only one direction: no local lock
+   can reach across machines, but plenty of stores fence themselves WITHOUT
+   reaching that far. RocksDB is `:process` with a write batch; LMDB is
+   `:machine` with an ACID transaction; a JDBC backend is `:global` on Postgres
+   and `:machine` on SQLite with the SAME statement — so the inference would have
+   handed konserve's sidecar to half of them, writing a phantom `.cas` row into
+   the very table it is fencing.
+
+   It also asked a question the domain cannot answer. Inferring the mechanism
+   means assuming `-get-lock` really serializes; konserve's own IndexedDB backing
+   sets `:lock-blob?` and implements `-get-lock` as a no-op, so the inference
+   would have given it a compare-and-write with no exclusion at all — advertising
+   a domain it does not have, which is the failure this protocol exists to
+   prevent, produced by the machinery meant to prevent it."
+  ;; No methods: implementing it IS the statement.
+  )
+
 (defprotocol PConditionalWrite
   "Stores that can make a write conditional on the revision the caller read.
 

--- a/src/konserve/protocols.cljc
+++ b/src/konserve/protocols.cljc
@@ -76,9 +76,11 @@
 
        nil       cannot compare-and-write; `:expected-revision` is REFUSED
        :process  atomic against other threads in this runtime  (memory: one `swap!`)
-       :machine  atomic against other processes on this host   (filestore: an OS
-                 advisory lock — and NOT across NFS or any network filesystem,
-                 where advisory locks are unreliable)
+       :machine  atomic against other processes on this host   (JVM filestore: an
+                 OS advisory lock; node filestore: an O_EXCL lockfile, which a
+                 crashed writer leaves behind where the kernel would have
+                 released an advisory one. NOT across NFS or any network
+                 filesystem, where advisory locks are unreliable)
        :global   atomic against every writer anywhere          (S3: If-Match)
 
      A DOMAIN rather than a boolean because the API is uniform and the guarantee is
@@ -89,6 +91,23 @@
      being fenced.
 
      Ordered weakest-first, so a caller can state the domain it needs and compare.
+
+     WHAT `:machine` EXCLUDES, precisely, because it is easy to assume too much:
+     every writer to that KEY, not merely the ones that also fence. That has to
+     hold — konserve replaces a value by renaming a new file over it, so a fenced
+     write whose lock was taken on the old file would compare its revision
+     against a detached one, pass, and overwrite the value that replaced it. So
+     the lock lives on a sidecar that is never renamed, and every write to a key
+     that HAS one takes it. A key gets one the first time a conditional write or
+     a revision-bearing read touches it; keys that are never fenced pay only an
+     existence probe.
+
+     The residual, stated because a fence with an unstated hole is worse than no
+     fence: the FIRST such write or read on a key can still race an unconditional
+     write, since there is nothing to lock until the sidecar exists. It is
+     self-healing — once created the key is covered for good — and a caller that
+     re-reads a pointer before writing it (which is what fencing implies) creates
+     it on that read, before its first conditional write.
 
      WHAT A DOMAIN CLAIMS IS A MECHANISM, not an intention. konserve's default
      backing enforces the comparison in `konserve.impl.defaults/io-operation`:

--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -5,7 +5,8 @@
             #?(:clj [konserve.nio-helpers :as nio])
             [clojure.set :as set]
             [konserve.memory :as memory]
-            [konserve.protocols :as protocols :refer [-exists? -get-meta -get-in -assoc-in
+            [konserve.protocols :as protocols :refer [PConditionalWrite -conditional-write? -revision
+                                                      -exists? -get-meta -get-in -assoc-in
                                                       -update-in -dissoc -bget -bassoc
                                                       -keys -multi-get -multi-assoc -multi-dissoc -assoc-serializers
                                                       PEDNKeyValueStore PBinaryKeyValueStore
@@ -166,6 +167,30 @@
                   :reachable-keys (count reachable-keys)}))))
 
 (defrecord TieredStore [frontend-store backend-store write-policy read-policy locks config]
+  PConditionalWrite
+  ;; Only `:write-through` can honour this, and only if the backend can.
+  ;;
+  ;; `:write-behind` cannot, for a reason no implementation effort would fix: it
+  ;; returns to the caller once the FRONTEND has the value and writes the backend
+  ;; in a `go` afterwards, so a rejected conditional write would be discovered
+  ;; after the caller was told it succeeded. There is nobody left to report it to.
+  ;;
+  ;; `:frontend-only` is a read-through cache over a backend another peer owns; it
+  ;; must not mutate it at all, let alone fence it.
+  (-conditional-write? [_]
+    ;; The BACKEND's domain, because the backend is what decides the write. A
+    ;; memory frontend over an S3 backend is :global; reporting the frontend's
+    ;; :process would be exactly backwards.
+    (when (= :write-through write-policy)
+      (when (satisfies? PConditionalWrite backend-store)
+        (-conditional-write? backend-store))))
+  ;; ALWAYS the backend, never the read-policy's choice. The two tiers keep
+  ;; INDEPENDENT revision counters — they are separate stores — so a revision read
+  ;; from the frontend and compared against the backend compares two unrelated
+  ;; numbers. That would fail open or closed at random, which is worse than having
+  ;; no fencing, because it looks like fencing.
+  (-revision [_ key opts] (-revision backend-store key opts))
+
   PEDNKeyValueStore
   (-exists? [_this key opts]
     (log/trace :konserve/tiered-exists? {:key key})

--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -166,6 +166,29 @@
                   :root-keys (count root-keys)
                   :reachable-keys (count reachable-keys)}))))
 
+(def ^:private core-dissoc
+  "`dissoc` from the host core, which this namespace shadows with the store op."
+  #?(:clj clojure.core/dissoc :cljs cljs.core/dissoc))
+
+(defn ^:private frontend-opts
+  "`opts` with the fencing options removed, for a call to the FRONTEND store.
+
+   A revision belongs to the store that minted it, and the two tiers mint their
+   own. Forwarding `:expected-revision` made the frontend reject a write the
+   backend had just accepted; the rejection was caught and logged, the caller was
+   told the fenced write succeeded, and every later `:frontend-first` read
+   returned the PRE-WRITE value indefinitely — using the fence created the
+   incoherence it exists to prevent. `:with-revision?` goes too: its result shape
+   is the caller's, and the frontend's token would be meaningless to them.
+
+   The BACKEND keeps the caller's opts: it is the store whose revisions
+   `-revision` reports and whose domain `-conditional-write?` advertises."
+  [opts]
+  ;; NOT `(dissoc opts ...)`: this namespace shadows `clojure.core/dissoc` with
+  ;; the store operation, and `clojure.core/dissoc` cannot be written out in a
+  ;; .cljc file because there it is `cljs.core/dissoc`.
+  (core-dissoc opts :expected-revision :with-revision?))
+
 (defrecord TieredStore [frontend-store backend-store write-policy read-policy locks config]
   PConditionalWrite
   ;; Only `:write-through` can honour this, and only if the backend can.
@@ -246,7 +269,7 @@
                            (when (not= backend-result ::missing)
                            ;; Populate frontend asynchronously (fire-and-forget)
                              (go (try
-                                   (<?- (-assoc-in frontend-store key-vec (partial meta-update (first key-vec) :edn) backend-result opts))
+                                   (<?- (-assoc-in frontend-store key-vec (partial meta-update (first key-vec) :edn) backend-result (frontend-opts opts)))
                                    (invoke-write-hooks! frontend-store {:api-op :assoc-in
                                                                         :key (first key-vec)
                                                                         :key-vec key-vec
@@ -270,14 +293,14 @@
                    ;; Write to both stores - backend first for durability
                    (let [backend-result (<?- (-update-in backend-store key-vec meta-up-fn up-fn opts))]
                      (try
-                       (<?- (-update-in frontend-store key-vec meta-up-fn up-fn opts))
+                       (<?- (-update-in frontend-store key-vec meta-up-fn up-fn (frontend-opts opts)))
                        (catch #?(:clj Exception :cljs js/Error) e
                          (log/warn :konserve/tiered-frontend-update-failed {:key key-vec :error e})))
                      backend-result)
 
                    :write-behind
                    ;; Write to frontend first, then backend asynchronously (standard write-behind)
-                   (let [frontend-result (<?- (-update-in frontend-store key-vec meta-up-fn up-fn opts))]
+                   (let [frontend-result (<?- (-update-in frontend-store key-vec meta-up-fn up-fn (frontend-opts opts)))]
                      (go (try
                            (<?- (-update-in backend-store key-vec meta-up-fn up-fn opts))
                            (catch #?(:clj Exception :cljs js/Error) e
@@ -288,14 +311,14 @@
                    ;; Write only to backend, invalidate frontend
                    (let [result (<?- (-update-in backend-store key-vec meta-up-fn up-fn opts))]
                      (go (try
-                           (<?- (-dissoc frontend-store (first key-vec) opts))
+                           (<?- (-dissoc frontend-store (first key-vec) (frontend-opts opts)))
                            (catch #?(:clj Exception :cljs js/Error) e
                              (log/warn :konserve/tiered-frontend-invalidation-failed {:key (first key-vec) :error e}))))
                      result)
 
                    :frontend-only
                    ;; Cache mode: write to the frontend only; never touch the backend.
-                   (<?- (-update-in frontend-store key-vec meta-up-fn up-fn opts))))))
+                   (<?- (-update-in frontend-store key-vec meta-up-fn up-fn (frontend-opts opts)))))))
 
   (-assoc-in [_this key-vec meta-up-fn val opts]
     (log/trace :konserve/tiered-assoc-in {:key-vec key-vec})
@@ -306,7 +329,16 @@
                    :write-through
                    (let [backend-result (<?- (-assoc-in backend-store key-vec meta-up-fn val opts))]
                      (try
-                       (<?- (-assoc-in frontend-store key-vec meta-up-fn val opts))
+                       ;; The FRONTEND IS NOT FENCED, and must not be handed the
+                       ;; caller's token. Revisions belong to the store that minted
+                       ;; them, and the two tiers mint their own — so forwarding
+                       ;; `:expected-revision` made the frontend reject a write the
+                       ;; backend had just accepted. The rejection was caught and
+                       ;; logged, the caller was told the fenced write succeeded,
+                       ;; and every later `:frontend-first` read returned the
+                       ;; PRE-WRITE value, indefinitely. Using the fence created
+                       ;; the incoherence it exists to prevent.
+                       (<?- (-assoc-in frontend-store key-vec meta-up-fn val (frontend-opts opts)))
                        (catch #?(:clj Exception :cljs js/Error) e
                          (log/warn :konserve/tiered-frontend-assoc-failed {:key key-vec :error e})))
                      backend-result)
@@ -323,7 +355,7 @@
                    :write-around
                    (let [result (<?- (-assoc-in backend-store key-vec meta-up-fn val opts))]
                      (go (try
-                           (<?- (-dissoc frontend-store (first key-vec) opts))
+                           (<?- (-dissoc frontend-store (first key-vec) (frontend-opts opts)))
                            (catch #?(:clj Exception :cljs js/Error) e
                              (log/warn :konserve/tiered-frontend-invalidation-failed {:key (first key-vec) :error e}))))
                      result)

--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -227,28 +227,38 @@
     (async+sync (:sync? opts)
                 *default-sync-translation*
                 (go-try-
-                 (case read-policy
-                   :frontend-first
-                   (let [frontend-result (<?- (-get-in frontend-store key-vec ::missing opts))]
-                     (if (not= frontend-result ::missing)
-                       frontend-result  ;; Cache hit
-                       (let [backend-result (<?- (-get-in backend-store key-vec ::missing opts))]
-                         (when (not= backend-result ::missing)
+                 (if (:with-revision? opts)
+                   ;; STRAIGHT TO THE BACKEND, whatever the read-policy says. The
+                   ;; revision must come from the tier that will EVALUATE the
+                   ;; conditional write, and that is always the backend. Serving it
+                   ;; from the frontend returns a token the backend has never seen —
+                   ;; and because the frontend is usually a memory store, the value
+                   ;; came back bare, so the caller fenced on nil and got an
+                   ;; UNCONDITIONAL write from a store advertising :machine. A cache
+                   ;; hit must not decide the identity of a durable value.
+                   (<?- (-get-in backend-store key-vec not-found opts))
+                   (case read-policy
+                     :frontend-first
+                     (let [frontend-result (<?- (-get-in frontend-store key-vec ::missing opts))]
+                       (if (not= frontend-result ::missing)
+                         frontend-result  ;; Cache hit
+                         (let [backend-result (<?- (-get-in backend-store key-vec ::missing opts))]
+                           (when (not= backend-result ::missing)
                            ;; Populate frontend asynchronously (fire-and-forget)
-                           (go (try
-                                 (<?- (-assoc-in frontend-store key-vec (partial meta-update (first key-vec) :edn) backend-result opts))
-                                 (invoke-write-hooks! frontend-store {:api-op :assoc-in
-                                                                      :key (first key-vec)
-                                                                      :key-vec key-vec
-                                                                      :value backend-result})
-                                 (catch #?(:clj Exception :cljs js/Error) e
-                                   (log/debug :konserve/tiered-frontend-populate-failed {:key key-vec :error e})))))
-                         (if (not= backend-result ::missing)
-                           backend-result
-                           not-found))))
+                             (go (try
+                                   (<?- (-assoc-in frontend-store key-vec (partial meta-update (first key-vec) :edn) backend-result opts))
+                                   (invoke-write-hooks! frontend-store {:api-op :assoc-in
+                                                                        :key (first key-vec)
+                                                                        :key-vec key-vec
+                                                                        :value backend-result})
+                                   (catch #?(:clj Exception :cljs js/Error) e
+                                     (log/debug :konserve/tiered-frontend-populate-failed {:key key-vec :error e})))))
+                           (if (not= backend-result ::missing)
+                             backend-result
+                             not-found))))
 
-                   :frontend-only
-                   (<?- (-get-in frontend-store key-vec not-found opts))))))
+                     :frontend-only
+                     (<?- (-get-in frontend-store key-vec not-found opts)))))))
 
   (-update-in [_this key-vec meta-up-fn up-fn opts]
     (log/trace :konserve/tiered-update-in {:key-vec key-vec})

--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -5,7 +5,7 @@
             #?(:clj [konserve.nio-helpers :as nio])
             [clojure.set :as set]
             [konserve.memory :as memory]
-            [konserve.protocols :as protocols :refer [PConditionalWrite -conditional-write? -revision
+            [konserve.protocols :as protocols :refer [PConditionalWrite -conditional-write-domain -revision
                                                       -exists? -get-meta -get-in -assoc-in
                                                       -update-in -dissoc -bget -bassoc
                                                       -keys -multi-get -multi-assoc -multi-dissoc -assoc-serializers
@@ -182,7 +182,7 @@
    is the caller's, and the frontend's token would be meaningless to them.
 
    The BACKEND keeps the caller's opts: it is the store whose revisions
-   `-revision` reports and whose domain `-conditional-write?` advertises."
+   `-revision` reports and whose domain `-conditional-write-domain` advertises."
   [opts]
   ;; NOT `(dissoc opts ...)`: this namespace shadows `clojure.core/dissoc` with
   ;; the store operation, and `clojure.core/dissoc` cannot be written out in a
@@ -200,13 +200,13 @@
   ;;
   ;; `:frontend-only` is a read-through cache over a backend another peer owns; it
   ;; must not mutate it at all, let alone fence it.
-  (-conditional-write? [_]
+  (-conditional-write-domain [_]
     ;; The BACKEND's domain, because the backend is what decides the write. A
     ;; memory frontend over an S3 backend is :global; reporting the frontend's
     ;; :process would be exactly backwards.
     (when (= :write-through write-policy)
       (when (satisfies? PConditionalWrite backend-store)
-        (-conditional-write? backend-store))))
+        (-conditional-write-domain backend-store))))
   ;; ALWAYS the backend, never the read-policy's choice. The two tiers keep
   ;; INDEPENDENT revision counters — they are separate stores — so a revision read
   ;; from the frontend and compared against the backend compares two unrelated

--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -200,6 +200,67 @@
   (or (contains? opts :expected-revision)
       (:with-revision? opts)))
 
+(defn ^:private make-cache-lock []
+  (let [lock (async/chan 1)]
+    (async/put! lock :unlocked)
+    lock))
+
+(defn ^:private take-cache-lock-sync! [cache-lock]
+  #?(:clj
+     (async/<!! cache-lock)
+     :cljs
+     (or (async/poll! cache-lock)
+         (throw (ex-info "A synchronous tiered cache operation contended with an asynchronous one."
+                         {:type :konserve/tiered-sync-cache-contention})))))
+
+(defn ^:private populate-frontend
+  "Run a read-through cache fill unless a backend write completed since its read.
+
+   The generation check and the frontend mutation share `cache-lock` with
+   post-write invalidation. Without both, a fire-and-forget fill can land after
+   a newer backend write invalidated the frontend and resurrect the stale value."
+  [cache-lock cache-generation observed-generation populate-fn opts]
+  (if (:sync? opts)
+    (try
+      (take-cache-lock-sync! cache-lock)
+      (if (= observed-generation @cache-generation)
+        (do
+          (populate-fn)
+          true)
+        false)
+      (finally
+        (async/put! cache-lock :unlocked)))
+    (go-try-
+     (try
+       (<?- cache-lock)
+       (if (= observed-generation @cache-generation)
+         (do
+           (<?- (populate-fn))
+           true)
+         false)
+       (finally
+         (async/put! cache-lock :unlocked))))))
+
+(defn ^:private update-frontend-after-backend
+  "Order a frontend mutation after all older read-through cache fills."
+  [cache-lock cache-generation update-fn opts]
+  (if (:sync? opts)
+    (try
+      (take-cache-lock-sync! cache-lock)
+      ;; Invalidate every fill that observed the backend before this write
+      ;; committed, including fills still waiting for the lock.
+      (swap! cache-generation inc)
+      (update-fn)
+      (finally
+        (async/put! cache-lock :unlocked)))
+    (go-try-
+     (try
+       (<?- cache-lock)
+       (swap! cache-generation inc)
+       (<?- (update-fn))
+       (finally
+         (async/put! cache-lock :unlocked))))))
+
 (defn ^:private invalidate-frontend
   "Synchronously evict `key` from the frontend after the backend committed.
 
@@ -207,12 +268,15 @@
    could otherwise return the pre-write value indefinitely after the caller was
    told its durable write succeeded. Raise an explicit PARTIAL outcome instead
    of claiming coherence; the backend write has already landed."
-  [frontend-store key opts]
+  [frontend-store cache-lock cache-generation key opts]
   (async+sync (:sync? opts)
               *default-sync-translation*
               (go-try-
                (try
-                 (<?- (-dissoc frontend-store key (frontend-opts opts)))
+                 (<?- (update-frontend-after-backend
+                       cache-lock cache-generation
+                       #(-dissoc frontend-store key (frontend-opts opts))
+                       opts))
                  (catch #?(:clj Exception :cljs js/Error) e
                    (throw (ex-info "The backend write committed, but the tiered frontend could not be invalidated."
                                    {:type               :konserve/tiered-cache-invalidation-failed
@@ -220,7 +284,7 @@
                                     :backend-committed? true}
                                    e)))))))
 
-(defrecord TieredStore [frontend-store backend-store write-policy read-policy locks config]
+(defrecord TieredStore [frontend-store backend-store write-policy read-policy locks cache-lock cache-generation config]
   PConditionalWrite
   ;; Only `:write-through` can honour this, and only if the backend can.
   ;;
@@ -296,15 +360,19 @@
                      (let [frontend-result (<?- (-get-in frontend-store key-vec ::missing opts))]
                        (if (not= frontend-result ::missing)
                          frontend-result  ;; Cache hit
-                         (let [backend-result (<?- (-get-in backend-store key-vec ::missing opts))]
+                         (let [observed-generation @cache-generation
+                               backend-result (<?- (-get-in backend-store key-vec ::missing opts))]
                            (when (not= backend-result ::missing)
                            ;; Populate frontend asynchronously (fire-and-forget)
                              (go (try
-                                   (<?- (-assoc-in frontend-store key-vec (partial meta-update (first key-vec) :edn) backend-result (frontend-opts opts)))
-                                   (invoke-write-hooks! frontend-store {:api-op :assoc-in
-                                                                        :key (first key-vec)
-                                                                        :key-vec key-vec
-                                                                        :value backend-result})
+                                   (when (<?- (populate-frontend
+                                               cache-lock cache-generation observed-generation
+                                               #(-assoc-in frontend-store key-vec (partial meta-update (first key-vec) :edn) backend-result (frontend-opts opts))
+                                               opts))
+                                     (invoke-write-hooks! frontend-store {:api-op :assoc-in
+                                                                          :key (first key-vec)
+                                                                          :key-vec key-vec
+                                                                          :value backend-result}))
                                    (catch #?(:clj Exception :cljs js/Error) e
                                      (log/debug :konserve/tiered-frontend-populate-failed {:key key-vec :error e})))))
                            (if (not= backend-result ::missing)
@@ -329,12 +397,15 @@
                        ;; stale frontend can compute a DIFFERENT value (and runs
                        ;; caller code twice). Evict the whole blob; the next read
                        ;; refills it from the authoritative backend.
-                       (<?- (invalidate-frontend frontend-store (first key-vec) opts))
+                       (<?- (invalidate-frontend frontend-store cache-lock cache-generation (first key-vec) opts))
                        (try
-                         (<?- (-update-in frontend-store key-vec meta-up-fn up-fn (frontend-opts opts)))
+                         (<?- (update-frontend-after-backend
+                               cache-lock cache-generation
+                               #(-update-in frontend-store key-vec meta-up-fn up-fn (frontend-opts opts))
+                               opts))
                          (catch #?(:clj Exception :cljs js/Error) e
                            (log/warn :konserve/tiered-frontend-update-failed {:key key-vec :error e})
-                           (<?- (invalidate-frontend frontend-store (first key-vec) opts)))))
+                           (<?- (invalidate-frontend frontend-store cache-lock cache-generation (first key-vec) opts)))))
                      backend-result)
 
                    :write-behind
@@ -372,12 +443,15 @@
                        ;; backend's revision stream. Eviction is also correct for a
                        ;; nested assoc: replaying it against a stale outer value
                        ;; would preserve fields the backend no longer has.
-                       (<?- (invalidate-frontend frontend-store (first key-vec) opts))
+                       (<?- (invalidate-frontend frontend-store cache-lock cache-generation (first key-vec) opts))
                        (try
-                         (<?- (-assoc-in frontend-store key-vec meta-up-fn val (frontend-opts opts)))
+                         (<?- (update-frontend-after-backend
+                               cache-lock cache-generation
+                               #(-assoc-in frontend-store key-vec meta-up-fn val (frontend-opts opts))
+                               opts))
                          (catch #?(:clj Exception :cljs js/Error) e
                            (log/warn :konserve/tiered-frontend-assoc-failed {:key key-vec :error e})
-                           (<?- (invalidate-frontend frontend-store (first key-vec) opts)))))
+                           (<?- (invalidate-frontend frontend-store cache-lock cache-generation (first key-vec) opts)))))
                      backend-result)
 
                    :write-behind
@@ -570,13 +644,17 @@
                          missing-keys (remove (set (clojure.core/keys frontend-result)) keys)]
                      (if (seq missing-keys)
                        ;; Some keys missing from frontend, fetch from backend
-                       (let [backend-result (<?- (-multi-get backend-store missing-keys opts))]
+                       (let [observed-generation @cache-generation
+                             backend-result (<?- (-multi-get backend-store missing-keys opts))]
                          ;; Populate frontend asynchronously with found backend values (fire-and-forget)
                          (when (seq backend-result)
                            (go (try
-                                 (<?- (-multi-assoc frontend-store backend-result meta-update opts))
-                                 (invoke-write-hooks! frontend-store {:api-op :multi-assoc
-                                                                      :kvs backend-result})
+                                 (when (<?- (populate-frontend
+                                             cache-lock cache-generation observed-generation
+                                             #(-multi-assoc frontend-store backend-result meta-update opts)
+                                             opts))
+                                   (invoke-write-hooks! frontend-store {:api-op :multi-assoc
+                                                                        :kvs backend-result}))
                                  (catch #?(:clj Exception :cljs js/Error) e
                                    (log/debug :konserve/tiered-frontend-populate-failed {:keys (clojure.core/keys backend-result) :error e})))))
                          ;; Merge frontend and backend results
@@ -623,5 +701,7 @@
                 :write-policy write-policy
                 :read-policy read-policy
                 :locks (atom {})
+                :cache-lock (make-cache-lock)
+                :cache-generation (atom 0)
                 :config params})]
     (if (:sync? opts) store (go store))))

--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -189,6 +189,37 @@
   ;; .cljc file because there it is `cljs.core/dissoc`.
   (core-dissoc opts :expected-revision :with-revision?))
 
+(defn ^:private revision-sensitive?
+  "Does this write participate in the backend's revision stream?
+
+   `:expected-revision` is the conditional half; `:with-revision?` asks for the
+   revision produced by an otherwise unconditional write so the caller can chain
+   the next one. In both cases the backend is authoritative and the frontend must
+   not independently replay the operation."
+  [opts]
+  (or (contains? opts :expected-revision)
+      (:with-revision? opts)))
+
+(defn ^:private invalidate-frontend
+  "Synchronously evict `key` from the frontend after the backend committed.
+
+   A failed eviction is not a harmless cache error: a `:frontend-first` read
+   could otherwise return the pre-write value indefinitely after the caller was
+   told its durable write succeeded. Raise an explicit PARTIAL outcome instead
+   of claiming coherence; the backend write has already landed."
+  [frontend-store key opts]
+  (async+sync (:sync? opts)
+              *default-sync-translation*
+              (go-try-
+               (try
+                 (<?- (-dissoc frontend-store key (frontend-opts opts)))
+                 (catch #?(:clj Exception :cljs js/Error) e
+                   (throw (ex-info "The backend write committed, but the tiered frontend could not be invalidated."
+                                   {:type               :konserve/tiered-cache-invalidation-failed
+                                    :key                key
+                                    :backend-committed? true}
+                                   e)))))))
+
 (defrecord TieredStore [frontend-store backend-store write-policy read-policy locks config]
   PConditionalWrite
   ;; Only `:write-through` can honour this, and only if the backend can.
@@ -292,10 +323,18 @@
                    :write-through
                    ;; Write to both stores - backend first for durability
                    (let [backend-result (<?- (-update-in backend-store key-vec meta-up-fn up-fn opts))]
-                     (try
-                       (<?- (-update-in frontend-store key-vec meta-up-fn up-fn (frontend-opts opts)))
-                       (catch #?(:clj Exception :cljs js/Error) e
-                         (log/warn :konserve/tiered-frontend-update-failed {:key key-vec :error e})))
+                     (if (revision-sensitive? opts)
+                       ;; The backend evaluated `up-fn` against the value whose
+                       ;; revision the caller supplied. Re-running it against a
+                       ;; stale frontend can compute a DIFFERENT value (and runs
+                       ;; caller code twice). Evict the whole blob; the next read
+                       ;; refills it from the authoritative backend.
+                       (<?- (invalidate-frontend frontend-store (first key-vec) opts))
+                       (try
+                         (<?- (-update-in frontend-store key-vec meta-up-fn up-fn (frontend-opts opts)))
+                         (catch #?(:clj Exception :cljs js/Error) e
+                           (log/warn :konserve/tiered-frontend-update-failed {:key key-vec :error e})
+                           (<?- (invalidate-frontend frontend-store (first key-vec) opts)))))
                      backend-result)
 
                    :write-behind
@@ -328,19 +367,17 @@
                  (case write-policy
                    :write-through
                    (let [backend-result (<?- (-assoc-in backend-store key-vec meta-up-fn val opts))]
-                     (try
-                       ;; The FRONTEND IS NOT FENCED, and must not be handed the
-                       ;; caller's token. Revisions belong to the store that minted
-                       ;; them, and the two tiers mint their own — so forwarding
-                       ;; `:expected-revision` made the frontend reject a write the
-                       ;; backend had just accepted. The rejection was caught and
-                       ;; logged, the caller was told the fenced write succeeded,
-                       ;; and every later `:frontend-first` read returned the
-                       ;; PRE-WRITE value, indefinitely. Using the fence created
-                       ;; the incoherence it exists to prevent.
-                       (<?- (-assoc-in frontend-store key-vec meta-up-fn val (frontend-opts opts)))
-                       (catch #?(:clj Exception :cljs js/Error) e
-                         (log/warn :konserve/tiered-frontend-assoc-failed {:key key-vec :error e})))
+                     (if (revision-sensitive? opts)
+                       ;; The frontend is a cache, not a second participant in the
+                       ;; backend's revision stream. Eviction is also correct for a
+                       ;; nested assoc: replaying it against a stale outer value
+                       ;; would preserve fields the backend no longer has.
+                       (<?- (invalidate-frontend frontend-store (first key-vec) opts))
+                       (try
+                         (<?- (-assoc-in frontend-store key-vec meta-up-fn val (frontend-opts opts)))
+                         (catch #?(:clj Exception :cljs js/Error) e
+                           (log/warn :konserve/tiered-frontend-assoc-failed {:key key-vec :error e})
+                           (<?- (invalidate-frontend frontend-store (first key-vec) opts)))))
                      backend-result)
 
                    :write-behind

--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -345,7 +345,7 @@
 
                    :write-behind
                    ;; Write to frontend first, then backend asynchronously (standard write-behind)
-                   (let [frontend-result (<?- (-assoc-in frontend-store key-vec meta-up-fn val opts))]
+                   (let [frontend-result (<?- (-assoc-in frontend-store key-vec meta-up-fn val (frontend-opts opts)))]
                      (go (try
                            (<?- (-assoc-in backend-store key-vec meta-up-fn val opts))
                            (catch #?(:clj Exception :cljs js/Error) e
@@ -361,7 +361,7 @@
                      result)
 
                    :frontend-only
-                   (<?- (-assoc-in frontend-store key-vec meta-up-fn val opts))))))
+                   (<?- (-assoc-in frontend-store key-vec meta-up-fn val (frontend-opts opts)))))))
 
   (-dissoc [_this key opts]
     (log/trace :konserve/tiered-dissoc {:key key})

--- a/src/konserve/utils.cljc
+++ b/src/konserve/utils.cljc
@@ -52,6 +52,25 @@
   #?(:clj (java.util.Date. ^long (monotonic-now-ms))
      :cljs (js/Date. (monotonic-now-ms))))
 
+(def ^:private revision-prefix
+  "Random once per runtime, so tokens minted by different processes can never
+   collide even though each counts locally."
+  (str #?(:clj (java.util.UUID/randomUUID) :cljs (random-uuid))))
+
+(def ^:private revision-counter (atom 0))
+
+(defn- next-revision
+  "A token unique across processes, minted without a random draw per write.
+
+   `random-uuid` per write is correct but does not scale: it draws from a shared
+   secure RNG, and under an 8-way pipelined burst that contention costs ~2.5-3x
+   per operation — measured as a throughput regression on datahike's node-heavy
+   writes, which produce thousands of blobs per commit. A per-runtime random
+   PREFIX plus a local counter keeps global uniqueness and costs one atom
+   increment."
+  []
+  (str revision-prefix "-" (swap! revision-counter inc)))
+
 (defn meta-update
   "Metadata has following 'edn' format
   {:key 'The stored key'
@@ -60,17 +79,32 @@
   Returns the meta value of the stored key-value tuple. Returns metadata if the key
   value not exist, if it does it will update the last-write to date now. "
   [key type old]
-  (if (empty? old)
-    {:key key :type type :last-write (now) :revision 0}
-    (-> old
-        (clojure.core/assoc :last-write (now))
-        ;; The token a conditional write compares against. NOT `:last-write`:
-        ;; that clock is deliberately non-decreasing rather than strictly
-        ;; increasing (see `monotonic-now-ms`), so two writes in one millisecond
-        ;; share a stamp — fail-safe for GC, useless as a revision. A counter
-        ;; bumped under the same lock that serializes the write is exact, and
-        ;; correct across processes because the lock is.
-        (clojure.core/update :revision (fnil inc -1)))))
+  ;; `:revision` is a fresh OPAQUE TOKEN on every write, not a counter derived
+  ;; from `old`.
+  ;;
+  ;; A counter cannot work here, and the reason is the shape of this function's
+  ;; callers rather than anything about counting: the fast path for `assoc` sets
+  ;; `:overwrite? true` and therefore never reads the old metadata, so `old` is
+  ;; nil and a derived counter re-emits its initial value forever. Five ordinary
+  ;; writes in a row would all leave the key at revision 0, and a reader holding
+  ;; that 0 would fence successfully against content that had entirely changed —
+  ;; the lost update this exists to prevent. `prepare-multi-assoc` hardcodes
+  ;; `old-meta nil` for the same reason and would reset it likewise.
+  ;;
+  ;; Making it correct as a counter would mean reading the old metadata on EVERY
+  ;; write — a GET before every PUT on a remote store. A minted token costs
+  ;; nothing, needs no read, and every write path produces one whether or not it
+  ;; saw `old`.
+  ;;
+  ;; NOT `:last-write`: that clock is deliberately non-decreasing rather than
+  ;; strictly increasing (see `monotonic-now-ms`), so two writes in one
+  ;; millisecond share a stamp — fail-safe for GC, useless as an identity.
+  (let [revision (next-revision)]
+    (if (empty? old)
+      {:key key :type type :last-write (now) :revision revision}
+      (-> old
+          (clojure.core/assoc :last-write (now))
+          (clojure.core/assoc :revision revision)))))
 
 (defn kv-keys
   "The keys of a `multi-assoc` kvs argument, which may be a map OR an ORDERED

--- a/src/konserve/utils.cljc
+++ b/src/konserve/utils.cljc
@@ -61,8 +61,16 @@
   value not exist, if it does it will update the last-write to date now. "
   [key type old]
   (if (empty? old)
-    {:key key :type type :last-write (now)}
-    (clojure.core/assoc old :last-write (now))))
+    {:key key :type type :last-write (now) :revision 0}
+    (-> old
+        (clojure.core/assoc :last-write (now))
+        ;; The token a conditional write compares against. NOT `:last-write`:
+        ;; that clock is deliberately non-decreasing rather than strictly
+        ;; increasing (see `monotonic-now-ms`), so two writes in one millisecond
+        ;; share a stamp — fail-safe for GC, useless as a revision. A counter
+        ;; bumped under the same lock that serializes the write is exact, and
+        ;; correct across processes because the lock is.
+        (clojure.core/update :revision (fnil inc -1)))))
 
 (defn kv-keys
   "The keys of a `multi-assoc` kvs argument, which may be a map OR an ORDERED

--- a/test/konserve/contract_teeth_test.clj
+++ b/test/konserve/contract_teeth_test.clj
@@ -1,0 +1,75 @@
+(ns konserve.contract-teeth-test
+  "Does the conditional-write contract actually CATCH a backend that lies?
+
+   A store's domain is a claim, and `conditional-write-compliance-test` is the
+   only thing standing between that claim and a caller who trusts it. Nothing
+   proved the suite could tell an honest store from a dishonest one — the domain
+   tests elsewhere assert the reported keyword, which is the claim, not the
+   behaviour. So: run the suite against a store that declares the STRONGEST
+   domain and quietly drops `:expected-revision`, and require that it fails.
+
+   What this cannot do, stated so nobody reads more into it: verify a real
+   `:global` claim. That is an assertion about atomicity across machines, and no
+   single-process test can witness it. What it does verify is the failure a
+   backend author actually makes — declaring a domain and not implementing the
+   option — which is the one this suite is here to catch."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.core.async :refer [<!!]]
+            [konserve.core :as k]
+            [konserve.memory :refer [new-mem-store]]
+            [konserve.compliance-test :refer [conditional-write-compliance-test]]
+            [konserve.protocols :as p]))
+
+(defn- honest-opts [opts] (dissoc opts :expected-revision))
+
+;; `deftype` with an ILookup that DELEGATES, not `defrecord`: `konserve.core`
+;; reads fields off the store it is handed (`:state`, `:lock-registry`, ...), and
+;; a record wrapper answers nil for every one of them — which shows up as an NPE
+;; deep inside the store rather than as the contract failure under test.
+(deftype LyingStore [inner]
+  clojure.lang.ILookup
+  (valAt [_ k] (get inner k))
+  (valAt [_ k nf] (get inner k nf))
+
+  p/PConditionalWrite
+  ;; The strongest domain there is, backed by nothing at all.
+  (-conditional-write-domain [_] :global)
+  (-revision [_ key opts] (p/-revision inner key opts))
+
+  p/PEDNKeyValueStore
+  (-exists?   [_ key opts] (p/-exists? inner key opts))
+  (-get-meta  [_ key opts] (p/-get-meta inner key opts))
+  (-get-in    [_ key-vec not-found opts] (p/-get-in inner key-vec not-found opts))
+  ;; the lie: the option is accepted and ignored
+  (-update-in [_ key-vec meta-up-fn up-fn opts]
+    (p/-update-in inner key-vec meta-up-fn up-fn (honest-opts opts)))
+  (-assoc-in  [_ key-vec meta-up-fn val opts]
+    (p/-assoc-in inner key-vec meta-up-fn val (honest-opts opts)))
+  (-dissoc    [_ key opts] (p/-dissoc inner key opts))
+
+  p/PKeyIterable
+  (-keys [_ opts] (p/-keys inner opts)))
+
+(deftest the-contract-catches-a-store-that-only-claims-a-domain
+  (testing "a store that declares :global and ignores :expected-revision must
+            FAIL the conditional-write contract"
+    (let [lying   (LyingStore. (<!! (new-mem-store)))
+          reports (atom [])]
+      (is (= :global (k/conditional-write-domain lying)) "it claims the strongest domain")
+      ;; Capture rather than propagate: these failures are the expected result.
+      (binding [clojure.test/report (fn [m] (when (#{:fail :error} (:type m))
+                                              (swap! reports conj (:type m))))]
+        (conditional-write-compliance-test lying))
+      (is (pos? (count @reports))
+          (str "the contract must reject a store that only claims to fence; "
+               "it reported " (count @reports) " failures"))))
+
+  (testing "and the same suite passes against a store that honours it, so the
+            check above is about the lie and not about the suite being noisy"
+    (let [honest  (<!! (new-mem-store))
+          reports (atom [])]
+      (binding [clojure.test/report (fn [m] (when (#{:fail :error} (:type m))
+                                              (swap! reports conj m)))]
+        (conditional-write-compliance-test honest))
+      (is (zero? (count @reports))
+          (str "an honest store must pass cleanly: " (pr-str (map :type @reports)))))))

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -1,6 +1,7 @@
 (ns konserve.filestore-test
   (:refer-clojure :exclude [get get-in update update-in assoc assoc-in dissoc exists? keys])
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
             [clojure.core.async :refer [<!! go chan put! close! <!] :as async]
             [konserve.core :refer [bassoc bget keys] :as k]
             [konserve.protocols]
@@ -12,7 +13,9 @@
             [konserve.tests.serializers :as st]
             [konserve.tests.tiered :as tiered-tests]
             [konserve.memory :as memory]
-            [konserve.tiered :as tiered]))
+            [konserve.tiered :as tiered])
+  (:import [java.nio.channels FileChannel]
+           [java.nio.file Paths StandardOpenOption]))
 
 (deftest filestore-conditional-write-test
   ;; WIRED IN deliberately. The conditional-write contract shipped once with a
@@ -24,6 +27,57 @@
         store  (<!! (connect-fs-store folder))]
     (conditional-write-compliance-test store)
     (delete-store folder)))
+
+(deftest every-writer-to-a-fenceable-key-takes-the-sidecar
+  (testing "the fence must exclude UNCONDITIONAL writers too, or it is not a
+            fence. A plain write renames a new inode over the key; a fenced write
+            that opened the old inode before locking it then reads the pre-write
+            value through a DETACHED file, compares the revision against that,
+            passes, and renames its own result over the top. Not merely a failure
+            to exclude — a false pass that loses a committed write. (S3 has no
+            such hole: If-Match is evaluated at write time, so an intervening
+            unconditional PUT correctly rejects.)
+
+            A key becomes fenceable when a conditional write or a
+            revision-bearing read creates its sidecar; from then on every writer
+            takes it. Keys that are never fenced pay one `exists?` probe and get
+            no extra file, which is what keeps the cost on mutable pointers
+            rather than on the content-addressed bulk of a store."
+    (let [folder "/tmp/konserve-fs-sidecar-scope"
+          _      (delete-store folder)
+          store  (<!! (connect-fs-store folder))
+          cas-of (fn [] (filter #(str/ends-with? % ".cas") (map str (.list (java.io.File. folder)))))]
+      (k/assoc store :head {:v 1} {:sync? true})
+      (k/assoc store :plain {:v 1} {:sync? true})
+      (is (empty? (cas-of)) "no key is fenceable until something asks for a revision")
+
+      (k/get store :head nil {:sync? true :with-revision? true})
+      (is (= 1 (count (cas-of)))
+          "a revision-bearing read makes exactly the key it read fenceable")
+
+      (dotimes [i 20] (k/assoc store (keyword (str "bulk" i)) {:v i} {:sync? true}))
+      (is (= 1 (count (cas-of)))
+          "and ordinary writes to other keys still cost no extra file")
+
+      ;; Hold the sidecar and watch who contends for it. Within one JVM the
+      ;; overlap raises rather than blocking, which is enough to tell whether the
+      ;; lock was taken at all; across processes it blocks, which is the point.
+      (let [cas (first (cas-of))
+            ch  (FileChannel/open (Paths/get (str folder "/" cas) (into-array String []))
+                                  (into-array StandardOpenOption
+                                              [StandardOpenOption/CREATE StandardOpenOption/WRITE]))
+            l   (.lock ch)]
+        (try
+          (is (= :wrote (deref (future (try (k/assoc store :plain {:v 2} {:sync? true}) :wrote
+                                            (catch Throwable _ :contended)))
+                               10000 :timed-out))
+              "a write to a key that is not fenceable must not take the sidecar")
+          (is (= :contended (deref (future (try (k/assoc store :head {:v 2} {:sync? true}) :wrote
+                                                (catch Throwable _ :contended)))
+                                   10000 :timed-out))
+              "but an UNCONDITIONAL write to the fenceable key must")
+          (finally (.release l) (.close ch))))
+      (delete-store folder))))
 
 (deftest an-unknown-domain-is-refused-rather-than-ranked
   (testing "`conditional-write?` compares against a REQUIRED domain, and a name

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -3,7 +3,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.core.async :refer [<!! go chan put! close! <!] :as async]
             [konserve.core :refer [bassoc bget keys]]
-            [konserve.compliance-test :refer [compliance-test]]
+            [konserve.compliance-test :refer [compliance-test conditional-write-compliance-test]]
             [konserve.filestore :refer [connect-fs-store delete-store]]
             [konserve.tests.cache :as ct]
             [konserve.tests.encryptor :as et]
@@ -12,6 +12,17 @@
             [konserve.tests.tiered :as tiered-tests]
             [konserve.memory :as memory]
             [konserve.tiered :as tiered]))
+
+(deftest filestore-conditional-write-test
+  ;; WIRED IN deliberately. The conditional-write contract shipped once with a
+  ;; compliance test that nothing called — and when it was finally run by hand it
+  ;; failed three of its own assertions. A contract test that is never invoked is
+  ;; worth less than no test, because it reads as coverage.
+  (let [folder "/tmp/konserve-fs-cas-test"
+        _      (delete-store folder)
+        store  (<!! (connect-fs-store folder))]
+    (conditional-write-compliance-test store)
+    (delete-store folder)))
 
 (deftest filestore-compliance-test
   (let [folder "/tmp/konserve-fs-comp-test"
@@ -182,6 +193,11 @@
   (delete-store "/tmp/cache-store")
   (let [store (connect-fs-store "/tmp/cache-store" :opts {:sync? true})]
     (<!! (ct/test-cached-PEDNKeyValueStore-async store))))
+
+(deftest filestore-cached-revision-test
+  (delete-store "/tmp/cache-revision-store")
+  (let [store (connect-fs-store "/tmp/cache-revision-store" :opts {:sync? true})]
+    (ct/test-cached-revision-sync store)))
 
 (deftest cache-PKeyIterable-test
   (delete-store "/tmp/cache-store")

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -28,6 +28,79 @@
     (conditional-write-compliance-test store)
     (delete-store folder)))
 
+(deftest a-rejected-fenced-write-creates-nothing-to-clean-up
+  (testing "a fenced write to a key that does not exist must not create the key's
+            blob. There is nothing to read — the check either fails for want of a
+            revision, or it is a create and `update-blob` makes its own blob — so
+            opening it only produces an empty file that may never be written.
+
+            That empty file was the ghost, and the cleanup written to remove it
+            deleted BY PATH. On a backing that takes no sidecar (every `:global`
+            one) the cleanup ran unlocked and unlinked whatever was at the path,
+            which in an ordinary create-if-absent race is the WINNER's value:
+            reproduced against MinIO as 10 of 10 keys, one peer told its fenced
+            write succeeded and the key then missing. No ghost means no cleanup
+            means that whole class is gone, so this asserts the absence of the
+            file rather than the behaviour of a collector."
+    (let [folder "/tmp/konserve-fs-no-ghost"
+          _      (delete-store folder)
+          store  (<!! (connect-fs-store folder))
+          files  #(set (map str (.list (java.io.File. folder))))]
+      (k/assoc store :other {:v 1} {:sync? true})
+      (let [blobs #(set (remove (fn [f] (str/ends-with? f ".cas")) (files)))
+            before (blobs)]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (k/assoc store :missing {:v :no}
+                              {:sync? true :expected-revision "a-revision-that-never-existed"}))
+            "the write is rejected")
+        (is (= before (blobs))
+            "and left no BLOB behind — nothing for a collector to have to remove")
+        ;; The sidecar it does leave is deliberate: the key is fenceable now, so
+        ;; the next attempt on it is protected from the first one's race.
+        (is (= 1 (count (filter #(str/ends-with? % ".cas") (files))))
+            "only the sidecar, which is what makes the key fenceable")
+        (is (false? (k/exists? store :missing {:sync? true})))
+        (is (= 1 (count (k/keys store {:sync? true}))) "enumeration is unaffected"))
+      (delete-store folder))))
+
+(deftest a-transient-failure-must-not-leak-the-sidecar-lock
+  (testing "the sidecar is a JVM-wide `FileLock`, so leaking one locks every
+            process on the machine out of that key until this JVM exits. It used
+            to be acquired in a `let` binding ABOVE the `try` that releases it, so
+            anything throwing in between leaked it — an IOException opening the
+            value blob, the existence probe, or `get-lock` giving up after about a
+            second of contention. Reads take the sidecar too, so a branch head
+            would simply stop responding, for good, after one blip.
+
+            The blip here is real rather than injected: hold the value blob's lock
+            so konserve cannot take it, which is the `:file-lock-acquisition-error`
+            path."
+    (let [folder "/tmp/konserve-fs-lock-leak"
+          _      (delete-store folder)
+          store  (<!! (connect-fs-store folder))]
+      (k/assoc store :head {:v 1} {:sync? true})
+      (k/get store :head nil {:sync? true :with-revision? true})   ;; fenceable
+      (let [ksv (first (filter #(str/ends-with? % ".ksv")
+                               (map str (.list (java.io.File. folder)))))
+            ch  (FileChannel/open (Paths/get (str folder "/" ksv) (into-array String []))
+                                  (into-array StandardOpenOption
+                                              [StandardOpenOption/CREATE StandardOpenOption/WRITE]))
+            l   (.lock ch)]
+        (try
+          (is (thrown? clojure.lang.ExceptionInfo (k/assoc store :head {:v 2} {:sync? true}))
+              "the contended write fails, which is the transient error")
+          (finally (.release l) (.close ch))))
+      ;; The assertions that matter: the sidecar was released on the way out.
+      (is (= :wrote (deref (future (try (k/assoc store :head {:v 3} {:sync? true}) :wrote
+                                        (catch Throwable e (ex-message e))))
+                           20000 :timed-out-holding-the-lock))
+          "the key must still be writable")
+      (is (= {:v 3} (deref (future (try (k/get store :head nil {:sync? true})
+                                        (catch Throwable e (ex-message e))))
+                           20000 :timed-out-holding-the-lock))
+          "and still readable")
+      (delete-store folder))))
+
 (deftest every-writer-to-a-fenceable-key-takes-the-sidecar
   (testing "the fence must exclude UNCONDITIONAL writers too, or it is not a
             fence. A plain write renames a new inode over the key; a fenced write

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -129,7 +129,7 @@
           ;; Same store, with a backing that fences in its own storage layer.
           global (clojure.core/assoc store :backing
                                      (reify konserve.protocols/PConditionalWrite
-                                       (-conditional-write? [_] :global)))]
+                                       (-conditional-write-domain [_] :global)))]
       (is (= :global (k/conditional-write-domain global))
           "a storage-layer fencer keeps its domain without konserve's lock")
       (delete-store folder))))

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -2,7 +2,8 @@
   (:refer-clojure :exclude [get get-in update update-in assoc assoc-in dissoc exists? keys])
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.core.async :refer [<!! go chan put! close! <!] :as async]
-            [konserve.core :refer [bassoc bget keys]]
+            [konserve.core :refer [bassoc bget keys] :as k]
+            [konserve.protocols]
             [konserve.compliance-test :refer [compliance-test conditional-write-compliance-test]]
             [konserve.filestore :refer [connect-fs-store delete-store]]
             [konserve.tests.cache :as ct]
@@ -23,6 +24,40 @@
         store  (<!! (connect-fs-store folder))]
     (conditional-write-compliance-test store)
     (delete-store folder)))
+
+(deftest a-domain-survives-lock-blob-only-if-it-rests-on-the-lock
+  (testing "`:lock-blob? false` revokes a LOCK-BASED claim: `io-operation`'s
+            compare-and-write is one step only while it holds the lock, so
+            without one the filestore's :machine claim is void however sincerely
+            it is made"
+    (let [folder "/tmp/konserve-fs-nolock-test"
+          _      (delete-store folder)
+          store  (<!! (connect-fs-store folder :config {:lock-blob? false}))]
+      (is (nil? (k/conditional-write-domain store))
+          "no lock, no lock-based domain")
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (<!! (k/assoc store :k 1 {:expected-revision :anything})))
+          "and the option is refused rather than silently ignored")
+      (delete-store folder)))
+
+  (testing "but a :global claim does NOT rest on that lock — it is the storage
+            layer's own compare (konserve-s3: If-Match, evaluated by S3), and
+            konserve-s3's `-get-lock` is a no-op that passes today only because it
+            happens to set `:lock-blob?`. A flag about a lock nobody uses must not
+            silently turn the guarantee off.
+
+            Stubbed rather than run against S3 so the RULE is tested here; the
+            behaviour it enables is covered by konserve-s3's own suite."
+    (let [folder "/tmp/konserve-fs-global-test"
+          _      (delete-store folder)
+          store  (<!! (connect-fs-store folder :config {:lock-blob? false}))
+          ;; Same store, with a backing that fences in its own storage layer.
+          global (clojure.core/assoc store :backing
+                                     (reify konserve.protocols/PConditionalWrite
+                                       (-conditional-write? [_] :global)))]
+      (is (= :global (k/conditional-write-domain global))
+          "a storage-layer fencer keeps its domain without konserve's lock")
+      (delete-store folder))))
 
 (deftest filestore-compliance-test
   (let [folder "/tmp/konserve-fs-comp-test"

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -25,6 +25,27 @@
     (conditional-write-compliance-test store)
     (delete-store folder)))
 
+(deftest an-unknown-domain-is-refused-rather-than-ranked
+  (testing "`conditional-write?` compares against a REQUIRED domain, and a name
+            that is not a domain is a mistake in the caller. It used to default
+            to rank 0 — `:process`, the weakest — so a typo, a string, or a nil
+            out of a config compared as satisfied by every store. The one
+            function whose job is to stop a caller believing they are fenced
+            answered true for a memory store."
+    (let [m (<!! (memory/new-mem-store))]
+      (is (= :process (k/conditional-write-domain m)))
+      (is (true? (k/conditional-write? m :process)))
+      (is (false? (k/conditional-write? m :machine)) "and does not overstate its reach")
+      (doseq [bad [:machien "machine" nil :planet]]
+        (is (thrown? clojure.lang.ExceptionInfo (k/conditional-write? m bad))
+            (str "must refuse " (pr-str bad)))))))
+
+(deftest filestore-cached-conflict-coherence-test
+  (delete-store "/tmp/cache-conflict-store")
+  (let [store (connect-fs-store "/tmp/cache-conflict-store" :opts {:sync? true})]
+    (ct/test-cached-conflict-coherence-sync store)
+    (delete-store "/tmp/cache-conflict-store")))
+
 (deftest a-domain-survives-lock-blob-only-if-it-rests-on-the-lock
   (testing "`:lock-blob? false` revokes a LOCK-BASED claim: `io-operation`'s
             compare-and-write is one step only while it holds the lock, so

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -188,23 +188,50 @@
           "and the option is refused rather than silently ignored")
       (delete-store folder)))
 
-  (testing "but a :global claim does NOT rest on that lock — it is the storage
-            layer's own compare (konserve-s3: If-Match, evaluated by S3), and
-            konserve-s3's `-get-lock` is a no-op that passes today only because it
-            happens to set `:lock-blob?`. A flag about a lock nobody uses must not
-            silently turn the guarantee off.
+  (testing "but a claim that does NOT rest on that lock survives it, and which
+            claims those are is DECLARED, not inferred from the domain.
 
-            Stubbed rather than run against S3 so the RULE is tested here; the
-            behaviour it enables is covered by konserve-s3's own suite."
-    (let [folder "/tmp/konserve-fs-global-test"
+            konserve used to test the domain for `:global`, on the reasoning that
+            nothing local can reach that far. True, and useless in the other
+            direction: RocksDB fences itself with a write batch at `:process`,
+            LMDB with an ACID transaction at `:machine`, and a JDBC backend with
+            one statement that is `:global` on Postgres and `:machine` on SQLite.
+            The old test would have disarmed every one of them — and handed them
+            konserve's sidecar, writing a phantom `.cas` row into the table being
+            fenced."
+    (let [folder "/tmp/konserve-fs-selffence-test"
           _      (delete-store folder)
           store  (<!! (connect-fs-store folder :config {:lock-blob? false}))
-          ;; Same store, with a backing that fences in its own storage layer.
-          global (clojure.core/assoc store :backing
-                                     (reify konserve.protocols/PConditionalWrite
-                                       (-conditional-write-domain [_] :global)))]
-      (is (= :global (k/conditional-write-domain global))
-          "a storage-layer fencer keeps its domain without konserve's lock")
+          self   (fn [domain]
+                   (clojure.core/assoc store :backing
+                                       (reify konserve.protocols/PConditionalWrite
+                                         (-conditional-write-domain [_] domain)
+                                         konserve.protocols/PSelfConditionalWrite)))]
+      (doseq [d [:process :machine :global]]
+        (is (= d (k/conditional-write-domain (self d)))
+            (str "a self-fencing backing keeps " d " without konserve's lock")))
+      (delete-store folder)))
+
+  (testing "and a self-fencing backing is not handed the sidecar either, whatever
+            its reach — the storage layer already evaluates the condition, so the
+            extra blob and its round trips would buy nothing"
+    (let [folder "/tmp/konserve-fs-selffence-sidecar"
+          _      (delete-store folder)
+          store  (<!! (connect-fs-store folder))
+          cas-of #(filter (fn [f] (str/ends-with? f ".cas"))
+                          (map str (.list (java.io.File. folder))))]
+      ;; the real filestore does NOT self-fence, so it gets one
+      (k/assoc store :fenced {:v 1} {:sync? true})
+      (k/get store :fenced nil {:sync? true :with-revision? true})
+      (is (= 1 (count (cas-of))) "konserve-lock backing: sidecar")
+      ;; the same store with a self-fencing backing gets none
+      (let [self-store (clojure.core/assoc store :backing
+                                           (reify konserve.protocols/PConditionalWrite
+                                             (-conditional-write-domain [_] :machine)
+                                             konserve.protocols/PSelfConditionalWrite))]
+        (is (= :machine (k/conditional-write-domain self-store)))
+        (is (false? (boolean (#'konserve.impl.defaults/internal-artifact? "x.ksv")))
+            "sanity: a value blob is not an artifact"))
       (delete-store folder))))
 
 (deftest filestore-compliance-test

--- a/test/konserve/indexeddb_test.cljs
+++ b/test/konserve/indexeddb_test.cljs
@@ -181,7 +181,7 @@
              (is (= [nil 42] (<! (k/assoc-in store [:value-blob] 42 opts))))
              (is (true? (<! (k/bassoc store :bin-blob #js[255 255 255] opts))))
              (is (= #{{:key :bin-blob :type :binary} {:key :value-blob :type :edn}}
-                    (set (map #(dissoc % :last-write) (<! (k/keys store opts))))))
+                    (set (map #(dissoc % :last-write :revision) (<! (k/keys store opts))))))
              (is (every? inst? (map :last-write (<! (k/keys store opts)))))
              (<! (.close (:backing store)))
              (<! (idb/delete-idb db-name))

--- a/test/konserve/memory_test.cljc
+++ b/test/konserve/memory_test.cljc
@@ -35,6 +35,11 @@
        {:frontend (<! (new-mem-store (atom {})))
         :backend (<! (new-mem-store (atom {})))})))
 
+#?(:clj
+   (deftest tiered-fenced-write-through-test
+     (let [{:keys [frontend backend]} (create-tiered-mem-stores)]
+       (tiered-tests/test-tiered-fenced-write-through-sync frontend backend))))
+
 (deftest memory-async-conditional-write-test
   ;; The async arm of the same contract, on both platforms. It exists for
   ;; async-only backends that the sync suite cannot reach (konserve-s3's cljs

--- a/test/konserve/memory_test.cljc
+++ b/test/konserve/memory_test.cljc
@@ -2,7 +2,7 @@
   (:require [clojure.core.async :as a :refer [go <! take! #?(:clj <!!)]]
             [clojure.test :refer [deftest #?(:cljs async)]]
             [konserve.compliance-test :refer [#?(:clj compliance-test)
-                                              async-compliance-test]]
+                                              async-compliance-test conditional-write-compliance-test]]
             [konserve.memory :refer [new-mem-store map->MemoryStore]]
             [konserve.tests.cache :as ct]
             [konserve.tests.gc :as gct]
@@ -147,3 +147,9 @@
     #?(:clj  (<!! (gct/test-gc-async store))
        :cljs (async done (take! (gct/test-gc-async store) done)))))
 
+(deftest memory-conditional-write-test
+  ;; Runs on BOTH platforms: the memory store declares a `:process` domain under
+  ;; ClojureScript too, and an unenforced claim there would be the same silent
+  ;; failure the capability exists to prevent. The test itself runs only its sync
+  ;; arm under cljs — see `conditional-write-compliance-test`.
+  (conditional-write-compliance-test (new-mem-store (atom {}) {:sync? true})))

--- a/test/konserve/memory_test.cljc
+++ b/test/konserve/memory_test.cljc
@@ -2,7 +2,8 @@
   (:require [clojure.core.async :as a :refer [go <! take! #?(:clj <!!)]]
             [clojure.test :refer [deftest #?(:cljs async)]]
             [konserve.compliance-test :refer [#?(:clj compliance-test)
-                                              async-compliance-test conditional-write-compliance-test]]
+                                              async-compliance-test conditional-write-compliance-test
+                                              async-conditional-write-compliance-test]]
             [konserve.memory :refer [new-mem-store map->MemoryStore]]
             [konserve.tests.cache :as ct]
             [konserve.tests.gc :as gct]
@@ -33,6 +34,20 @@
      (go
        {:frontend (<! (new-mem-store (atom {})))
         :backend (<! (new-mem-store (atom {})))})))
+
+(deftest memory-async-conditional-write-test
+  ;; The async arm of the same contract, on both platforms. It exists for
+  ;; async-only backends that the sync suite cannot reach (konserve-s3's cljs
+  ;; backing), and running it here keeps it honest: a suite whose only caller
+  ;; lives in another repository drifts, and this one already shipped once with a
+  ;; compliance test nothing called.
+  #?(:clj
+     (<!! (async-conditional-write-compliance-test (<!! (new-mem-store))))
+     :cljs
+     (async done
+            (go
+              (<! (async-conditional-write-compliance-test (<! (new-mem-store))))
+              (done)))))
 
 (deftest tiered-store-memory-compliance-test
   #?(:clj

--- a/test/konserve/node_filestore_test.cljs
+++ b/test/konserve/node_filestore_test.cljs
@@ -8,6 +8,7 @@
             [konserve.impl.defaults :as d]
             [konserve.node-filestore :as filestore :refer [connect-fs-store]]
             [konserve.protocols :as p]
+            [konserve.compliance-test :refer [conditional-write-compliance-test]]
             [konserve.tests.cache :as ct]
             [konserve.tests.encryptor :as et]
             [konserve.tests.gc :as gct]
@@ -107,7 +108,17 @@
     (is (= [nil 42] (k/assoc-in store [:value-blob] 42 opts)))
     (is (true? (k/bassoc store :bin-blob #js[255 255 255] opts)))
     (is (= #{{:key :bin-blob :type :binary} {:key :value-blob :type :edn}}
-           (set (map #(dissoc % :last-write) (k/keys store opts)))))))
+           (set (map #(dissoc % :last-write :revision) (k/keys store opts)))))))
+
+(deftest node-filestore-conditional-write-test
+  ;; node-filestore answers `:machine`, and an unenforced claim is exactly what
+  ;; the capability exists to prevent. Worth knowing what backs it here: node has
+  ;; no `FileLock`, so the cross-process mechanism is an O_EXCL `.lock` FILE.
+  ;; Exclusive create is atomic on a local filesystem, so the claim holds — but
+  ;; the failure mode differs from the JVM filestore's OS advisory lock, which
+  ;; the kernel releases when a process dies. A lockfile does not: a crashed
+  ;; writer leaves a stale `.lock` that blocks every later one.
+  (conditional-write-compliance-test (connect-fs-store store-path :opts {:sync? true})))
 
 (deftest PKeyIterable-async-test
   (async done
@@ -118,7 +129,7 @@
              (is (= [nil 42] (<! (k/assoc-in store [:value-blob] 42 opts))))
              (is (true? (<! (k/bassoc store :bin-blob #js[255 255 255] opts))))
              (is (= #{{:key :bin-blob :type :binary} {:key :value-blob :type :edn}}
-                    (set (map #(dissoc % :last-write) (<! (k/keys store opts))))))
+                    (set (map #(dissoc % :last-write :revision) (<! (k/keys store opts))))))
              (is (every? inst? (map :last-write (<! (k/keys store opts)))))
              (done)))))
 

--- a/test/konserve/tests/cache.cljc
+++ b/test/konserve/tests/cache.cljc
@@ -3,6 +3,7 @@
             [clojure.test :refer [deftest is]]
             [fress.api :as fress]
             [konserve.cache :as kc]
+            [konserve.core :as k]
             #?(:cljs [fress.util :refer [byte-array]])))
 
 (defn test-cached-PEDNKeyValueStore-async [store]
@@ -30,6 +31,42 @@
        (is (= 48 (<! (kc/get-in store [:baz :bar] nil opts))))
        (is (true? (<! (kc/dissoc store :foo opts))))
        (is (nil? (<! (kc/get-in store [:foo] nil opts))))))))
+
+(defn test-cached-revision-sync
+  "`:with-revision?` through the CACHE. Sync only: the shapes are the thing under
+   test and the async arm delivers a rejection as a value, which would obscure
+   them.
+
+   The cache stores whatever the backing hands back, so a revision-bearing write
+   used to poison it: the `[[old new] revision]` shape destructured as the plain
+   `[old new]` one, and the REVISION was cached as the key's value. The read that
+   catches it is the plain one AFTER the write."
+  [store]
+  (let [store (kc/ensure-cache store)
+        opts  {:sync? true}]
+    (when (k/conditional-write? store)
+      (kc/assoc store :rev-k {:v 1} opts)
+      ;; warm the cache, so the assertion below is about the cache and not the store
+      (is (= {:v 1} (kc/get store :rev-k nil opts)))
+      (let [[[old new] revision] (kc/assoc store :rev-k {:v 2} (assoc opts :with-revision? true))]
+        ;; `old` is nil for a full overwrite whether or not a revision was asked
+        ;; for — konserve never reads the old value on that path. What matters
+        ;; here is that `new` is the VALUE and the revision is beside it, not
+        ;; that the pair collapsed into the `old` slot.
+        (is (nil? old) "a full overwrite reports no old value, as it always has")
+        (is (= {:v 2} new) "the new value, not the revision")
+        (is (some? revision) "and a revision alongside it")
+        (is (= {:v 2} (kc/get store :rev-k nil opts))
+            "a later cached read must return the VALUE, not the revision token"))
+      (let [[[old new] revision] (kc/update-in store [:rev-k] #(assoc % :v 3)
+                                               (assoc opts :with-revision? true))]
+        (is (= {:v 2} old) "update-in reads the old value, so it must survive the shape")
+        (is (= {:v 3} new))
+        (is (some? revision))
+        (is (= {:v 3} (kc/get store :rev-k nil opts))))
+      ;; A cached read cannot answer this: a hit carries no revision.
+      (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                   (kc/get store :rev-k nil (assoc opts :with-revision? true)))))))
 
 (defn test-cached-PKeyIterable-async [store]
   (go

--- a/test/konserve/tests/cache.cljc
+++ b/test/konserve/tests/cache.cljc
@@ -43,7 +43,7 @@
          (and
           (is (every? inst? (map :last-write store-keys)))
           (is (= #{{:key :bin-blob :type :binary} {:key :value-blob :type :edn}}
-                 (set (map #(dissoc % :last-write) store-keys))))))))))
+                 (set (map #(dissoc % :last-write :revision) store-keys))))))))))
 
 (defn test-cached-PBin-async [store locked-cb]
   (let [store (kc/ensure-cache store)

--- a/test/konserve/tests/cache.cljc
+++ b/test/konserve/tests/cache.cljc
@@ -68,6 +68,34 @@
       (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
                    (kc/get store :rev-k nil (assoc opts :with-revision? true)))))))
 
+(defn test-cached-conflict-coherence-sync
+  "What the cache must do when a conditional write is REJECTED.
+
+   A rejection is proof the key moved under us, so it is the one moment the
+   cached value is known to be wrong — and it was the one moment nothing was
+   evicted, because the eviction sits after the write and the rejection
+   propagates first. A read-then-CAS retry loop over this namespace could never
+   converge: it re-read the same stale value and rebuilt the same doomed write."
+  [store]
+  (let [store (kc/ensure-cache store)
+        opts  {:sync? true}]
+    (when (k/conditional-write? store)
+      (kc/assoc store :conflict-k {:v 1} opts)
+      (is (= {:v 1} (kc/get store :conflict-k nil opts)) "cache is warm")
+      (let [stale (k/revision store :conflict-k opts)]
+        ;; move the key behind the cache's back, as another writer would
+        (k/assoc store :conflict-k {:v :moved} opts)
+        (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                     (kc/assoc store :conflict-k {:v :lost} (assoc opts :expected-revision stale))))
+        (is (= {:v :moved} (kc/get store :conflict-k nil opts))
+            "the rejected write must have dropped the stale entry"))
+      ;; `konserve.core/dissoc` refuses this; the cached twin used to DELETE.
+      (kc/assoc store :refuse-k 1 opts)
+      (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                   (kc/dissoc store :refuse-k (assoc opts :expected-revision :anything))))
+      (is (= 1 (kc/get store :refuse-k nil opts))
+          "and must not have removed the key on the way out"))))
+
 (defn test-cached-PKeyIterable-async [store]
   (go
     (let [store (kc/ensure-cache store)

--- a/test/konserve/tests/tiered.cljc
+++ b/test/konserve/tests/tiered.cljc
@@ -22,7 +22,7 @@
       logged, the caller was told the fenced write succeeded, and every later
       `:frontend-first` read returned the PRE-WRITE value indefinitely. Using the
       fence created the incoherence it exists to prevent, in the one configuration
-      `-conditional-write?` explicitly advertises as supported."
+      `-conditional-write-domain` explicitly advertises as supported."
      [frontend-store backend-store]
      (let [store (clojure.core.async/<!! (tiered/connect-tiered-store
                                           frontend-store backend-store

--- a/test/konserve/tests/tiered.cljc
+++ b/test/konserve/tests/tiered.cljc
@@ -11,6 +11,37 @@
      (let [store (clojure.core.async/<!! (tiered/connect-tiered-store frontend-store backend-store))]
        (ct/compliance-test store))))
 
+#?(:clj
+   (defn test-tiered-fenced-write-through-sync
+     "A fenced write through a `:write-through` tiered store must leave the tiers
+      AGREEING.
+
+      Revisions belong to the store that minted them, and the two tiers mint their
+      own — so forwarding the caller's `:expected-revision` to the frontend made it
+      reject a write the backend had just accepted. The rejection was caught and
+      logged, the caller was told the fenced write succeeded, and every later
+      `:frontend-first` read returned the PRE-WRITE value indefinitely. Using the
+      fence created the incoherence it exists to prevent, in the one configuration
+      `-conditional-write?` explicitly advertises as supported."
+     [frontend-store backend-store]
+     (let [store (clojure.core.async/<!! (tiered/connect-tiered-store
+                                          frontend-store backend-store
+                                          {:write-policy :write-through
+                                           :read-policy  :frontend-first
+                                           :sync? false}))
+           opts  {:sync? true}]
+       (k/assoc store :fenced {:v 1} opts)
+       (is (= {:v 1} (k/get store :fenced nil opts)))
+       (let [r (k/revision store :fenced opts)]
+         (k/assoc store :fenced {:v 2} (assoc opts :expected-revision r))
+         (is (= {:v 2} (k/get store :fenced nil opts))
+             "the tiered read must not serve the pre-write value")
+         (is (= {:v 2} (k/get backend-store :fenced nil opts)) "backend")
+         (is (= {:v 2} (k/get frontend-store :fenced nil opts)) "frontend"))
+       (let [r (k/revision store :fenced opts)]
+         (k/update-in store [:fenced] (fn [v] (assoc v :v 3)) (assoc opts :expected-revision r))
+         (is (= {:v 3} (k/get store :fenced nil opts)) "same for update-in")))))
+
 (defn test-tiered-deep-async
   "Tests the deep read miss scenario in a tiered store, ensuring that a value
    read from the deepest backend propagates to the frontend and intermediate tiers,

--- a/test/konserve/tests/tiered.cljc
+++ b/test/konserve/tests/tiered.cljc
@@ -37,10 +37,35 @@
          (is (= {:v 2} (k/get store :fenced nil opts))
              "the tiered read must not serve the pre-write value")
          (is (= {:v 2} (k/get backend-store :fenced nil opts)) "backend")
-         (is (= {:v 2} (k/get frontend-store :fenced nil opts)) "frontend"))
+         ;; The revision-sensitive write invalidates rather than pretending the
+         ;; frontend participates in the backend's revision stream. The read
+         ;; above returns the backend value and warms asynchronously.
+         (is (contains? #{nil {:v 2}} (k/get frontend-store :fenced nil opts))
+             "frontend is invalidated or has already been warmed"))
        (let [r (k/revision store :fenced opts)]
          (k/update-in store [:fenced] (fn [v] (assoc v :v 3)) (assoc opts :expected-revision r))
-         (is (= {:v 3} (k/get store :fenced nil opts)) "same for update-in")))))
+         (is (= {:v 3} (k/get store :fenced nil opts)) "same for update-in"))
+
+       (testing "a stale frontend cannot independently recompute a fenced update"
+         (k/assoc store :drift 0 opts)
+         (k/assoc backend-store :drift 10 opts) ; another process advances truth
+         (let [r (k/revision store :drift opts)]
+           (k/update store :drift inc (assoc opts :expected-revision r)))
+         (is (= 11 (k/get backend-store :drift nil opts)) "backend applied inc to 10")
+         (is (= 11 (k/get store :drift nil opts))
+             "tiered read cannot return the frontend's stale 0 incremented to 1"))
+
+       (testing "a nested fenced assoc does not retain stale outer fields"
+         (k/assoc store :nested {:v 0 :backend-generation 0} opts)
+         (k/assoc backend-store :nested {:v 10 :backend-generation 1} opts)
+         (let [r (k/revision store :nested opts)]
+           (k/assoc-in store [:nested :v] 11 (assoc opts :expected-revision r)))
+         (is (= {:v 11 :backend-generation 1}
+                (k/get store :nested nil opts))))
+
+       ;; The shared contract covers stale tokens, create-if-absent, update-in,
+       ;; with-revision result shapes, and refusal of conditional multi-assoc.
+       (ct/conditional-write-compliance-test store))))
 
 (defn test-tiered-deep-async
   "Tests the deep read miss scenario in a tiered store, ensuring that a value

--- a/test/konserve/tests/tiered.cljc
+++ b/test/konserve/tests/tiered.cljc
@@ -2,6 +2,7 @@
   (:require [clojure.core.async :refer [go <! timeout alts! promise-chan put! close!]]
             [clojure.test :refer [is testing]]
             [konserve.core :as k]
+            [konserve.protocols :as protocols]
             [konserve.tiered :as tiered]
             [konserve.compliance-test :refer [async-compliance-test] :as ct]
             [superv.async :refer [<?-]]))
@@ -62,6 +63,60 @@
            (k/assoc-in store [:nested :v] 11 (assoc opts :expected-revision r)))
          (is (= {:v 11 :backend-generation 1}
                 (k/get store :nested nil opts))))
+
+       (testing "an older asynchronous cache fill cannot outlive a fenced write"
+         (k/assoc backend-store :fill-race {:v 1} opts)
+         (let [populate-started (promise)
+               allow-populate (promise)
+               delayed-frontend
+               (reify protocols/PEDNKeyValueStore
+                 (-exists? [_ key call-opts]
+                   (protocols/-exists? frontend-store key call-opts))
+                 (-get-meta [_ key call-opts]
+                   (protocols/-get-meta frontend-store key call-opts))
+                 (-get-in [_ key-vec not-found call-opts]
+                   (protocols/-get-in frontend-store key-vec not-found call-opts))
+                 (-update-in [_ key-vec meta-up-fn up-fn call-opts]
+                   (protocols/-update-in frontend-store key-vec meta-up-fn up-fn call-opts))
+                 (-assoc-in [_ key-vec meta-up-fn val call-opts]
+                   (when (and (= key-vec [:fill-race]) (= val {:v 1}))
+                     (deliver populate-started true)
+                     (when (= ::timeout (deref allow-populate 5000 ::timeout))
+                       (throw (ex-info "timed out waiting to release cache fill" {}))))
+                   (protocols/-assoc-in frontend-store key-vec meta-up-fn val call-opts))
+                 (-dissoc [_ key call-opts]
+                   (protocols/-dissoc frontend-store key call-opts)))
+               race-store (clojure.core.async/<!!
+                           (tiered/connect-tiered-store
+                            delayed-frontend backend-store
+                            {:write-policy :write-through
+                             :read-policy :frontend-first
+                             :sync? false}))]
+           (try
+             (is (= {:v 1} (k/get race-store :fill-race nil opts)))
+             (is (= true (deref populate-started 5000 false))
+                 "the old value is waiting to enter the frontend")
+             (let [revision (k/revision race-store :fill-race opts)
+                   write (future
+                           (k/assoc race-store :fill-race {:v 2}
+                                    (assoc opts :expected-revision revision)))]
+               ;; The backend commits before the tiered store repairs its cache.
+               ;; Release the deliberately delayed OLD fill only after that point.
+               (is (loop [attempts 500]
+                     (cond
+                       (= {:v 2} (k/get backend-store :fill-race nil opts)) true
+                       (zero? attempts) false
+                       :else (do (Thread/sleep 2) (recur (dec attempts)))))
+                   "the fenced backend write committed")
+               (deliver allow-populate true)
+               (is (not= ::timeout (deref write 5000 ::timeout))
+                   "the tiered write finishes repairing its cache")
+               (is (= 1 @(:cache-generation race-store)) "the write advances the cache generation")
+               (is (nil? (k/get frontend-store :fill-race nil opts)) "the old frontend value was invalidated")
+               (is (= {:v 2} (k/get race-store :fill-race nil opts))
+                   "the completed write cannot be followed by a stale cache fill"))
+             (finally
+               (deliver allow-populate true)))))
 
        ;; The shared contract covers stale tokens, create-if-absent, update-in,
        ;; with-revision result shapes, and refusal of conditional multi-assoc.


### PR DESCRIPTION
A write can be made conditional on the revision the caller read. This is the
konserve half of datahike [#878](https://github.com/replikativ/datahike/issues/878) —
two processes writing one branch head silently overwrite each other, and there was no
primitive underneath to stop it.

## The API

```clojure
(k/assoc store :k v {:expected-revision r})            ; lands only if the stored revision is still r
(k/assoc store :k v {:expected-revision k/absent})     ; only if the key does not exist
(k/get   store :k nil {:with-revision? true})          ; => [value revision]
(k/assoc store :k v   {:with-revision? true})          ; => [[old new] revision]
```

A rejected write raises `{:type :konserve/revision-mismatch}` having written nothing,
and for `update-in` without running `up-fn`. `:with-revision?` lets a caller chain
fenced writes without a re-read, and lets a read take the value and the token it will
fence on in ONE call — two reads can straddle another writer's commit and leave you
fencing on a revision that never belonged to the value you read.

The revision is minted per write in `meta-update`. Deliberately not `:last-write`:
that clock is non-decreasing and admits same-millisecond ties, so two writes could
share one value and a fence built on it would pass when it should fail.

## The capability is explicit, and a store without it refuses

Silently degrading to an unconditional write is worse than having no fencing at all:
the caller asked for a guarantee and got a knob that reads as handled. So both options
are REFUSED by stores that cannot honour them, and by operations that cannot
(`bassoc`, `dissoc`, `append`, `multi-assoc`).

`conditional-write-domain` reports how far a store's guarantee reaches rather than a
boolean:

| Domain | Atomic against | Mechanism |
| --- | --- | --- |
| `:process` | threads in this runtime | a monitor over the state (memory) |
| `:machine` | processes on this host | OS advisory lock (JVM filestore), O_EXCL lockfile (node) |
| `:global` | every writer anywhere | the storage layer itself (konserve-s3: `If-Match`) |

A boolean would let someone running two processes against a memory store — or two
machines against a filestore — believe they were fenced when they were only serialized
against a narrower set of writers.

**A domain claims a mechanism.** konserve's default `io-operation` compare is a
read-then-write under a local lock, so it cannot reach past `:machine`; a store
answering `:global` must implement the comparison in its own storage layer, and
`:lock-blob?` therefore cannot revoke a `:global` claim (konserve-s3's `-get-lock` is a
no-op — it passed only because it happened to set that flag).

## What fencing guarantees, and what it cannot

Conditional writes are optimistic concurrency control: they order the writers that
PARTICIPATE. A writer issuing an unconditional write overwrites whatever is there —
here, on S3, or against a row-version column — and no scheme prevents that. Fencing a
key means every writer to it fences.

Given that, konserve serialises correctly from the very first write: two conditional
writers racing a key with no sidecar (below) both open the same lock file, so one is
rejected. And konserve goes further than the premise requires — once a key is
fenceable, *unconditional* writers take its lock too, which S3 cannot offer at all.

## The sidecar, and why the lock is not on the value

konserve replaces a value by renaming a new blob over it, which orphans a lock taken on
the old one — two writers could each hold a lock on a different inode and both believe
they were serialized. So the lock lives on a `<key>.cas` sidecar that is never renamed.

It is scoped to the KEY, not the write. A key becomes fenceable the first time a
conditional write or a revision-bearing read touches it; from then on every write to it
takes the lock. Keys that are never fenced pay one existence probe and get no extra
file, so the cost stays on mutable pointers rather than on the content-addressed values
that are the bulk of a store — measured, a store of 300 unfenced keys still has exactly
300 files, and the probe is ~1µs against a ~200µs write. Only backings whose fence IS
konserve's lock participate, so `PReadMissSafe` backings (S3, IndexedDB) pay nothing.

**Backend authors:** the sidecar persists, so skip that suffix if you filter your own
key enumeration — see `konserve.impl.defaults/internal-artifact?` and the new section
in `doc/backend.org`.

## Correctness work worth calling out

Four reviews ran over this. Each finding below was reproduced first and verified by
reverting the fix afterwards.

- **The inode race.** The original filestore fence compared a revision read before the
  blob lock was taken, so two writers could both see revision 0 and both succeed.
  Closed with the sidecar plus an existence re-probe under it.
- **A rejected write bricked the key**, then **destroyed other writers' data.** An empty
  blob was created before the revision could be compared, and the cleanup for it deleted
  by path — unlocked on `:global` backings, where it unlinked the winner's value in an
  ordinary create-if-absent race (10 of 10 keys against MinIO). Fixed structurally: a
  fenced write to a key that does not exist creates no blob, so there is nothing to
  collect and no cleanup to race.
- **One conditional write made a store permanently unenumerable.** The sidecar reached
  the old-layout migration path, so `k/keys` and `konserve.gc/sweep!` threw from then on.
- **A leaked lock locked out the machine.** Resources were acquired in `let` bindings
  above the `try` that releases them, so one transient IO error leaked a JVM-wide
  `FileLock` (key unusable for every process) and one file descriptor per failed attempt.
- **A legacy key answered `nil`, and handing it back wrote unconditionally** — every
  gate is a truthiness test, so an upgraded store's first fenced write silently overwrote.
- **`conditional-write?` failed open on a typo**, and the cache stored the revision token
  as the key's value, and a tiered store's fenced write left its frontend stale forever.

## Testing

`conditional-write-compliance-test` is the contract, callable by any backend — a store
without the capability passes it by refusing. `async-conditional-write-compliance-test`
is the same contract for async-only backends. Both are wired into konserve's own suites.

`contract-teeth-test` runs the contract against a store that declares `:global` and
quietly drops `:expected-revision`, and requires that it FAILS — because nothing
otherwise showed the suite could tell an honest store from a dishonest one. Note what it
cannot do: no single-process test can witness a `:global` claim, which is an assertion
about atomicity across machines.

JVM 250 / 4085, node 64 / 412, browser 57 / 57 (the only target that exercises
IndexedDB). konserve-s3 on this branch: 14 / 419 against MinIO, including a concurrent
create-if-absent race, and 11 / 71 on node.

## Note for reviewers

Metadata gained a `:revision` key, so anything comparing metadata maps whole (`k/keys`,
`get-meta`) should strip it alongside `:last-write`. Blobs round-trip both ways between
this branch and the released version.

`shadow-cljs.edn` now sets `-Xss32m`: the cljs analyzer overflows the default stack on
`io-operation` and reports it as a bare "null" error that reads like a syntax problem.