### PR TITLE
Connecting to an existing IndexedDB store opens it again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable, user-visible changes to konserve are documented here.
 ## Unreleased
 
 ### Fixed
+- **Connecting to an existing IndexedDB store opens it again.** The previous
+  fix (connect no longer writes) skipped `-create-store` for a store that
+  already exists — and for the IndexedDB backing, `-create-store` *is* the open:
+  `indexedDB.open` both creates and opens, and the handle it yields is what
+  every later transaction needs. A reconnect to an existing store therefore
+  left the handle nil, and the first access failed with "Cannot read properties
+  of null (reading 'transaction')" — every datahike-in-the-browser reconnect.
+  Backings whose create is also their open now implement the optional
+  `PBackingOpen` (`-open-store`), which connect calls for an existing store;
+  `-create-store` still runs only for a missing one, so the read-only
+  existing-store path is preserved for object-store backings.
 - **Connecting to an existing store no longer writes.** `connect-default-store`
   called `-create-store` unconditionally on every connect — "auto-create on
   connect" implemented as "create on connect". On an object-store backing that

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -17,6 +17,7 @@
                                              PWriteHookStore]]
    #?(:clj [konserve.nio-helpers :as nio])
    [konserve.impl.storage-layout :refer [-streaming-binary-write? -atomic-move -create-store -store-exists?
+                                         PBackingOpen -open-store
                                          -copy -create-blob -delete-blob -blob-exists?
                                          -keys -sync-store
                                          -migratable -migrate -handle-foreign-key
@@ -1320,7 +1321,13 @@
               ;; write a marker whose content is constant, and `-create-store`
               ;; has always had to be idempotent — until this change it ran on
               ;; EVERY connect.
-              _                  (when-not (<?- (-store-exists? backing opts))
+              ;; A backing whose create IS its open (IndexedDB sets its db
+              ;; handle in -create-store) still has to open an existing store:
+              ;; skipping create there left the handle nil and every later
+              ;; transaction failed. `PBackingOpen` is the read-only half.
+              _                  (if (<?- (-store-exists? backing opts))
+                                   (when (satisfies? PBackingOpen backing)
+                                     (<?- (-open-store backing opts)))
                                    (<?- (-create-store backing opts)))
               store              (map->DefaultStore {:backing             backing
                                                      :default-serializer  default-serializer

--- a/src/konserve/impl/storage_layout.cljc
+++ b/src/konserve/impl/storage_layout.cljc
@@ -175,6 +175,16 @@
   (-keys [this env] "List all the keys representing blobs in the store.")
   (-handle-foreign-key [this migration-key serializer read-handlers write-handlers env] "Handle keys not recognized by the current konserve version."))
 
+(defprotocol PBackingOpen
+  "OPTIONAL. A backing whose `-create-store` also OPENS a handle — IndexedDB
+   sets its database object there — implements this so that connecting to an
+   EXISTING store can open without creating. `connect-default-store` probes
+   `-store-exists?` first and, for a store that exists, calls `-open-store`
+   when the backing provides it and nothing otherwise; `-create-store` runs
+   only for a missing store. Backings whose create is a pure creation (a
+   directory, a marker object) need not implement this."
+  (-open-store [this env] "Open the underlying store's handle without creating anything."))
+
 (defprotocol PMultiWriteBackingStore
   "Protocol for backing stores that support atomic multi-key writes."
   (-multi-write-blobs [this store-key-values env]

--- a/src/konserve/indexeddb.cljs
+++ b/src/konserve/indexeddb.cljs
@@ -6,6 +6,7 @@
             [konserve.impl.defaults :as defaults]
             [konserve.impl.storage-layout :as storage-layout
              :refer [PMultiWriteBackingStore PMultiReadBackingStore PReadMissSafe
+                     PBackingOpen -open-store
                      store-key-not-found-ex store-key-not-found?]]
             [konserve.serializers]
             [konserve.protocols :as protocols]
@@ -388,18 +389,16 @@
                                                {:cause ?err
                                                 :caller 'konserve.indexeddb/-copy}))
                             (close! out)))))))))
