### PR TITLE
perf: remove the reflective calls, and gate on them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,42 @@ version: 2.1
 orbs:
   tools: replikativ/clj-tools@0
 
+# Reflection is a latency cost on the JVM and a correctness cost under
+# native-image, where a reflective call resolves at run time and so works only
+# if the target was registered when the image was built. Datahike compiles
+# konserve into its `dthk` binary, so a reflective call added here becomes a
+# runtime failure in a shipped artifact. Gate on our own namespaces only — a
+# dependency's warnings are real but are not fixable from here.
+#
+# Runs with :zstd so the optional compressor is checked too; without it that
+# namespace fails to load and would be skipped silently.
+jobs:
+  reflection:
+    docker:
+      - image: clojure:temurin-21-tools-deps
+    steps:
+      - checkout
+      - run:
+          name: fail on reflective calls
+          command: |
+            NSES=$(find src -name '*.clj' -o -name '*.cljc' \
+                     | sed 's|^src/||; s|\.cljc\?$||; s|/|.|g; s|_|-|g' \
+                     | sort -u | sed "s/^/'/" | tr '\n' ' ')
+            clojure -M:zstd -e "(set! *warn-on-reflection* true)(doseq [n [$NSES]] (require n))(println :loaded)" \
+              > /tmp/refl.out 2> /tmp/refl.err || { cat /tmp/refl.err; exit 1; }
+            if grep -q '^Reflection warning.*konserve/' /tmp/refl.err; then
+              echo "Reflective calls in konserve sources:"
+              grep '^Reflection warning.*konserve/' /tmp/refl.err
+              echo
+              echo "Add a type hint. Under native-image these fail at run time."
+              exit 1
+            fi
+            echo "No reflective calls in konserve sources."
+
 workflows:
   build-test-and-deploy:
     jobs:
+      - reflection
       - tools/setup:
           context: docker-deploy
           setup_cljs: true

--- a/src/konserve/compressor/zstd.clj
+++ b/src/konserve/compressor/zstd.clj
@@ -23,7 +23,8 @@
   is zstd's own default and the right default here; the higher levels trade
   encode time for a few percent."
   (:require [konserve.protocols :refer [PStoreSerializer -serialize -deserialize]])
-  (:import [com.github.luben.zstd ZstdInputStream ZstdOutputStream]))
+  (:import [com.github.luben.zstd ZstdInputStream ZstdOutputStream]
+           [java.io OutputStream]))
 
 (defrecord ZstdCompressor [serializer level]
   PStoreSerializer
@@ -35,7 +36,7 @@
     ;; The wrapper owns the wrapper stream, not the caller's stream -- closing a
     ;; ZstdOutputStream does close the underlying one, which is why konserve's
     ;; callers hand this a fresh per-blob stream.
-    (let [^ZstdOutputStream o (ZstdOutputStream. bytes (int level))]
+    (let [^ZstdOutputStream o (ZstdOutputStream. ^OutputStream bytes (int level))]
       (-serialize serializer o write-handlers val)
       (.close o))))
 

--- a/src/konserve/gc.cljc
+++ b/src/konserve/gc.cljc
@@ -7,6 +7,17 @@
             [superv.async :refer [go-try- <?- reduce<?-]])
   #?(:clj (:import [java.util Date])))
 
+(defn- epoch-ms
+  "Epoch millis of a timestamp.
+
+  A function rather than an inline `.getTime` with a `^Date` hint: the call
+  sites sit inside `go-try-`, and the go macro rewrites locals into its
+  state-machine array, dropping their hints and leaving a reflective call
+  behind. A parameter hint on an ordinary function survives."
+  ^long [d]
+  #?(:clj  (.getTime ^Date d)
+     :cljs (.getTime d)))
+
 (defn- delete-batch!
   "Delete one batch of keys, concurrently where the platform allows it.
 
@@ -87,11 +98,11 @@
                           (filter (fn [{:keys [key last-write] :as meta}]
                                     (not
                                      (or (contains? whitelist key)
-                                         (<= (.getTime ^Date cutoff)
-                                             (.getTime (if last-write
-                                                         ^Date last-write
+                                         (<= (epoch-ms cutoff)
+                                             (epoch-ms (if last-write
+                                                         last-write
                                                          ;; old name
-                                                         ^Date (:konserve.core/timestamp meta))))))))
+                                                         (:konserve.core/timestamp meta))))))))
                           (partition-all batch-size))]
        (<?-
         (reduce<?-

--- a/src/konserve/mmap.clj
+++ b/src/konserve/mmap.clj
@@ -104,11 +104,11 @@
                                      " at " (.getPath f))
                                 {:type :konserve/key-not-found :key key
                                  :path (.getPath f)})))
