### PR TITLE
Connecting to an existing store no longer writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable, user-visible changes to konserve are documented here.
 
 ## Unreleased
 
+### Fixed
+- **Connecting to an existing store no longer writes.** `connect-default-store`
+  called `-create-store` unconditionally on every connect — "auto-create on
+  connect" implemented as "create on connect". On an object-store backing that
+  is a PUT of the store marker, so every connect to an EXISTING store performed
+  a write it had no reason to perform: a reader holding read-only credentials
+  could not connect at all, and (measured against S3 in
+  replikativ/datahike-serverless#6) a cold datahike tenant open cost 2 PUTs —
+  it probes and then connects, writing the marker twice — where the correct
+  number is zero. Connect now probes `-store-exists?` first and creates only
+  what is missing: the existing-store path is a HEAD/stat, read-only
+  credentials work, and auto-create is untouched for a missing store. The
+  first-connect race is benign and no worse than before — `-create-store` has
+  always had to be idempotent, since until now it ran on every connect.
+
 ### Added
 - **Conditional writes (`:expected-revision`), with an explicit capability.** A
   write can now be made conditional on the revision the caller read: it lands

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -16,7 +16,7 @@
                                              PMultiKeyEDNValueStore
                                              PWriteHookStore]]
    #?(:clj [konserve.nio-helpers :as nio])
