### PR TITLE
Refuse the fencing options where they cannot be honoured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,36 @@ All notable, user-visible changes to konserve are documented here.
   being switched to the high one.
 
 ### Fixed
+- **`multi-get`, `multi-dissoc` and a copy-and-rename layout no longer drop
+  `:expected-revision` silently.** Three ways the option could be asked for and
+  not honoured, each of which now raises instead:
+
+  - `multi-get` forwarded it to the backing. A read cannot be fenced, so on its
+    own that is merely meaningless — but a backing that fences ITSELF has to
+    remember, for the duration of one conditional write, the metadata konserve
+    read under the lock, because `-sync` runs on a different blob record than the
+    read did. `multi-get` takes no per-key lock and closes no rows, so such a
+    read looked exactly like the read belonging to an in-flight fenced write and
+    replaced the metadata that write was about to compare against. Reproduced on
+    konserve-jdbc: the fenced write reported SUCCESS and overwrote the value that
+    had committed in between.
+  - `multi-dissoc` forwarded it into `-multi-delete-blobs`, where every backing
+    ignores it, so a caller asking for a fenced batch delete was told it
+    happened. `multi-assoc` has always refused; this is the same rule.
+  - A backing that declares `PSelfConditionalWrite` now LOSES its domain when the
+    store is configured `:in-place? false`. That layout writes `<store-key>.new`
+    and renames it into place, so the storage layer's precondition is evaluated
+    against a key that by construction does not exist — every such write is a
+    create, and creates succeed — while the rename that follows compares nothing.
+    A lock-based claim is unaffected and must be: there konserve holds the lock
+    and evaluates the revision itself, across the write and the rename, which is
+    how the filestore (`:in-place? false` by default) is fenced correctly.
+
+  Every released self-fencing backend sets `:in-place? true`, so no default
+  deployment was affected; `connect-default-store`'s own default is `false`, and
+  a caller's `:config` is merged over a backend's, so the guarantee rested on a
+  flag rather than on anything structural.
+
 - **Compression combined with encryption never worked.** The read path nested
   the wrappers the opposite way round from the write path, so it tried to
   *decompress ciphertext*: `zstd` + `aes` failed with "Unknown frame

--- a/src/konserve/compliance_test.cljc
+++ b/src/konserve/compliance_test.cljc
@@ -130,7 +130,23 @@
         (testing "multi-assoc refuses to be made conditional"
           (when (utils/multi-key-capable? store)
             (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                         (<!! (k/multi-assoc store {:cas-m1 1} (assoc opts :expected-revision :x)))))))))))
