### PR TITLE
fix: tolerate a directory that cannot be fsynced, and stop returning exceptions as values

### DIFF
--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -80,12 +80,24 @@
    Note: Jimfs doesn't support directory sync via FileChannel, so we skip it."
   ([base] (sync-base nil base))
   ([filesystem base]
-   ;; Only sync directories on the default filesystem (Jimfs doesn't support this)
+   ;; Only sync directories on the default filesystem (Jimfs doesn't support this).
+   ;;
+   ;; Tolerant of a directory that cannot be opened. fsync-ing a DIRECTORY is a
+   ;; POSIX durability step for a just-renamed entry; Windows has no such
+   ;; operation, and `FileChannel/open` on a directory there throws
+   ;; AccessDeniedException whose whole message is the path. NTFS journals its
+   ;; metadata, so skipping the sync loses nothing that was available. Before
+   ;; this, `delete-store` on Windows failed with a bare
+   ;; "target\\native-image-tests" — the PARENT path, since the parent is what
+   ;; gets synced after an entry is removed — which was diagnosable only by
+   ;; reading the exception class datahike's CLI did not print.
    (when-not filesystem
-     (let [p (get-path filesystem base)
-           fc (FileChannel/open p (into-array OpenOption []))]
-       (.force fc true)
-       (.close fc)))))
+     (try
+       (let [p (get-path filesystem base)
+             fc (FileChannel/open p (into-array OpenOption []))]
+         (.force fc true)
+         (.close fc))
+       (catch java.io.IOException _ nil)))))
 
 (defn- check-and-create-backing-store
   "Helper Function to Check if Base is not writable"
@@ -124,18 +136,23 @@
            (.close ds))
          (Files/delete base-path))
        (when parent-path
+         ;; Return nil, not the exception: a Throwable returned as a VALUE is
+         ;; put on the go-try- channel and re-thrown by the caller's <?-, so
+         ;; this catch never swallowed anything. sync-base is tolerant now
+         ;; anyway; the guard stays against anything else it could raise.
          (try
            (sync-base filesystem (str parent-path))
-           (catch Exception e e))))
+           (catch Exception _ nil))))
      ;; For default filesystem, use io/file
      (let [f           (io/file base)
            parent-base (.getParent f)]
        (doseq [c (.list (io/file base))]
          (.delete (io/file (str base "/" c))))
        (.delete f)
+       ;; nil, not e — see the custom-filesystem branch above.
        (try
          (sync-base parent-base)
-         (catch Exception e e))))))
+         (catch Exception _ nil))))))
 
 (defn list-files
   "Lists all files on the first level of a directory."

--- a/src/konserve/mmap.clj
+++ b/src/konserve/mmap.clj
@@ -429,11 +429,15 @@
   the atomic rename is only crash-DURABLE, not merely crash-atomic, once the
   directory entry is synced."
   [^String fpath]
+  ;; Same tolerance as filestore/sync-base, for the same reason: Windows cannot
+  ;; open a directory as a channel, and has no directory fsync to skip.
   (let [dir (.getParent (File. fpath))]
     (when dir
-      (with-open [fc (FileChannel/open (path-of dir)
-                                       (into-array OpenOption []))]
-        (.force fc true)))))
+      (try
+        (with-open [fc (FileChannel/open (path-of dir)
+                                         (into-array OpenOption []))]
+          (.force fc true))
+        (catch java.io.IOException _ nil)))))
 
 (defn- splice-write!
   "Transform the value region of `fpath` (bytes from `voff` to EOF) with `xform`


### PR DESCRIPTION
fix: tolerate a directory that cannot be fsynced, and stop returning exceptions as values

Datahike's Windows CI has failed five rounds running on its very first
`dthk delete-database`, printing one line:

    ❌ Error executing command: target\native-image-tests

That is the store's PARENT directory, with a backslash the caller never wrote.
Traced, and verified at every link that runs on Linux:

1. `delete-store` fsyncs the parent directory after removing an entry, via
   `sync-base` -> `FileChannel/open` on the directory. Windows cannot open a
   directory as a channel; it throws AccessDeniedException whose whole message
   is the path. `File.getParent()` on Windows is what supplies the backslash.
2. The call sits in `(try ... (catch Exception e e))` — which RETURNS the
   exception as a value. Under superv.async that is not swallowing: `go-try-`
   puts the value on its channel and the caller's `<?-` throws it. Reproduced
   directly: a Throwable returned from a catch inside go-try- comes back out of
   `<?-` as a throw. So `-delete-store :file` -> `(go-try- res)` re-raised it
   into datahike, whose CLI printed only `getMessage` — the bare path.

Linux and macOS fsync directories fine, so they never hit step 1.

## The fix

`sync-base` catches IOException and skips. fsync-ing a DIRECTORY is a POSIX
durability step for a just-renamed entry; Windows has no such operation and
NTFS journals its metadata, so nothing that was available is lost. `sync-dir!`
in mmap.clj is the identical unguarded open on the identical path and gets the
identical guard — it would have failed the same way on the first in-place edit.

Both `(catch Exception e e)` in `delete-store` now return nil. Returning the
exception was already wrong on its own terms: it re-raises through any channel
consumer that follows the Throwable-as-value convention, which is every
superv.async caller.

## Verified

- the propagation claim, directly: `(<?- (go-try- (try (throw x) (catch Exception e e))))`
  throws x. With the catch returning nil it does not.
- full suite with :zstd: 257 tests, 4258 assertions, 0 failures — filestore,
  mmap and the store-level delete/create paths are all covered there.
- cljfmt clean.

Not verified here: the Windows leg itself, which is the only place step 1
occurs. Datahike's CLI now prints the exception class (datahike#1022), so if
anything remains it will name itself.