-   [konserve.impl.storage-layout :refer [-streaming-binary-write? -atomic-move -create-store
+   [konserve.impl.storage-layout :refer [-streaming-binary-write? -atomic-move -create-store -store-exists?
                                          -copy -create-blob -delete-blob -blob-exists?
                                          -keys -sync-store
                                          -migratable -migrate -handle-foreign-key
@@ -1303,7 +1303,25 @@
         (throw (ex-info "You need to activate file-locking for in-place mode."
                         {:type :store-configuration-error
                          :config complete-config}))
-        (let [_                  (<?- (-create-store backing opts))
+        (let [;; ENSURE means make-it-so, not write-regardless. This used to
+              ;; call `-create-store` unconditionally on every connect, which on
+              ;; an object-store backing is a PUT of the store marker — so every
+              ;; connect to an EXISTING store performed a write it had no reason
+              ;; to perform. Two practical consequences, both measured against
+              ;; S3 (replikativ/datahike-serverless#6): a reader holding
+              ;; read-only credentials could not connect at all, and a cold
+              ;; open cost 2 PUTs (datahike probes and then connects, so the
+              ;; marker was written twice) where the correct number is zero.
+              ;;
+              ;; Probing first makes the existing-store path READ-ONLY — a
+              ;; HEAD/stat instead of a write — while auto-create semantics are
+              ;; untouched for a missing store. The first-connect race is
+              ;; benign and no worse than before: two concurrent creators both
+              ;; write a marker whose content is constant, and `-create-store`
+              ;; has always had to be idempotent — until this change it ran on
+              ;; EVERY connect.
+              _                  (when-not (<?- (-store-exists? backing opts))
+                                   (<?- (-create-store backing opts)))
               store              (map->DefaultStore {:backing             backing
                                                      :default-serializer  default-serializer
                                                      :serializers         (merge key->serializer serializers)

--- a/test/konserve/connect_readonly_test.clj
+++ b/test/konserve/connect_readonly_test.clj
@@ -1,0 +1,78 @@
+(ns konserve.connect-readonly-test
+  "Connecting to an EXISTING store must not write.
+
+   `connect-default-store` used to call `-create-store` unconditionally on
+   every connect — 'auto-create on connect' implemented as 'create on
+   connect'. On an object-store backing that is a PUT of the store marker, so
+   every connect performed a write it had no reason to perform: a reader
+   holding read-only credentials could not connect at all, and a cold open
+   against S3 cost 2 PUTs (datahike probes and then connects) where the
+   correct number is zero. Measured in replikativ/datahike-serverless#6.
+
+   The oracle here is a REFUSING backing: `-create-store` on it throws once
+   the store exists, exactly as a read-only credential would. A counting
+   assertion alone could go stale; a backing that fails the way production
+   fails cannot."
+  (:require [clojure.test :refer [deftest is testing]]
+            [konserve.core :as k]
+            [konserve.filestore :refer [delete-store]]
+            [konserve.impl.defaults :refer [connect-default-store]]
+            [konserve.impl.storage-layout :as sl])
+  (:import [java.util UUID]))
+
+(defn- counting-refusing-backing
+  "Wrap `inner` so that `-create-store` counts its calls and THROWS when the
+   store already exists — the behaviour of a backing reached through
+   read-only credentials. Everything else delegates."
+  [inner counter]
+  (reify
+    sl/PBackingStore
+    (-create-blob [_ store-key env] (sl/-create-blob inner store-key env))
+    (-delete-blob [_ store-key env] (sl/-delete-blob inner store-key env))
+    (-blob-exists? [_ store-key env] (sl/-blob-exists? inner store-key env))
+    (-copy [_ from to env] (sl/-copy inner from to env))
+    (-atomic-move [_ from to env] (sl/-atomic-move inner from to env))
+    (-migratable [_ key store-key env] (sl/-migratable inner key store-key env))
+    (-migrate [_ mk kv ser rh wh env] (sl/-migrate inner mk kv ser rh wh env))
+    (-create-store [this env]
+      (swap! counter inc)
+      (if (sl/-store-exists? inner env)
+        (throw (ex-info "write refused: store exists and credentials are read-only"
+                        {:type ::readonly-violation}))
+        (sl/-create-store inner env)))
+    (-sync-store [_ env] (sl/-sync-store inner env))
+    (-store-exists? [_ env] (sl/-store-exists? inner env))
+    (-delete-store [_ env] (sl/-delete-store inner env))
+    (-keys [_ env] (sl/-keys inner env))))
+
+(defn- fs-backing
+  "A filestore backing constructed DIRECTLY — `connect-fs-store` would run
+   `connect-default-store` itself and thereby create the store before the
+   wrapped backing under test ever saw a call, making the first-connect
+   assertion vacuously zero."
+  [path]
+  (konserve.filestore/map->BackingFilestore
+   ;; nil filesystem = the default one (see filestore's get-path)
+   {:base path :detected-old-blobs nil :ephemeral? false :filesystem nil}))
+
+(deftest connect-to-an-existing-store-does-not-write
+  (let [path (str "/tmp/konserve-readonly-test-" (UUID/randomUUID))]
+    (try
+      (testing "first connect creates — auto-create is untouched"
+        (let [counter (atom 0)
+              backing (counting-refusing-backing (fs-backing path) counter)
+              store   (connect-default-store backing {:opts {:sync? true}})]
+          (is (= 1 @counter) "a missing store is created, exactly once")
+          (k/assoc store :seed {:v 1} {:sync? true})))
+      (testing "a second connect performs NO create — and therefore works on
+                credentials that cannot write"
+        (let [counter (atom 0)
+              backing (counting-refusing-backing (fs-backing path) counter)
+              ;; With the old behaviour this THROWS ::readonly-violation before
+              ;; returning a store — which is precisely what an S3 reader on a
+              ;; read-only IAM policy saw.
+              store   (connect-default-store backing {:opts {:sync? true}})]
+          (is (zero? @counter) "an existing store is probed, never created")
+          (is (= {:v 1} (k/get store :seed nil {:sync? true}))
+              "and the connect is fully functional for reads")))
+      (finally (delete-store path)))))


### PR DESCRIPTION
`connect-default-store` called `-create-store` **unconditionally on every connect** — "auto-create on connect" implemented as "create on connect". On an object-store backing that's a PUT of the store marker, so every connect to an *existing* store performed a write it had no reason to perform.

Measured against S3 with a request-counting proxy (replikativ/datahike-serverless#6): a pure reader connect on an existing datahike tenant issued **2 PUTs, both to `<store-id>_.konserve-metadata`** — datahike probes (`database-exists?`) and then connects, each connect writing the marker once. Two practical consequences, both fixed here:

1. **A reader holding read-only object-store credentials can now connect.** Read-only IAM as the second, independent enforcement of a reader/writer split works.
2. **A cold tenant open is 0 PUTs**, not 2 — which in the quiet-tenant serverless regime (most opens cold) is a materially different cost model.

The change is probe-then-create:

```clojure
(when-not (<?- (-store-exists? backing opts))
  (<?- (-create-store backing opts)))
```

Auto-create is untouched for a missing store; the existing-store path becomes a HEAD/stat. The first-connect race is benign and no worse than before — `-create-store` has always had to be idempotent, since until now it ran on *every* connect.

**The regression test's oracle is a refusing backing**, not a counter alone: its `-create-store` throws once the store exists, exactly as a read-only credential does — so the old behaviour cannot connect at all (verified red-first: reverting the fix errors with `::readonly-violation`), while first-connect still counts exactly one create. The fixture constructs the filestore backing directly; going through `connect-fs-store` would create the store before the wrapped backing saw a call and the assertion would pass vacuously.

JVM: **255 tests, 4230 assertions, 0 failures.** cljs (node): **65 tests, 420 assertions, 0 failures.** cljfmt clean.