### PR TITLE
Support awaited tiered read-through

### DIFF
--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -320,6 +320,41 @@
        (finally
          (async/put! cache-lock :unlocked))))))
 
+(defn- complete-read-through
+  "Populate one frontend read and run its write hook.
+
+   Kept as an async+sync operation so a caller that needs a COMPLETE cache can
+   await exactly the same generation-fenced fill that ordinary reads launch in
+   the background. In a nested tier, `opts` reaches the backend read first, so
+   `:await-read-through?` fills deepest-to-outermost."
+  [frontend-store cache-lock cache-generation observed-generation
+   populate-fn hook-event opts]
+  (async+sync (:sync? opts)
+              *default-sync-translation*
+              (go-try-
+               (when (<?- (populate-frontend cache-lock cache-generation
+                                             observed-generation populate-fn opts))
+                 (invoke-write-hooks! frontend-store hook-event)))))
+
+(defn- start-read-through!
+  "Await a cache fill when requested; otherwise preserve fire-and-forget reads."
+  [frontend-store cache-lock cache-generation observed-generation
+   populate-fn hook-event opts]
+  (let [fill #(complete-read-through frontend-store cache-lock cache-generation
+                                     observed-generation populate-fn hook-event opts)]
+    (if (:await-read-through? opts)
+      (fill)
+      (do
+        (go
+          (try
+            (<?- (fill))
+            (catch #?(:clj Exception :cljs js/Error) e
+              (log/debug :konserve/tiered-frontend-populate-failed
+                         {:event hook-event :error e}))))
+        ;; The caller uniformly awaits this function. Deliver an immediate
+        ;; completion in ordinary mode while the detached fill continues.
+        (async+sync (:sync? opts) *default-sync-translation* (go-try- true))))))
+
 (defn ^:private update-frontend-after-backend
   "Order a frontend mutation after all older read-through cache fills."
   [cache-lock cache-generation update-fn opts]
@@ -442,18 +477,16 @@
                          (let [observed-generation @cache-generation
                                backend-result (<?- (-get-in backend-store key-vec ::missing opts))]
                            (when (not= backend-result ::missing)
-                           ;; Populate frontend asynchronously (fire-and-forget)
-                             (go (try
-                                   (when (<?- (populate-frontend
-                                               cache-lock cache-generation observed-generation
-                                               #(-assoc-in frontend-store key-vec (partial meta-update (first key-vec) :edn) backend-result (frontend-opts opts))
-                                               opts))
-                                     (invoke-write-hooks! frontend-store {:api-op :assoc-in
-                                                                          :key (first key-vec)
-                                                                          :key-vec key-vec
-                                                                          :value backend-result}))
-                                   (catch #?(:clj Exception :cljs js/Error) e
-                                     (log/debug :konserve/tiered-frontend-populate-failed {:key key-vec :error e})))))
+                             (<?- (start-read-through!
+                                   frontend-store cache-lock cache-generation observed-generation
+                                   #(-assoc-in frontend-store key-vec
+                                               (partial meta-update (first key-vec) :edn)
+                                               backend-result (frontend-opts opts))
+                                   {:api-op :assoc-in
+                                    :key (first key-vec)
+                                    :key-vec key-vec
+                                    :value backend-result}
+                                   opts)))
                            (if (not= backend-result ::missing)
                              backend-result
                              not-found))))
@@ -725,17 +758,13 @@
                        ;; Some keys missing from frontend, fetch from backend
                        (let [observed-generation @cache-generation
                              backend-result (<?- (-multi-get backend-store missing-keys opts))]
-                         ;; Populate frontend asynchronously with found backend values (fire-and-forget)
                          (when (seq backend-result)
-                           (go (try
-                                 (when (<?- (populate-frontend
-                                             cache-lock cache-generation observed-generation
-                                             #(-multi-assoc frontend-store backend-result meta-update opts)
-                                             opts))
-                                   (invoke-write-hooks! frontend-store {:api-op :multi-assoc
-                                                                        :kvs backend-result}))
-                                 (catch #?(:clj Exception :cljs js/Error) e
-                                   (log/debug :konserve/tiered-frontend-populate-failed {:keys (clojure.core/keys backend-result) :error e})))))
+                           (<?- (start-read-through!
+                                 frontend-store cache-lock cache-generation observed-generation
+                                 #(-multi-assoc frontend-store backend-result meta-update
+                                                (frontend-opts opts))
+                                 {:api-op :multi-assoc :kvs backend-result}
+                                 opts)))
                          ;; Merge frontend and backend results
                          (merge frontend-result backend-result))
                        ;; All keys found in frontend

