### PR TITLE
Release sidecar after failed revision reads

### DIFF
--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -459,26 +459,36 @@
               ;; flag itself, so testing the operation is both correct and the only
               ;; thing available here.
               cas-blob (when (and (= :read-edn-meta operation) lock-based-fencing?)
-                         (<?- (-create-blob backing cas-store-key env)))
-              cas-lock (when cas-blob
-                         (log/trace :konserve/acquiring-cas-lock {:key key})
-                         (<?- (get-lock cas-blob (first key-vec) env)))
-              blob (<?- (-create-blob backing store-key env))
-              lock (when (:lock-blob? config)
-                     (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
-                     (<?- (get-lock blob (first key-vec) env)))]
+                         (<?- (-create-blob backing cas-store-key env)))]
+          ;; Keep each acquisition INSIDE the try that releases the preceding
+          ;; resource. A failure opening or locking the value blob must not strand
+          ;; the sidecar's JVM-wide FileLock; one leaked revision read otherwise
+          ;; wedges every later read and write of this key until the JVM exits.
           (try
-            (<?- (read-blob blob read-handlers serializers env))
-            (catch #?(:clj Exception :cljs js/Error) e
-              (if (store-key-not-found? e) (:not-found env) (throw e)))
+            (let [cas-lock (when cas-blob
+                             (log/trace :konserve/acquiring-cas-lock {:key key})
+                             (<?- (get-lock cas-blob (first key-vec) env)))]
+              (try
+                (let [blob (<?- (-create-blob backing store-key env))]
+                  (try
+                    (let [lock (when (:lock-blob? config)
+                                 (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
+                                 (<?- (get-lock blob (first key-vec) env)))]
+                      (try
+                        (<?- (read-blob blob read-handlers serializers env))
+                        (catch #?(:clj Exception :cljs js/Error) e
+                          (if (store-key-not-found? e) (:not-found env) (throw e)))
+                        (finally
+                          (when lock
+                            (log/trace :konserve/releasing-blob-lock
+                                       {:key (first key-vec) :blob (str blob)})
+                            (<?- (-release lock env))))))
+                    (finally
+                      (<?- (-close blob env)))))
+                (finally
+                  (when cas-lock (<?- (-release cas-lock env))))))
             (finally
-              (when (:lock-blob? config)
-                (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
-                (<?- (-release lock env)))
-              (<?- (-close blob env))
-              (when cas-lock
-                (<?- (-release cas-lock env))
-                (<?- (-close cas-blob env))))))
+              (when cas-blob (<?- (-close cas-blob env))))))
 
         (and (not store-key-exists?) migration-key)
         (<?- (-migrate backing migration-key key-vec serializer read-handlers write-handlers env))

--- a/test/konserve/filestore_test.clj
+++ b/test/konserve/filestore_test.clj
@@ -101,6 +101,40 @@
           "and still readable")
       (delete-store folder))))
 
+(deftest a-failed-revision-read-must-not-leak-the-sidecar-lock
+  (testing "a revision-bearing READ takes the sidecar before it takes the value
+            blob lock. If the latter acquisition fails, both the sidecar lock and
+            its channel still have to be released; otherwise one failed head read
+            wedges the mutable pointer for the lifetime of this JVM."
+    (let [folder "/tmp/konserve-fs-revision-read-lock-leak"
+          _      (delete-store folder)
+          store  (<!! (connect-fs-store folder))]
+      (k/assoc store :head {:v 1} {:sync? true})
+      (k/get store :head nil {:sync? true :with-revision? true})
+      (let [ksv (first (filter #(and (str/ends-with? % ".ksv")
+                                     (not (str/ends-with? % ".ksv.cas")))
+                               (map str (.list (java.io.File. folder)))))
+            ch  (FileChannel/open (Paths/get (str folder "/" ksv) (into-array String []))
+                                  (into-array StandardOpenOption
+                                              [StandardOpenOption/CREATE StandardOpenOption/WRITE]))
+            l   (.lock ch)]
+        (try
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (k/get store :head nil {:sync? true :with-revision? true}))
+              "the contended revision read reaches the transient failure path")
+          (finally (.release l) (.close ch))))
+      (let [[value revision]
+            (k/get store :head nil {:sync? true :with-revision? true})]
+        (is (= {:v 1} value)
+            "the sidecar was released and a subsequent fenced read succeeds")
+        (is (some? revision) "and still returns its fencing token"))
+      (is (= :wrote (deref (future (try (k/assoc store :head {:v 2} {:sync? true})
+                                        :wrote
+                                        (catch Throwable e (ex-message e))))
+                           20000 :timed-out-holding-the-lock))
+          "the key remains writable too")
+      (delete-store folder))))
+
 (deftest every-writer-to-a-fenceable-key-takes-the-sidecar
   (testing "the fence must exclude UNCONDITIONAL writers too, or it is not a
             fence. A plain write renames a new inode over the key; a fenced write


### PR DESCRIPTION
A revision-bearing filestore read acquired the permanent CAS sidecar, its lock,
the value blob, and its lock before entering the only cleanup block. If opening
or locking the value failed, the sidecar FileLock and channel leaked for the
lifetime of the JVM, wedging later fenced reads/writes of that key.

This is reachable from the Datahike GC-root registry: registry updates first
perform a revision-bearing read. A transient failure can then make a later root
release fail on the registry `.ksv.cas` sidecar and leave the lease behind.

This change nests acquisition/cleanup one resource at a time, matching the
already-hardened write path. The regression test holds the value blob lock,
forces a revision read to fail after taking the sidecar, then proves a later
fenced read and write succeed.

Validated:

- `clojure -M:test -n konserve.filestore-test` — 23 tests / 607 assertions
- `clojure -M:test` — 257 tests / 4,238 assertions
- `npx shadow-cljs release node-tests` — 0 warnings
- `node out/node-tests.js` — 66 tests / 424 assertions
- `clojure -M:format`

`clojure -M:lint` reports the existing 23 repository warnings and no errors.
