### PR TITLE
Say that multi-key means ATOMIC, because the docstring invited the opposite

### DIFF
--- a/doc/backend.org
+++ b/doc/backend.org
@@ -269,6 +269,31 @@
    your store allows atomic transactions over both objects, e.g. using two
    columns in a SQL database.
 
+** Multi-key operations
+   :PROPERTIES:
+   :CUSTOM_ID: h:8c3d1a54-6f21-4b90-8d77-2e5f9a0c3b18
+   :END:
+   =PMultiWriteBackingStore= and =PMultiReadBackingStore= are for backends that can
+   apply a batch ATOMICALLY. Implement them only if your storage layer gives you
+   all-or-nothing across the whole batch — an object-store "batch request" that
+   reports per-item success is NOT that, and neither is a loop over single writes.
+
+   A store that cannot is not second-class: =multi-key-capable?= is false, the
+   multi-key API refuses, and callers write the batch themselves with ordinary
+   ordered =assoc= calls (values first, the pointer that makes them reachable
+   LAST). That discipline is crash-safe without atomicity, which is why offering a
+   weaker "batched" version here would be a bad trade — the caller would lose the
+   all-or-nothing they asked for and gain nothing they could not already do.
+
+   Today: IndexedDB (object-store transactions), DynamoDB (=TransactWriteItems=,
+   which refuses above its 100-item limit rather than splitting), Redis
+   (=MULTI=/=EXEC=) and JDBC (a database transaction). The filestore, S3 and GCS do
+   not implement them.
+
+   Note that =-supports-multi-key?= requires BOTH protocols, while =-multi-dissoc=
+   needs only the write one — so a backend that can batch deletes but not batch
+   reads cannot currently expose that alone.
+
 ** Conditional writes
    :PROPERTIES:
    :CUSTOM_ID: h:1f4a0c62-3b7a-4f0e-9a5a-7a6c0d2b41e2

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -664,9 +664,16 @@
                     {:type :konserve/conditional-multi-write-unsupported}))))
 
 (defn multi-assoc
-  "Associates multiple key-value pairs with flat keys, as one batch. Atomically where the
-  backend can (IndexedDB); ordered everywhere (see below), which is the weaker guarantee
-  that actually suffices.
+  "Associates multiple key-value pairs with flat keys, as ONE ATOMIC BATCH.
+
+  ONLY AVAILABLE WHERE THE BACKEND CAN APPLY IT ATOMICALLY. A store that cannot
+  refuses — `multi-key-capable?` is false and this throws — rather than degrading to
+  a sequence of individual writes. That is deliberate: a caller reaching for
+  `multi-assoc` is asking for all-or-nothing, and a partial batch presented as a
+  successful one is the kind of silent corruption no caller can detect afterwards.
+  Today that means IndexedDB (object-store transactions), DynamoDB
+  (`TransactWriteItems`), Redis (`MULTI`/`EXEC`) and JDBC (a database transaction);
+  object stores and filesystems cannot, so they do not offer it.
 
   `kvs` is either a map, or — preferred when the batch has internal dependencies — an
   ORDERED sequence of `[k v]` pairs. **Sequence order is apply order**, and it is preserved
@@ -674,24 +681,26 @@
   write-hook (so a sync layer can relay the batch in the same order). A map has no order,
   so a map batch makes no ordering promise.
 
-  Why that matters: not every backend can write multiple keys atomically (S3, filesystems
-  cannot; IndexedDB can). For a batch that writes a set of immutable, content-addressed
-  values plus a MUTABLE pointer that makes them reachable, you do not need atomicity — you
-  need order. Put the pointer LAST:
+  IF YOUR STORE CANNOT DO THIS, do not look for a weaker version of it here — write the
+  batch yourself with ordinary `assoc` calls, in order. For a batch of immutable,
+  content-addressed values plus a MUTABLE pointer that makes them reachable, ordering is
+  enough and atomicity is not needed. Put the pointer LAST:
 
   ```
   (multi-assoc store [[node-a v] [node-b v] [:root {:refs [node-a node-b]}]]
                (uniform-meta [node-a node-b] {:immutable? true}))
   ```
 
-  Then any prefix of the batch leaves the store consistent: the values are written but
-  unreachable (harmless orphans, collectable), and the pointer flips only once everything it
-  references exists. A torn batch can never produce a dangling pointer. This is the
-  write-the-leaves-then-flip-the-root discipline, and it is what lets non-atomic backends be
-  crash-safe.
+  Then any prefix leaves the store consistent: the values are written but unreachable
+  (harmless orphans, collectable), and the pointer flips only once everything it
+  references exists. A torn sequence can never produce a dangling pointer. This is the
+  write-the-leaves-then-flip-the-root discipline, and it is what lets a caller be
+  crash-safe on a backend with no atomic batch at all.
 
-  Atomic backends still apply the batch all-or-nothing, in which case the order is simply
-  redundant — passing an ordered seq is always safe.
+  That discipline is the CALLER'''s to apply, not a guarantee this function makes on a
+  non-atomic store. Order is still preserved here — sequence order is apply order, and it
+  reaches the write-hook verbatim — but on an atomic backend the ordering is simply
+  redundant.
 
   Returns a map of keys to results (typically true for each key).
 


### PR DESCRIPTION
`multi-assoc`'s docstring opened with:

> Atomically where the backend can (IndexedDB); ordered everywhere, which is the weaker
> guarantee that actually suffices.

and then explained that ordering is enough for a leaves-then-root batch. Read by a backend
author, that is an invitation to implement the protocols non-atomically and provide
ordering.

**The invariant konserve actually maintains is the opposite**: the multi-key protocols are
declared only where the backend can apply the batch atomically, and a store that cannot
refuses outright.

I audited every backend before changing the text, and it holds today:

| backend | mechanism | atomic |
| --- | --- | --- |
| IndexedDB | object-store transaction | yes |
| DynamoDB | `TransactWriteItems`, refuses above its 100-item limit rather than splitting | yes |
| Redis | `MULTI`/`EXEC` | yes |
| JDBC | `jdbc/with-transaction` around the whole batch | yes |
| filestore, S3, GCS | not implemented | — |

So nothing unsafe is shipping. What *was* shipping is a docstring licensing it.

That matters beyond tidiness. A caller reaching for `multi-assoc` is asking for
all-or-nothing, and datahike would write unsafely against a store that quietly provided
ordering instead. An object store cannot honour it either way: Google documents batch
requests as [explicitly not atomic](https://docs.cloud.google.com/storage/docs/batch) — *"it is possible for some of the operations
contained within the batch to fail while others succeed"* — and S3 has no cross-object
transaction at all.

The leaves-then-root discipline is still described, but as what it is: the **caller's**
pattern for a store with no atomic batch, using ordinary ordered `assoc`s — not a weaker
mode of this function.

`doc/backend.org` gains the matching section, including one mismatch worth recording:
`-supports-multi-key?` requires **both** protocols while `-multi-dissoc` needs only the
write one, so a backend that can batch deletes but not batch reads cannot expose that
alone today.

Docs only — 250 tests / 4144 assertions unchanged.