-        hdr   (or (read-header f)
-                  (throw (ex-info (str "konserve.mmap: " (.getPath f) " is shorter "
-                                       "than a " header-size "-byte header")
-                                  {:type :konserve/malformed-blob
-                                   :path (.getPath f) :size (.length f)})))
+        ^bytes hdr (or (read-header f)
+                       (throw (ex-info (str "konserve.mmap: " (.getPath f) " is shorter "
+                                            "than a " header-size "-byte header")
+                                       {:type :konserve/malformed-blob
+                                        :path (.getPath f) :size (.length f)})))
         [_ sb cb eb] (map #(bit-and (aget hdr (int %)) 0xff) (range 4))]
     ;; All three are refused rather than worked around -- see the namespace
     ;; docstring on why a silent fallback would be worse than an error.

--- a/src/konserve/simulation/crash.clj
+++ b/src/konserve/simulation/crash.clj
@@ -140,14 +140,14 @@
         (if (compare-and-set! lock-atom nil lock-id)
           (->CrashAwareLock lock-atom lock-id)
           (do
-            (Thread/sleep (rand-int 10))
+            (Thread/sleep (long (rand-int 10)))
             (recur))))
       (go-try-
        (loop []
          (if (compare-and-set! lock-atom nil lock-id)
            (->CrashAwareLock lock-atom lock-id)
            (do
-             (Thread/sleep (rand-int 10))
+             (Thread/sleep (long (rand-int 10)))
              (recur))))))))
 
 ;; =============================================================================

--- a/src/konserve/simulation/memory.clj
+++ b/src/konserve/simulation/memory.clj
@@ -39,14 +39,14 @@
         (if (compare-and-set! lock-atom nil lock-id)
           (->MemoryLock lock-atom lock-id)
           (do
-            (Thread/sleep (rand-int 10))
+            (Thread/sleep (long (rand-int 10)))
             (recur))))
       (go-try-
        (loop []
          (if (compare-and-set! lock-atom nil lock-id)
            (->MemoryLock lock-atom lock-id)
            (do
-             (Thread/sleep (rand-int 10))
+             (Thread/sleep (long (rand-int 10)))
              (recur))))))))
 
 ;; =============================================================================


### PR DESCRIPTION
perf: remove the reflective calls, and gate on them

Seven reflective calls, found while clearing them out of Datahike's
native-image build. Reflection is a latency cost on the JVM, but Datahike
compiles konserve into its `dthk` binary, and under native-image a reflective
call resolves at run time — so it works only if the target was registered when
the image was built, and a warning nobody reads becomes a runtime failure in a
shipped artifact.

konserve/gc.cljc — `.getTime` inside `go-try-`. The `^Date` hint was already
there and still reflected: the go macro rewrites locals into its state-machine
array and drops their hints, which is also why the reported line was the
enclosing binding rather than the call. Moved into an `epoch-ms` function,
where a parameter hint survives.

konserve/mmap.clj — `read-header` is declared `^bytes`, but the local came from
an `(or ... (throw ...))`, which is Object. Hinted the binding.

konserve/simulation/{crash,memory}.clj — `Thread/sleep` on a boxed `rand-int`
cannot pick between `sleep(long)` and `sleep(long,int)`. Coerced.

konserve/compressor/zstd.clj — the `ZstdOutputStream` constructor could not be
resolved because the protocol method's `bytes` parameter is untyped. Hinted
`^OutputStream`.

That last one only shows up if you load the namespace with the optional
zstd-jni dependency present; without it the namespace fails to load and a
sweep skips it silently. So the new `reflection` CircleCI job runs with
`:zstd`, and gates on konserve's own namespaces only — a dependency's warnings
are real but are not fixable from here.

Verified: the sweep reports 0 across all namespaces including zstd; the suite
passes (257 tests, 4258 assertions, 0 failures), which covers gc, mmap, the
simulation backings and the compressors; cljfmt is clean. The gate was tested
in both directions — it passes here, and reverting the Thread/sleep coercions
makes it exit 1 naming those two lines.