--- a/test/konserve/memory_test.cljc
+++ b/test/konserve/memory_test.cljc
@@ -114,6 +114,17 @@
                 (<! (tiered-tests/test-read-policies-async frontend backend))
                 (done))))))
 
+(deftest tiered-store-memory-awaited-read-through-test
+  #?(:clj
+     (let [{:keys [frontend backend]} (create-tiered-mem-stores)]
+       (<!! (tiered-tests/test-awaited-read-through-async frontend backend)))
+     :cljs
+     (async done
+            (go
+              (let [{:keys [frontend backend]} (<! (create-tiered-mem-stores))]
+                (<! (tiered-tests/test-awaited-read-through-async frontend backend))
+                (done))))))
+
 (deftest tiered-store-memory-key-operations-test
   #?(:clj
      (let [{:keys [frontend backend]} (create-tiered-mem-stores)]

--- a/test/konserve/tests/tiered.cljc
+++ b/test/konserve/tests/tiered.cljc
@@ -22,6 +22,32 @@
     (-dissoc [_ key opts]
       (protocols/-dissoc backend-store key opts))))
 
+(defn test-awaited-read-through-async
+  "An awaited miss is not complete until its frontend is populated, and a fill
+   failure is reported to that caller instead of being detached and logged."
+  [frontend-store backend-store]
+  (go
+    (<?- (k/dissoc frontend-store :awaited-read))
+    (<?- (k/assoc backend-store :awaited-read {:v 1}))
+    (let [store (<?- (tiered/connect-tiered-store frontend-store backend-store
+                                                  :read-policy :frontend-first))]
+      (is (= {:v 1}
+             (<?- (k/get store :awaited-read nil
+                         {:sync? false :await-read-through? true}))))
+      (is (= {:v 1} (<?- (k/get frontend-store :awaited-read)))
+          "the awaited read returns only after the frontend contains the value"))
+
+    (testing "an awaited cache-fill failure belongs to the read"
+      (<?- (k/dissoc frontend-store :awaited-read))
+      (let [failure (ex-info "deliberate awaited fill failure" {:test true})
+            broken-frontend (failing-assoc-store frontend-store failure)
+            store (<?- (tiered/connect-tiered-store broken-frontend backend-store
+                                                    :read-policy :frontend-first))
+            result (<! (k/get store :awaited-read nil
+                              {:sync? false :await-read-through? true}))]
+        (is (= "deliberate awaited fill failure" (ex-message result)))
+        (is (= {:test true} (ex-data result)))))))
+
 #?(:clj
    (defn test-tiered-compliance-sync [frontend-store backend-store]
      (let [store (clojure.core.async/<!! (tiered/connect-tiered-store frontend-store backend-store))]
@@ -152,7 +178,9 @@
          (is (= [nil "found-it"] (<! (k/assoc-in deepest-store [:deep-secret] "found-it"))))
          (is (false? (<! (k/exists? middle-store :deep-secret))) "Should not be in middle tier yet")
          (is (false? (<! (k/exists? frontend-store :deep-secret))) "Should not be in frontend yet")
-         (is (= "found-it" (<! (k/get-in top-store [:deep-secret]))) "Should retrieve value from deepest store")
+         (is (= "found-it" (<! (k/get-in top-store [:deep-secret]
+                                         nil {:sync? false :await-read-through? true})))
+             "Should retrieve and completely hydrate from the deepest store")
          (is (true? (<! (k/exists? frontend-store :deep-secret))) "Value should now be in frontend store")
          ;; Verify write hook on middle tier
          (let [[val port] (alts! [hook-promise (timeout 2000)])]


### PR DESCRIPTION
## Summary

- add an opt-in :await-read-through? operation option for tiered get/get-in and multi-get cache misses
- preserve the existing fire-and-forget behavior for ordinary reads
- propagate awaited hydration through nested tiered stores from the deepest backend outward
- surface frontend population failures to awaited callers

This supports callers such as Datahike that return a synchronous snapshot from an async refresh: the async boundary can now guarantee that every fetched persistent index node is locally readable before publishing the snapshot.

## Validation

- clojure -M:test (256 tests, 4,234 assertions)
- npx shadow-cljs release node-tests (0 warnings)
- node out/node-tests.js (66 tests, 424 assertions)
- clojure -M:format
- clojure -M:lint (0 errors; 23 pre-existing warnings)