+                         (<!! (k/multi-assoc store {:cas-m1 1} (assoc opts :expected-revision :x)))))))
+
+        ;; The other two multi-key entry points, for the same reason and with a
+        ;; sharper edge on `multi-get`: a backing that fences itself must remember
+        ;; what its read saw for the duration of one conditional write, and an
+        ;; unlocked multi-read carrying this option could replace that memory with
+        ;; metadata that had already overtaken it — turning the fenced write into
+        ;; the silent overwrite the option exists to prevent.
+        (testing "multi-dissoc refuses to be made conditional"
+          (when (utils/multi-key-capable? store)
+            (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                         (<!! (k/multi-dissoc store [:cas-m1] (assoc opts :expected-revision :x)))))))
+
+        (testing "multi-get refuses to be made conditional"
+          (when (utils/multi-key-capable? store)
+            (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                         (<!! (k/multi-get store [:cas-m1] (assoc opts :expected-revision :x)))))))))))
 
 #?(:clj
    (defn compliance-test [store]

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -594,6 +594,21 @@
    (multi-get store keys {:sync? false}))
   ([store keys opts]
    (log/trace :konserve/multi-get {:key-count (count keys)})
+   ;; A READ cannot be fenced, and forwarding the option here is not merely
+   ;; useless — it is dangerous. A backing that fences itself has to remember, for
+   ;; the duration of one conditional write, the metadata konserve read under the
+   ;; lock, because `-sync` runs on a different blob record than the read did.
+   ;; `multi-get` takes no per-key lock and closes nothing, so a multi-read
+   ;; carrying `:expected-revision` looked to such a backing exactly like the read
+   ;; belonging to an in-flight fenced write — and replaced the metadata that
+   ;; write was about to compare against with metadata that had overtaken it.
+   ;; Reproduced on JDBC before this: the fenced write reported SUCCESS and
+   ;; overwrote the value that had committed in between.
+   ;;
+   ;; The backings can and do defend themselves by narrowing what may deposit,
+   ;; but the option has no meaning on this path at all, so refusing it here
+   ;; removes the whole class rather than one instance of it.
+   (refuse-conditional-unsupported! "multi-get" opts)
    (when-not (multi-key-capable? store)
      (throw (#?(:clj ex-info :cljs js/Error.) "Store does not support multi-key operations"
                                               #?(:clj {:store-type (type store)
@@ -827,6 +842,13 @@
    (multi-dissoc store keys {:sync? false}))
   ([store keys opts]
    (log/trace :konserve/multi-dissoc {:key-count (count keys)})
+   ;; `multi-assoc` has always refused this; `multi-dissoc` forwarded it into
+   ;; `-multi-delete-blobs`, where every backing ignores it — so a caller asking
+   ;; for a fenced batch delete was told it happened. Same reasoning as
+   ;; `refuse-conditional-multi!`: checking every key and then deleting every key
+   ;; is not one step, so the guarantee could not be honoured even by a backing
+   ;; that wanted to. Refusing is recoverable; silently dropping it is not.
+   (refuse-conditional-unsupported! "multi-dissoc" opts)
    (when-not (multi-key-capable? store)
      (throw (#?(:clj ex-info :cljs js/Error.) "Store does not support multi-key operations"
                                               #?(:clj {:store-type (type store)

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -984,8 +984,22 @@
       ;; happened to be global — see `PSelfConditionalWrite` for the stores that
       ;; fence themselves without reaching that far, which the old test would have
       ;; silently disarmed.
+      ;; `:in-place?` revokes a SELF-fenced claim, and only that kind. The
+      ;; storage layer evaluates the precondition inside `-sync`, but under
+      ;; `:in-place? false` `update-blob` syncs to `<store-key>.new` and then
+      ;; renames it into place — so the comparison is made against a key that by
+      ;; construction does not exist (every such write is a create, and creates
+      ;; succeed), and the `-atomic-move` that follows compares nothing at all. A
+      ;; caller would be told its conditional write landed while no condition was
+      ;; ever evaluated.
+      ;;
+      ;; A LOCK-based claim survives that layout, which is why this is not
+      ;; hoisted out of the branch: there konserve holds the lock and evaluates
+      ;; `check-revision!` itself, across the write AND the rename. The filestore
+      ;; is `:in-place? false` by default and is fenced correctly; moving this
+      ;; test above the `if` would silently disarm it.
       (if (satisfies? protocols/PSelfConditionalWrite backing)
-        declared
+        (when (:in-place? config) declared)
         (when (:lock-blob? config) declared))))
   (-revision [this key opts]
     (async+sync (:sync? opts) *default-sync-translation*

--- a/test/konserve/contract_teeth_test.clj
+++ b/test/konserve/contract_teeth_test.clj
@@ -17,6 +17,8 @@
             [clojure.core.async :refer [<!!]]
             [konserve.core :as k]
             [konserve.memory :refer [new-mem-store]]
+            [konserve.filestore :refer [connect-fs-store delete-store]]
+            [konserve.impl.defaults :as defaults]
             [konserve.compliance-test :refer [conditional-write-compliance-test]]
             [konserve.protocols :as p]))
 
@@ -73,3 +75,54 @@
         (conditional-write-compliance-test honest))
       (is (zero? (count @reports))
           (str "an honest store must pass cleanly: " (pr-str (map :type @reports)))))))
+
+;; ---------------------------------------------------------------------------
+;; A claim the layout cannot support
+;; ---------------------------------------------------------------------------
+
+;; Only the two methods `-conditional-write-domain` reads are needed, so these
+;; are stubs rather than working backings: the question here is what a store
+;; PROMISES given a backing and a config, which is answered before any IO.
+(deftype SelfFencingBacking []
+  p/PSelfConditionalWrite
+  p/PConditionalWrite
+  (-conditional-write-domain [_] :global))
+
+(deftype LockFencingBacking []
+  p/PConditionalWrite
+  (-conditional-write-domain [_] :machine))
+
+(defn- domain-of [backing config]
+  (k/conditional-write-domain (defaults/map->DefaultStore {:backing backing :config config})))
+
+(deftest a-self-fenced-claim-does-not-survive-a-copy-and-rename-layout
+  (testing "`:in-place? false` revokes a SELF-fenced domain"
+    ;; Under that layout `update-blob` syncs to `<store-key>.new` and renames it
+    ;; into place. The storage layer's precondition is therefore evaluated
+    ;; against a key that cannot exist — so it always passes — and the rename
+    ;; compares nothing. The write would be reported as fenced with no condition
+    ;; ever evaluated, which is the one outcome the capability exists to prevent.
+    (is (= :global (domain-of (SelfFencingBacking.) {:in-place? true :lock-blob? true})))
+    (is (nil? (domain-of (SelfFencingBacking.) {:in-place? false :lock-blob? true}))
+        "a backing that fences itself cannot fence a key it is not writing to"))
+
+  (testing "but a LOCK-based claim survives it, which is the point of the branch"
+    ;; konserve holds the lock and evaluates `check-revision!` itself, across the
+    ;; write AND the rename, so the layout is irrelevant to that fence. The
+    ;; filestore ships `:in-place? false`; hoisting the test above the branch
+    ;; would silently disarm the one backend most likely to be run locally.
+    (is (= :machine (domain-of (LockFencingBacking.) {:in-place? false :lock-blob? true})))
+    (is (nil? (domain-of (LockFencingBacking.) {:in-place? false :lock-blob? false}))
+        "without the lock there is no mechanism left, whatever the backing claims")))
+
+(deftest the-filestore-still-declares-a-domain
+  ;; The end-to-end guard for the test above: a real filestore, with its real
+  ;; default config, must keep fencing.
+  (let [dir (str "/tmp/konserve-teeth-" (System/currentTimeMillis))
+        store (<!! (connect-fs-store dir))]
+    (try
+      (is (= false (:in-place? (:config store))) "the filestore is not in-place")
+      (is (some? (k/conditional-write-domain store))
+          "and is nevertheless fenced, by konserve's lock rather than by itself")
+      (conditional-write-compliance-test store)
+      (finally (delete-store dir)))))

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -202,8 +202,19 @@
     (let [folder "/tmp/konserve-fs-selffence-test"
           _      (delete-store folder)
           store  (<!! (connect-fs-store folder :config {:lock-blob? false}))
+          ;; `:in-place? true` alongside the swapped backing, because that is the
+          ;; configuration a self-fencing backend actually ships — and since
+          ;; konserve#176 it is part of what makes the claim valid. The filestore
+          ;; itself defaults to `:in-place? false`, which is fine for ITS fence
+          ;; (konserve holds the lock across the write and the rename) but not for
+          ;; a backing that evaluates the condition inside `-sync`: there the
+          ;; condition would be evaluated against `<key>.new` and the rename would
+          ;; compare nothing. What this test is about — `:lock-blob?` must not
+          ;; disarm a self-fencing backing — is unchanged.
           self   (fn [domain]
-                   (clojure.core/assoc store :backing
+                   (clojure.core/assoc store
+                                       :config (clojure.core/assoc (:config store) :in-place? true)
+                                       :backing
                                        (reify konserve.protocols/PConditionalWrite
                                          (-conditional-write-domain [_] domain)
                                          konserve.protocols/PSelfConditionalWrite)))]
@@ -225,7 +236,9 @@
       (k/get store :fenced nil {:sync? true :with-revision? true})
       (is (= 1 (count (cas-of))) "konserve-lock backing: sidecar")
       ;; the same store with a self-fencing backing gets none
-      (let [self-store (clojure.core/assoc store :backing
+      (let [self-store (clojure.core/assoc store
+                                           :config (clojure.core/assoc (:config store) :in-place? true)
+                                           :backing
                                            (reify konserve.protocols/PConditionalWrite
                                              (-conditional-write-domain [_] :machine)
                                              konserve.protocols/PSelfConditionalWrite))]


### PR DESCRIPTION
Closes #175, closes #176.

Three paths accepted `:expected-revision` and did not act on it. Silently dropping it is the one outcome the capability exists to prevent, so each now raises.

### `multi-get` — this one was a lost update, not just noise

A read cannot be fenced, which on its own makes the option merely meaningless. What makes it dangerous is that a backing which fences **itself** must remember, for the duration of one conditional write, the metadata konserve read under the lock — `-sync` runs on a different blob record than the read did, so the bytes have to travel between them somehow.

`multi-get` takes no per-key lock and closes no rows. So a multi-read carrying the option looked to such a backing exactly like the read belonging to an in-flight fenced write, and replaced the metadata that write was about to compare against with metadata that had already overtaken it. Reproduced on konserve-jdbc: the fenced write reported **success** and its stale value replaced the one that committed in between.

Backings can narrow what may deposit — konserve-jdbc now keys that on the operation — but the option has no meaning on this path at all, so refusing it here removes the class rather than one instance. **konserve-rocksdb has the same read-cache design and the same hole on main today; this closes it there without touching that repository.**

### `multi-dissoc`

Forwarded into `-multi-delete-blobs`, where every backing ignores it. `multi-assoc` has refused since the option existed, for a reason that applies unchanged: checking every key and then writing every key is not one step.

### `:in-place? false` revokes a self-fenced domain

A `PSelfConditionalWrite` backing evaluates the precondition inside `-sync`, but under that layout `update-blob` syncs to `<store-key>.new` and renames it into place afterwards. The condition is evaluated against a key that by construction does not exist — every such write is a create, and creates succeed — and the `-atomic-move` compares nothing.

**The test stays inside the self-fencing branch, deliberately.** A lock-based claim survives the same layout, because konserve holds the lock and evaluates `check-revision!` itself across both the write and the rename. The filestore ships `:in-place? false` and is fenced correctly; hoisting the test above the branch would silently disarm the backend most likely to be run locally. `filestore_test`'s self-fencing fixture now sets the flag a self-fencing backend actually ships, and a new test asserts a real filestore keeps its domain.

Every released self-fencing backend (s3, gcs, dynamodb, redis, rocksdb, jdbc) sets `:in-place? true`, so **no default deployment was affected**. But `connect-default-store` defaults it to `false` and a caller's `:config` is merged over a backend's, so the guarantee rested on a flag rather than on anything structural.

### Tests

Compliance gains `multi-dissoc` and `multi-get` refusals next to the existing `multi-assoc` one, so every backend's suite checks all three. `contract_teeth_test` gains the domain-revocation cases plus the filestore guard against over-fixing.

Negative controls, each red without its fix:

| control | result |
|---|---|
| un-revoke the self-fenced domain | `:in-place? false` store still claims `:global` |
| remove both refusals | `multi-get` and `multi-dissoc` return normally with the option set |

**JVM: 253 tests, 4213 assertions, 0 failures. cljs (node): 64 tests, 409 assertions, 0 failures.** clj-kondo warning count unchanged; cljfmt clean.

Found by two independent reviews of the konserve-jdbc conditional-write PR (replikativ/konserve-jdbc#38), which carries its own local defence for the deposit side.