+  ;; For IndexedDB, opening and creating are ONE operation: `indexedDB.open`
+  ;; creates a missing database and opens an existing one, and the handle it
+  ;; yields is what every later transaction needs. So -create-store is
+  ;; -open-store, and connect calls the latter for an existing store (see
+  ;; PBackingOpen): before that, an existing store was probed, create was
+  ;; skipped, and `db` stayed nil — "Cannot read properties of null (reading
+  ;; 'transaction')" on the first access after a reconnect.
   (-create-store [this env]
     (assert (not (:sync? env)) (str "-create-store requires async, got env: " (pr-str env)))
-    (with-promise out
-      (take! (connect-to-idb db-name)
-             (fn [res]
-               (if (instance? js/Error res)
-                 (put! out (ex-info "error connecting to database"
-                                    {:cause res
-                                     :caller 'konserve.indexeddb/-create-store}))
-                 (do
-                   (set! (.-db this) res)
-                   (put! out this)))))))
+    (-open-store this env))
   (-delete-store [_this env]
     (assert (not (:sync? env)))
     (with-promise out
@@ -415,6 +414,20 @@
     (assert (not (:sync? env)))
     (db-exists? db-name))
   (-sync-store [_this env] (when-not (:sync? env) (go)))
+
+  PBackingOpen
+  (-open-store [this env]
+    (assert (not (:sync? env)) (str "-open-store requires async, got env: " (pr-str env)))
+    (with-promise out
+      (take! (connect-to-idb db-name)
+             (fn [res]
+               (if (instance? js/Error res)
+                 (put! out (ex-info "error connecting to database"
+                                    {:cause res
+                                     :caller 'konserve.indexeddb/-open-store}))
+                 (do
+                   (set! (.-db this) res)
+                   (put! out this)))))))
 
   ;; Implementation for atomic multi-key operations
   PMultiWriteBackingStore

--- a/test/konserve/indexeddb_test.cljs
+++ b/test/konserve/indexeddb_test.cljs
@@ -345,3 +345,30 @@
                                         idb/connect-idb-store
                                         idb/delete-idb))
            (done))))
+(deftest ^:browser reconnect-existing-store-opens-its-handle-test
+  ;; Connect no longer writes for an existing store — it must still OPEN it.
+  ;; Before PBackingOpen, the second connect below skipped -create-store (which
+  ;; is where IndexedDB opens its database) and the first access failed with
+  ;; "Cannot read properties of null (reading 'transaction')".
+  (if ^boolean userAgent.GECKO
+    (is (true? true))
+    (async done
+           (go
+             (let [db-name "reconnect-existing-db"]
+               (<! (idb/delete-idb db-name))
+               (let [first-store (<! (idb/connect-idb-store db-name))]
+                 (is (not (instance? js/Error first-store)))
+                 (<! (konserve.core/assoc first-store :answer 42 {:sync? false}))
+                 (is (true? (<! (idb/db-exists? db-name))) "precondition: the store exists now")
+                 (testing "a second connect to the EXISTING store can read through it"
+                   (let [again (<! (idb/connect-idb-store db-name))]
+                     (is (not (instance? js/Error again))
+                         (str "reconnect failed: " again))
+                     (when-not (instance? js/Error again)
+                       (is (= 42 (<! (konserve.core/get again :answer nil {:sync? false})))
+                           "the handle is open: the value written before is readable")
+                       ;; deleteDatabase blocks while any connection is open.
+                       (some-> again :backing .-db .close))))
+                 (some-> first-store :backing .-db .close))
+               (<! (idb/delete-idb db-name))
+               (done))))))


### PR DESCRIPTION
## Summary

- #179 ("connecting to an existing store no longer writes") skips `-create-store` when the store exists. For the IndexedDB backing, `-create-store` **is** the open — `indexedDB.open` both creates and opens, and the handle it yields is what every later transaction needs. Since 0.9.380 a reconnect to an existing IndexedDB store leaves the handle nil and the first access fails with `Cannot read properties of null (reading 'transaction')`. Datahike's kabel browser integration test caught it on the bump to 0.9.380 (step 9, reconnect after release).
- Fix: an optional `PBackingOpen` protocol (`-open-store`). `connect-default-store` calls it for an existing store that implements it, and `-create-store` only for a missing store — so #179's read-only existing-store path is intact for object-store backings. IndexedDB implements `-open-store`; its `-create-store` delegates to it. No other in-tree backing mutates state in `-create-store` (checked filestore, node_filestore, memory).

## Tests

- New browser test `reconnect-existing-store-opens-its-handle-test`: connect, write, connect the **same existing** database again, read the value through the second handle (closing both handles before `deleteDatabase`, which otherwise blocks).
- JVM (`connect-readonly`, `filestore`, `tiered`): 23 tests / 606 assertions. Karma (Chrome headless): 59/59. `cljfmt` clean.