### PR TITLE
fix: close the target before moving .new over it, and retry the move on Windows

### DIFF
--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -91,16 +91,15 @@
    ;; "target\\native-image-tests" — the PARENT path, since the parent is what
    ;; gets synced after an entry is removed — which was diagnosable only by
    ;; reading the exception class datahike's CLI did not print.
+   ;; Only the OPEN is tolerated, and only its Windows shape. A `force` that
+   ;; fails on a directory that did open (EIO on POSIX) is the durability loss
+   ;; this sync exists to surface, and propagates; `with-open` closes the
+   ;; channel either way.
    (when-not filesystem
-     (try
-       (let [p (get-path filesystem base)
-             fc (FileChannel/open p (into-array OpenOption []))]
-         (.force fc true)
-         (.close fc))
-       ;; Only the Windows shape — opening the DIRECTORY is refused. A real
-       ;; fsync failure on a directory that did open (EIO on POSIX) is the
-       ;; durability loss this sync exists to surface, and must propagate.
-       (catch java.nio.file.AccessDeniedException _ nil)))))
+     (when-let [fc (try (FileChannel/open (get-path filesystem base) (into-array OpenOption []))
+                        (catch java.nio.file.AccessDeniedException _ nil))]
+       (with-open [^FileChannel fc fc]
+         (.force fc true))))))
 
 (defn- check-and-create-backing-store
   "Helper Function to Check if Base is not writable"

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -97,7 +97,10 @@
              fc (FileChannel/open p (into-array OpenOption []))]
          (.force fc true)
          (.close fc))
-       (catch java.io.IOException _ nil)))))
+       ;; Only the Windows shape — opening the DIRECTORY is refused. A real
+       ;; fsync failure on a directory that did open (EIO on POSIX) is the
+       ;; durability loss this sync exists to surface, and must propagate.
+       (catch java.nio.file.AccessDeniedException _ nil)))))
 
 (defn- check-and-create-backing-store
   "Helper Function to Check if Base is not writable"
@@ -190,6 +193,37 @@
            false)))))
 
 (declare migrate-old-files migrate-file-v2 migrate-file-v1)
+
+(defn- write-fully!
+  "Write every remaining byte of `buffer` at `pos`.
+
+   A positional write may return short — the count it returns is the only
+   thing that says so — and a write that stops early leaves the tail of the
+   region unwritten. Every caller here used to ignore that count."
+  [^FileChannel ch ^ByteBuffer buffer ^long pos]
+  (loop [p pos]
+    (when (.hasRemaining buffer)
+      (recur (+ p (long (.write ch buffer p)))))))
+
+(defn- write-fully-async
+  "`write-fully!` for an AsynchronousFileChannel: a channel that closes once
+   every remaining byte is written, or carries the error. Re-issues from the
+   completed count, which is what the three hand-written completion handlers
+   this replaces never looked at."
+  [^AsynchronousFileChannel ch ^ByteBuffer buffer ^long pos msg]
+  (let [out (chan)]
+    (letfn [(step [^long p]
+              (if (.hasRemaining buffer)
+                (.write ch buffer p nil
+                        (proxy [CompletionHandler] []
+                          (completed [n _] (step (+ p (long n))))
+                          (failed [t _]
+                            (put! out (ex-info "Could not write key file."
+                                               (assoc msg :exception t)))
+                            (close! out))))
+                (close! out)))]
+      (step pos))
+    out))
 
 (def ^:private max-move-attempts
   "Upper bound on `-atomic-move` retries against a Windows AccessDenied — about
@@ -307,70 +341,36 @@
   (-close [this _env] (go-try- (.close this)))
   (-get-lock [this _env] (go-try- (.get (.lock this))))
   (-write-header [this header env]
-    (let [{:keys [msg]} env
-          ch (chan)
-          buffer (ByteBuffer/wrap header)]
-      (.write this buffer 0 header-size
-              (proxy [CompletionHandler] []
-                (completed [_res _att]
-                  (close! ch))
-                (failed [t _att]
-                  (put! ch (ex-info "Could not write key file."
-                                    (assoc msg :exception t)))
-                  (close! ch))))
-      ch))
+    (write-fully-async this (ByteBuffer/wrap header) 0 (:msg env)))
   (-write-meta [this meta-arr env]
-    (let [{:keys [msg]} env
-          ch (chan)
-          meta-size (alength ^bytes meta-arr)
-          buffer (ByteBuffer/wrap meta-arr)]
-      (.write this buffer header-size (+ header-size meta-size)
-              (proxy [CompletionHandler] []
-                (completed [_res _att]
-                  (close! ch))
-                (failed [t _att]
-                  (put! ch (ex-info "Could not write key file."
-                                    (assoc msg :exception t)))
-                  (close! ch))))
-      ch))
+    (write-fully-async this (ByteBuffer/wrap meta-arr) header-size (:msg env)))
   (-write-value [this value-arr meta-size env]
-    (let [{:keys [msg]} env
-          ch (chan)
-          total-size (.size this)
-          buffer (ByteBuffer/wrap value-arr)]
-      (.write this buffer (+ header-size meta-size) total-size
-              (proxy [CompletionHandler] []
-                (completed [_res _att]
-                  (close! ch))
-                (failed [t _att]
-                  (put! ch (ex-info "Could not write key file."
-                                    (assoc msg :exception t)))
-                  (close! ch))))
-      ch))
+    (let [start (+ header-size meta-size)
+          end   (+ start (alength ^bytes value-arr))]
+      (go-try-
+       (<?- (write-fully-async this (ByteBuffer/wrap value-arr) start (:msg env)))
+       ;; The value is the last segment, so the file ends here. Without this a
+       ;; shorter value written over a longer one keeps the old tail — reachable
+       ;; in `:in-place?` mode, where the file is reused.
+       (.truncate this end)
+       nil)))
   (-write-binary [this meta-size blob env]
     (let [{:keys [msg buffer-size]} env
           [bis read] (blob->channel blob buffer-size)
-          buffer     (ByteBuffer/allocate buffer-size)
-          start      (+ header-size meta-size)
-          stop       (+ buffer-size start)]
+          buffer     (ByteBuffer/allocate buffer-size)]
       (go-try-
-       (loop [start-byte start
-              stop-byte  stop]
-         (let [size   (read bis buffer)
-               _      (.flip buffer)
-               ch (chan)]
-           (when-not (= size -1)
-             (.write this buffer start-byte stop-byte
-                     (proxy [CompletionHandler] []
-                       (completed [_res _att]
-                         (.clear buffer)
-                         (close! ch))
-                       (failed [t _att]
-                         (put! ch (ex-info "Could not write key file."
-                                           (assoc msg :exception t)))
-                         (close! ch))))
-             (<?- ch)
-             (recur (+ buffer-size start-byte) (+ buffer-size stop-byte)))))
+       ;; Advance by what the read actually PUT in the buffer, not by its
+       ;; capacity: a channel read may return short at any point, and a fixed
+       ;; stride then leaves a hole and shifts everything after it.
+       (loop [pos (+ header-size meta-size)]
+         (let [size (read bis buffer)]
+           (.flip buffer)
+           (if (= size -1)
+             (.truncate this pos)
+             (let [n (.remaining buffer)]
+               (<?- (write-fully-async this buffer pos msg))
+               (.clear buffer)
+               (recur (+ pos n))))))
        (catch Exception e
          (log/trace :konserve/write-binary-error {:error e})
          e)
@@ -454,29 +454,30 @@
   (-close [this _env] (.close this))
   (-get-lock [this _env] (.lock this))
   (-write-header [this header _env]
-    (let [buffer (ByteBuffer/wrap header)]
-      (.write this buffer 0)))
+    (write-fully! this (ByteBuffer/wrap header) 0))
   (-write-meta [this meta-arr _env]
-    (let [buffer (ByteBuffer/wrap meta-arr)]
-      (.write this buffer header-size)))
+    (write-fully! this (ByteBuffer/wrap meta-arr) header-size))
   (-write-value [this value-arr meta-size _env]
-    (let [buffer (ByteBuffer/wrap value-arr)]
-      (.write this buffer (+ header-size meta-size))))
+    (let [start (+ header-size meta-size)]
+      (write-fully! this (ByteBuffer/wrap value-arr) start)
+      ;; See the async twin: the value is the last segment.
+      (.truncate this (+ start (alength ^bytes value-arr)))
+      nil))
   (-write-binary [this meta-size blob env]
     (let [{:keys [buffer-size]} env
           [bis read] (blob->channel blob buffer-size)
-          buffer     (ByteBuffer/allocate buffer-size)
-          start      (+ header-size meta-size)
-          stop       (+ buffer-size start)]
+          buffer     (ByteBuffer/allocate buffer-size)]
       (try
-        (loop [start-byte start
-               stop-byte  stop]
-          (let [size   (read bis buffer)
-                _      (.flip buffer)]
-            (when-not (= size -1)
-              (.write this buffer start-byte)
-              (.clear buffer)
-              (recur (+ buffer-size start-byte) (+ buffer-size stop-byte)))))
+        ;; See the async twin: advance by what was buffered, not the capacity.
+        (loop [pos (+ header-size meta-size)]
+          (let [size (read bis buffer)]
+            (.flip buffer)
+            (if (= size -1)
+              (.truncate this pos)
+              (let [n (.remaining buffer)]
+                (write-fully! this buffer pos)
+                (.clear buffer)
+                (recur (+ pos n))))))
         (finally
           (.close ^Closeable bis)))))
   (-read-header [this _env]

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -351,7 +351,7 @@
        ;; The value is the last segment, so the file ends here. Without this a
        ;; shorter value written over a longer one keeps the old tail — reachable
        ;; in `:in-place?` mode, where the file is reused.
-       (.truncate this end)
+       (.truncate this (long end))
        nil)))
   (-write-binary [this meta-size blob env]
     (let [{:keys [msg buffer-size]} env
@@ -365,7 +365,7 @@
          (let [size (read bis buffer)]
            (.flip buffer)
            (if (= size -1)
-             (.truncate this pos)
+             (.truncate this (long pos))
              (let [n (.remaining buffer)]
                (<?- (write-fully-async this buffer pos msg))
                (.clear buffer)
@@ -460,7 +460,7 @@
     (let [start (+ header-size meta-size)]
       (write-fully! this (ByteBuffer/wrap value-arr) start)
       ;; See the async twin: the value is the last segment.
-      (.truncate this (+ start (alength ^bytes value-arr)))
+      (.truncate this (long (+ start (alength ^bytes value-arr))))
       nil))
   (-write-binary [this meta-size blob env]
     (let [{:keys [buffer-size]} env
@@ -472,7 +472,7 @@
           (let [size (read bis buffer)]
             (.flip buffer)
             (if (= size -1)
-              (.truncate this pos)
+              (.truncate this (long pos))
               (let [n (.remaining buffer)]
                 (write-fully! this buffer pos)
                 (.clear buffer)

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -1,6 +1,6 @@
 (ns konserve.filestore
   (:require
-   [clojure.core.async :refer [go <!! chan close! put!]]
+   [clojure.core.async :refer [go <! <!! chan close! put! timeout]]
    [clojure.java.io :as io]
    [clojure.string :refer [includes? ends-with?]]
    [konserve.impl.defaults :as kd :refer [update-blob connect-default-store key->store-key store-key->uuid-key normalize-store-config]]
@@ -191,6 +191,11 @@
 
 (declare migrate-old-files migrate-file-v2 migrate-file-v1)
 
+(def ^:private max-move-attempts
+  "Upper bound on `-atomic-move` retries against a Windows AccessDenied — about
+   a second of jittered waiting, the same budget `get-lock` gives contention."
+  60)
+
 (defrecord BackingFilestore [base detected-old-blobs ephemeral? filesystem]
   konserve.protocols/PConditionalWrite
   ;; :machine. `-get-lock` takes a java.nio FileLock, which the OS holds on behalf
@@ -257,10 +262,28 @@
   (-atomic-move [_this from to env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try-
-                 (Files/move (get-path filesystem base from)
-                             (get-path filesystem base to)
-                             (into-array [StandardCopyOption/ATOMIC_MOVE
-                                          StandardCopyOption/REPLACE_EXISTING])))))
+                 (let [src  (get-path filesystem base from)
+                       dst  (get-path filesystem base to)
+                       opts (into-array [StandardCopyOption/ATOMIC_MOVE
+                                         StandardCopyOption/REPLACE_EXISTING])]
+                   ;; Retried on AccessDeniedException, for Windows. POSIX renames
+                   ;; over a file that another process still has open; Windows
+                   ;; refuses until every handle on the target is gone. Our own
+                   ;; handle is closed before this is called (see the write path
+                   ;; in impl.defaults), so what remains is a READER in another
+                   ;; process, which is short-lived — hence a bounded wait rather
+                   ;; than an immediate failure. Bounded, because a handle held
+                   ;; indefinitely should surface as the error it is.
+                   (loop [attempt 0]
+                     (let [denied (try (Files/move src dst opts) nil
+                                       (catch java.nio.file.AccessDeniedException e e))]
+                       (when denied
+                         (if (< attempt max-move-attempts)
+                           (do (if (:sync? env)
+                                 (Thread/sleep (long (+ 5 (rand-int 20))))
+                                 (<! (timeout (+ 5 (rand-int 20)))))
+                               (recur (inc attempt)))
+                           (throw denied)))))))))
   (-create-store [_this env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try-

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -338,6 +338,31 @@
                        :expected expected
                        :actual   actual})))))
 
+(defn- release-held-lock!
+  "Release the lock in `held` (an atom) once; later calls are no-ops.
+
+   A function, not inline code: `io-operation`'s go block sits close to the
+   JVM's 64KB method limit, and the early release below is a second call site
+   for what the `finally` already does. Each call is one park on this channel
+   rather than the whole body expanded into the state machine."
+  [held key env]
+  (async+sync (:sync? env) *default-sync-translation*
+              (go-try-
+               (when-let [l @held]
+                 (reset! held nil)
+                 (log/trace :konserve/releasing-blob-lock {:key key})
+                 (<?- (-release l env))))))
+
+(defn- close-held-blob!
+  "Close the blob in `held` (an atom) once; later calls are no-ops. See
+   `release-held-lock!` for why this is a function."
+  [held env]
+  (async+sync (:sync? env) *default-sync-translation*
+              (go-try-
+               (when-let [b @held]
+                 (reset! held nil)
+                 (<?- (-close b env))))))
+
 (defn get-lock [this store-key env]
   (async+sync
    (:sync? env)
@@ -609,7 +634,11 @@
                                 ;; the race in the cleanup together.
                                 skip-blob? (and expected-revision (not exists-under-lock?))
                                 blob (when-not skip-blob?
-                                       (<?- (-create-blob backing store-key env)))]
+                                       (<?- (-create-blob backing store-key env)))
+                                ;; In an atom, not a plain binding: the target is
+                                ;; handed back EARLY in rename mode (below), and
+                                ;; the `finally` must then find nothing to close.
+                                held-blob (atom blob)]
                             ;; The value blob gets the same treatment as the
                             ;; sidecar, one level down, and for the same reason: it
                             ;; was opened in a `let` binding and closed in a
@@ -622,7 +651,8 @@
                             (try
                               (let [lock (when (and blob (:lock-blob? config))
                                            (log/trace :konserve/acquiring-blob-lock {:key key :blob (str blob)})
-                                           (<?- (get-lock blob (first key-vec) env)))]
+                                           (<?- (get-lock blob (first key-vec) env)))
+                                    held-lock (atom lock)]
                                 (try
                                   (let [old (cond
                                           ;; A FENCED write decides from the existence
@@ -646,6 +676,21 @@
                                               :else [nil nil])]
                                     (when expected-revision
                                       (check-revision! key expected-revision (first old)))
+                                    ;; RENAME MODE: hand the target back BEFORE `update-blob`
+                                    ;; moves `.new` over it. Everything the target was
+                                    ;; opened for is done — `old` is read, the revision
+                                    ;; checked. Holding it across the move is what made
+                                    ;; the write fail on Windows, which refuses to replace
+                                    ;; a file that has any open handle (POSIX renames
+                                    ;; underneath one). And the lock released here never
+                                    ;; guarded the move: it lives on the inode the rename
+                                    ;; detaches — see `cas-lock-suffix` — which is why the
+                                    ;; sidecar exists for the writes that need serializing,
+                                    ;; and that sidecar's lock stays held. In-place mode
+                                    ;; edits this very file and keeps both.
+                                    (when (and write-op? (not (:in-place? config)))
+                                      (<?- (release-held-lock! held-lock (first key-vec) env))
+                                      (<?- (close-held-blob! held-blob env)))
                                     (if write-op?
                                   ;; The meta is computed ONCE and the same value is both
                                   ;; written and reported. Calling the meta-fn a second time
@@ -664,11 +709,9 @@
                                           res))
                                       old))
                                   (finally
-                                    (when lock
-                                      (log/trace :konserve/releasing-blob-lock {:key (first key-vec) :blob (str blob)})
-                                      (<?- (-release lock env))))))
+                                    (<?- (release-held-lock! held-lock (first key-vec) env)))))
                               (finally
-                                (when blob (<?- (-close blob env))))))
+                                (<?- (close-held-blob! held-blob env)))))
                           (finally
                             (when cas-lock (<?- (-release cas-lock env))))))
                       (finally

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -49,8 +49,14 @@
 (defn store-key->uuid-key [^String store-key]
   (cond
     (.endsWith store-key ".ksv") (subs store-key 0 (- (.length store-key) 4))
-    (.endsWith store-key ".ksv.new") (subs store-key 0 (- (.length store-key) 8))
-    (.endsWith store-key ".ksv.backup") (subs store-key 0 (- (.length store-key) 11))
+    ;; Write artifacts carry the key as a prefix: `<uuid>.ksv.<nonce>.new` for a
+    ;; staging file (the nonce is per writer — see `update-blob`), and
+    ;; `<uuid>.ksv.backup`. Everything up to the first `.ksv` is the key.
+    (or (.endsWith store-key ".new") (.endsWith store-key ".backup"))
+    (let [i (.indexOf store-key ".ksv")]
+      (if (pos? i)
+        (subs store-key 0 i)
+        (throw (ex-info (str "Invalid konserve store key: " store-key) {:key store-key}))))
     :else (throw (ex-info (str "Invalid konserve store key: " store-key)
                           {:key store-key}))))
 
@@ -84,9 +90,22 @@
                   (if-not (empty? rkey)
                     (update-in old-value rkey up-fn)
                     (up-fn old-value)))
+          ;; The staging file is PER WRITER. A fixed `<key>.new` is a shared
+          ;; path with no exclusion around it: two writers to one key — two
+          ;; processes, or two stores connected to one path in one JVM —
+          ;; interleave header, meta and value writes into the same file, and
+          ;; whichever moves first can be overwritten in place by the other's
+          ;; remaining positional writes, AFTER it has reported success. That
+          ;; is a torn value, not the last-writer-wins lost update the design
+          ;; accepts for unfenced writes. The target's FileLock used to narrow
+          ;; that window incidentally; it is released before the move now (it
+          ;; never guarded the move — see `cas-lock-suffix`), so the staging
+          ;; file has to be exclusive on its own terms. It also makes the
+          ;; filestore's move retry unambiguous: it retries OUR file by name.
           new-store-key (if (:in-place? config)
                           store-key
-                          (str store-key ".new"))
+                          (str store-key "." (random-uuid) ".new"))
+          moved?        (atom false)
           backup-store-key (str store-key ".backup")
           _ (when (and (:in-place? config) (not (:no-backup? config))) ;; let's back things up before writing then
               (log/trace :konserve/backup-blob {:backup-store-key backup-store-key :key key})
@@ -95,7 +114,8 @@
           meta-size            (count meta-arr)
           header               (create-header version
                                               serializer compressor encryptor meta-size)
-          new-blob             (<?- (-create-blob backing new-store-key env))]
+          new-blob             (<?- (-create-blob backing new-store-key env))
+          new-blob-closed?     (atom false)]
       (try
         (<?- (-write-header new-blob header env))
         (<?- (-write-meta new-blob meta-arr env))
@@ -120,10 +140,12 @@
           (log/trace :konserve/syncing-blob {:key key})
           (<?- (-sync new-blob env)))
         (<?- (-close new-blob env))
+        (reset! new-blob-closed? true)
 
         (when-not (:in-place? config)
           (log/trace :konserve/moving-blob {:key key})
-          (<?- (-atomic-move backing new-store-key store-key env)))
+          (<?- (-atomic-move backing new-store-key store-key env))
+          (reset! moved? true))
 
         (when (:sync-blob? config)
           (log/trace :konserve/syncing-store {:key key})
@@ -136,7 +158,18 @@
 
         (if (= operation :write-edn) [old-value value] true)
         (finally
-          (<?- (-close new-blob env))))))))
+          ;; Once. `-close` is idempotent on a FileChannel by spec, but that is
+          ;; the filestore's property, not the protocol's.
+          (when-not @new-blob-closed?
+            (<?- (-close new-blob env)))
+          ;; A staging file that never got moved is ours to remove: with a
+          ;; per-writer name nothing later overwrites it, so a failed write
+          ;; would otherwise leave a complete-looking `.new` behind for good.
+          ;; Best effort — this runs while an exception may be propagating,
+          ;; and a cleanup failure must not replace it.
+          (when (and (not (:in-place? config)) (not @moved?))
+            (try (<?- (-delete-blob backing new-store-key env))
+                 (catch #?(:clj Exception :cljs js/Error) _ nil)))))))))
 
 (defn read-header [ac serializers env]
   (let [{:keys [sync? store-key]} env]
@@ -235,6 +268,21 @@
                             [meta value]))
         :read-binary (<?- (-read-binary blob meta-size locked-cb env)))))))
 
+(declare get-lock cas-lock-suffix)
+
+(defn- needs-sidecar-lock?
+  "Does konserve itself have to serialize conditional writes on this backing?
+
+   Only a backing that does NOT fence its own writes, and so relies on the
+   compare-and-write in `io-operation` being made atomic by a lock. Asked as a
+   mechanism question, not inferred from the domain — the domain says how far
+   a guarantee reaches, not who evaluates it; see `PSelfConditionalWrite`."
+  [backing config]
+  (and (:lock-blob? config)
+       (satisfies? protocols/PConditionalWrite backing)
+       (some? (protocols/-conditional-write-domain backing))
+       (not (satisfies? protocols/PSelfConditionalWrite backing))))
+
 (defn delete-blob
   "Remove/Delete key-value pair of backing store by given key. Returns true if the
    key existed and was deleted, false if it was absent.
@@ -250,19 +298,36 @@
   (async+sync
    (:sync? env) *default-sync-translation*
    (go-try-
-    (let [{:keys [key-vec base ignore-existence?]} env
+    (let [{:keys [key-vec base ignore-existence? config]} env
           key          (first key-vec)
           store-key    (key->store-key key)
           on-error     (fn [e] (ex-info "Could not delete key."
-                                        {:key key :base base :exception e}))]
-      (if (and ignore-existence? (satisfies? PReadMissSafe backing))
-        ;; opt-in fast path: no existed? boolean needed, idempotent delete.
-        (try (<?- (-delete-blob backing store-key env)) true
-             (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))
-        (if (<?- (-blob-exists? backing store-key env))
-          (try (<?- (-delete-blob backing store-key env)) true
-               (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))
-          false))))))
+                                        {:key key :base base :exception e}))
+          ;; A delete is a write. On a FENCEABLE key — one with a sidecar — it
+          ;; has to take the sidecar's lock like every other writer, or a fenced
+          ;; write can pass `check-revision!`, this delete can land, and the
+          ;; fenced value can then land on top: both report success and a
+          ;; deleted key reappears, with no serialization consistent with the
+          ;; revision the writer was promised. Same probe the write path pays.
+          cas-store-key (str store-key cas-lock-suffix)
+          cas-blob      (when (and (needs-sidecar-lock? backing config)
+                                   (<?- (-blob-exists? backing cas-store-key env)))
+                          (<?- (-create-blob backing cas-store-key env)))]
+      (try
+        (let [cas-lock (when cas-blob (<?- (get-lock cas-blob key env)))]
+          (try
+            (if (and ignore-existence? (satisfies? PReadMissSafe backing))
+              ;; opt-in fast path: no existed? boolean needed, idempotent delete.
+              (try (<?- (-delete-blob backing store-key env)) true
+                   (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))
+              (if (<?- (-blob-exists? backing store-key env))
+                (try (<?- (-delete-blob backing store-key env)) true
+                     (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))
+                false))
+            (finally
+              (when cas-lock (<?- (-release cas-lock env))))))
+        (finally
+          (when cas-blob (<?- (-close cas-blob env)))))))))
 
 (def ^:const max-lock-attempts 100)
 
@@ -453,11 +518,7 @@
           ;; billed HEAD on every write to S3, a `.getKey` transaction on every
           ;; write to IndexedDB — plus a sidecar blob written into a storage layer
           ;; that has no use for one.
-          lock-based-fencing?
-          (and (:lock-blob? config)
-               (satisfies? protocols/PConditionalWrite backing)
-               (some? (protocols/-conditional-write-domain backing))
-               (not (satisfies? protocols/PSelfConditionalWrite backing)))]
+          lock-based-fencing? (needs-sidecar-lock? backing config)]
       (cond
         ;; Read-first (PReadMissSafe): no existence probe — read the blob and
         ;; treat an absent key (store-key-not-found-ex) as the caller's

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -49,16 +49,13 @@
 (defn store-key->uuid-key [^String store-key]
   (cond
     (.endsWith store-key ".ksv") (subs store-key 0 (- (.length store-key) 4))
-    ;; Write artifacts carry the key as a prefix: `<uuid>.ksv.<nonce>.new` for a
-    ;; staging file (the nonce is per writer — see `update-blob`), and
-    ;; `<uuid>.ksv.backup`. Everything up to the first `.ksv` is the key.
-    (or (.endsWith store-key ".new") (.endsWith store-key ".backup"))
-    (let [i (.indexOf store-key ".ksv")]
-      (if (pos? i)
-        (subs store-key 0 i)
-        (throw (ex-info (str "Invalid konserve store key: " store-key) {:key store-key}))))
-    :else (throw (ex-info (str "Invalid konserve store key: " store-key)
-                          {:key store-key}))))
+    ;; The two write artifacts, exactly: `<key>.ksv.<nonce>.new` — a staging
+    ;; file, nonce per writer, see `update-blob` — and `<key>.ksv.backup`.
+    :else
+    (if-let [[_ k] (re-matches #"(.+)\.ksv(?:\.[^.]+\.new|\.backup)" store-key)]
+      k
+      (throw (ex-info (str "Invalid konserve store key: " store-key)
+                      {:key store-key})))))
 
 #?(:cljs (extend-type js/Uint8Array ICounted (-count [this] (alength this))))
 
@@ -139,8 +136,10 @@
         (when (:sync-blob? config)
           (log/trace :konserve/syncing-blob {:key key})
           (<?- (-sync new-blob env)))
-        (<?- (-close new-blob env))
+        ;; Marked before the call: a close that throws after releasing the
+        ;; resource must not be closed again from the `finally`.
         (reset! new-blob-closed? true)
+        (<?- (-close new-blob env))
 
         (when-not (:in-place? config)
           (log/trace :konserve/moving-blob {:key key})
@@ -312,18 +311,18 @@
           cas-store-key (str store-key cas-lock-suffix)
           cas-blob      (when (and (needs-sidecar-lock? backing config)
                                    (<?- (-blob-exists? backing cas-store-key env)))
-                          (<?- (-create-blob backing cas-store-key env)))]
+                          (<?- (-create-blob backing cas-store-key env)))
+          delete!       (fn [] (go-try-
+                                (try (<?- (-delete-blob backing store-key env)) true
+                                     (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))))]
       (try
         (let [cas-lock (when cas-blob (<?- (get-lock cas-blob key env)))]
           (try
-            (if (and ignore-existence? (satisfies? PReadMissSafe backing))
+            (cond
               ;; opt-in fast path: no existed? boolean needed, idempotent delete.
-              (try (<?- (-delete-blob backing store-key env)) true
-                   (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))
-              (if (<?- (-blob-exists? backing store-key env))
-                (try (<?- (-delete-blob backing store-key env)) true
-                     (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))
-                false))
+              (and ignore-existence? (satisfies? PReadMissSafe backing)) (<?- (delete!))
+              (<?- (-blob-exists? backing store-key env))                 (<?- (delete!))
+              :else                                                      false)
             (finally
               (when cas-lock (<?- (-release cas-lock env))))))
         (finally
@@ -480,6 +479,14 @@
           read-op?      (or (= :read-edn operation) (= :read-binary operation) (= :read-meta operation)
                             (= :read-edn-meta operation))
           write-op?     (or (= :write-edn operation) (= :write-binary operation))
+          ;; A read that hands the caller a revision token makes the key
+          ;; FENCEABLE — it gets a sidecar from here on, so the fenced write
+          ;; that follows is ordered against every other writer and deleter.
+          ;; Both token sources: `-get-in` with `:with-revision?` selects
+          ;; `:read-edn-meta`; `k/revision` goes through `:read-meta` and
+          ;; says so with `:revision-read?`. Computed ONCE and used by both
+          ;; sidecar sites below — they had drifted, and the drift was a hole.
+          revision-bearing? (or (= :read-edn-meta operation) (:revision-read? env))
           ;; A PReadMissSafe backing reports an absent key cleanly from the read
           ;; itself (an absent key throws store-key-not-found-ex), so the
           ;; -blob-exists? probe is a wasted round-trip (an S3 HEAD) whenever we
@@ -540,11 +547,7 @@
         ;; place before it ever issues a conditional write, so unconditional
         ;; writers are excluded from that point on.
         (let [cas-store-key (str store-key cas-lock-suffix)
-              ;; `:read-edn-meta` IS the revision-bearing read — `-get-in` selects
-              ;; that operation for `:with-revision? true` and does not forward the
-              ;; flag itself, so testing the operation is both correct and the only
-              ;; thing available here.
-              cas-blob (when (and (= :read-edn-meta operation) lock-based-fencing?)
+              cas-blob (when (and lock-based-fencing? revision-bearing?)
                          (<?- (-create-blob backing cas-store-key env)))]
           ;; Keep each acquisition INSIDE the try that releases the preceding
           ;; resource. A failure opening or locking the value blob must not strand
@@ -644,7 +647,7 @@
                         ;; first write.
                         cas-blob (when (and lock-based-fencing?
                                             (or (some? expected-revision)
-                                                (= :read-edn-meta operation)
+                                                revision-bearing?
                                                 (<?- (-blob-exists? backing cas-store-key env))))
                                    (<?- (-create-blob backing cas-store-key env)))]
                     ;; THREE NESTED try/finally, one per thing acquired, because a
@@ -951,10 +954,11 @@
               not-found
               (clojure.core/get-in a (rest key-vec)))))))))
   (-get-meta [this key opts]
-    (let [{:keys [sync?]} opts]
+    (let [{:keys [sync? revision-read?]} opts]
       (io-operation this serializers read-handlers write-handlers
                     {:key-vec [key]
                      :operation :read-meta
+                     :revision-read? revision-read?
                      :compressor compressor
                      :encryptor encryptor
                      :default-serializer default-serializer
@@ -1118,7 +1122,7 @@
         (when (:lock-blob? config) declared))))
   (-revision [this key opts]
     (async+sync (:sync? opts) *default-sync-translation*
-                (go-try- (let [m (<?- (protocols/-get-meta this key opts))]
+                (go-try- (let [m (<?- (protocols/-get-meta this key (assoc opts :revision-read? true)))]
                            (cond
                              (nil? m) absent
                              ;; A KEY WITH NO REVISION MUST NOT ANSWER nil. Every

--- a/src/konserve/nio_helpers.clj
+++ b/src/konserve/nio_helpers.clj
@@ -63,18 +63,25 @@
           ;; chars encode to at most 6 bytes, which the byte buffer may not
           ;; hold at the smallest sizes — the encoder then reports OVERFLOW,
           ;; keeps the rest, and the next call makes progress.
-          chars   (CharBuffer/allocate (max 2 (quot buffer-size 4)))]
+          chars   (CharBuffer/allocate (max 2 (quot buffer-size 4)))
+          ;; Set once EOF has been encoded and flushed. The caller stops on
+          ;; -1, but the EOF call can still hand over bytes (a held-back char,
+          ;; the flush), and a caller that received bytes calls again — an
+          ;; encoder used after `flush` throws IllegalStateException.
+          done    (volatile! false)]
       [input
        (fn [^Reader bis ^ByteBuffer nio-buffer]
-         (let [n   (.read bis chars)
-               eof (neg? n)]
-           (.flip chars)
-           (.encode encoder chars nio-buffer eof)
-           (.compact chars)
-           (when eof (.flush encoder nio-buffer))
-           ;; -1 only once nothing is left to hand over: at EOF a held-back
-           ;; char can still produce bytes, and the caller stops on -1.
-           (if (and eof (zero? (.position nio-buffer))) -1 (.position nio-buffer))))])))
+         (if @done
+           -1
+           (let [n   (.read bis chars)
+                 eof (neg? n)]
+             (.flip chars)
+             (.encode encoder chars nio-buffer eof)
+             (.compact chars)
+             (when eof
+               (.flush encoder nio-buffer)
+               (vreset! done true))
+             (if (and eof (zero? (.position nio-buffer))) -1 (.position nio-buffer)))))])))
 
 (extend
  byte-array-type

--- a/src/konserve/nio_helpers.clj
+++ b/src/konserve/nio_helpers.clj
@@ -1,5 +1,7 @@
 (ns konserve.nio-helpers
   (:import [java.nio.channels Channels ReadableByteChannel]
+           [java.nio CharBuffer]
+           [java.nio.charset StandardCharsets CodingErrorAction]
            [java.io Reader File InputStream
             ByteArrayInputStream FileInputStream StringReader]
            (java.util Arrays)
@@ -39,23 +41,40 @@
 
   Reader
   (blob->channel [input buffer-size]
-    [input
-     (fn [bis nio-buffer]
-       ;; At most a QUARTER of the buffer in chars: UTF-8 spends up to four
-       ;; bytes on one, so `buffer-size` chars of anything outside ASCII
-       ;; overflowed the `buffer-size`-byte ByteBuffer they were encoded into.
-       (let [_ (when (< buffer-size 4)
-                 (throw (ex-info "Reader input needs a buffer-size of at least 4: one UTF-8 character can take four bytes."
-                                 {:type :konserve/buffer-too-small :buffer-size buffer-size})))
-             char-array (make-array Character/TYPE (quot buffer-size 4))
-             size (.read ^StringReader bis ^chars char-array)]
-         (try
-           (when-not (= size -1)
-             (let [char-array-copy (Arrays/copyOf ^chars char-array size)]
-               (.put ^ByteBuffer nio-buffer (.getBytes (String. char-array-copy)))))
-           size
-           (catch Exception e
-             (throw e)))))]))
+    ;; A STATEFUL encoder, not `String.getBytes` per chunk. Chunking a Reader
+    ;; by chars splits UTF-16 surrogate pairs at chunk boundaries, and each
+    ;; half then encoded as a replacement — an emoji on a boundary came out
+    ;; as `??`. The encoder keeps an unpaired high surrogate (`compact`) until
+    ;; its partner arrives in the next chunk. REPLACE matches what
+    ;; `String.getBytes` did for input that is genuinely malformed.
+    ;;
+    ;; At most a QUARTER of the buffer in chars: UTF-8 spends up to four
+    ;; bytes on a pair (two chars) and three on any other char, so the
+    ;; encoded chunk always fits the `buffer-size`-byte ByteBuffer.
+    (when (< buffer-size 4)
+      (throw (ex-info "Reader input needs a buffer-size of at least 4: one UTF-8 character can take four bytes."
+                      {:type :konserve/buffer-too-small :buffer-size buffer-size})))
+    (let [encoder (doto (.newEncoder StandardCharsets/UTF_8)
+                    (.onMalformedInput CodingErrorAction/REPLACE)
+                    (.onUnmappableCharacter CodingErrorAction/REPLACE))
+          ;; Never fewer than TWO chars: a held-back high surrogate must leave
+          ;; room for its partner, or the buffer is full of one unencodable
+          ;; char, every read returns 0, and the writer loops forever. Two
+          ;; chars encode to at most 6 bytes, which the byte buffer may not
+          ;; hold at the smallest sizes — the encoder then reports OVERFLOW,
+          ;; keeps the rest, and the next call makes progress.
+          chars   (CharBuffer/allocate (max 2 (quot buffer-size 4)))]
+      [input
+       (fn [^Reader bis ^ByteBuffer nio-buffer]
+         (let [n   (.read bis chars)
+               eof (neg? n)]
+           (.flip chars)
+           (.encode encoder chars nio-buffer eof)
+           (.compact chars)
+           (when eof (.flush encoder nio-buffer))
+           ;; -1 only once nothing is left to hand over: at EOF a held-back
+           ;; char can still produce bytes, and the caller stops on -1.
+           (if (and eof (zero? (.position nio-buffer))) -1 (.position nio-buffer))))])))
 
 (extend
  byte-array-type

--- a/src/konserve/nio_helpers.clj
+++ b/src/konserve/nio_helpers.clj
@@ -41,7 +41,13 @@
   (blob->channel [input buffer-size]
     [input
      (fn [bis nio-buffer]
-       (let [char-array (make-array Character/TYPE buffer-size)
+       ;; At most a QUARTER of the buffer in chars: UTF-8 spends up to four
+       ;; bytes on one, so `buffer-size` chars of anything outside ASCII
+       ;; overflowed the `buffer-size`-byte ByteBuffer they were encoded into.
+       (let [_ (when (< buffer-size 4)
+                 (throw (ex-info "Reader input needs a buffer-size of at least 4: one UTF-8 character can take four bytes."
+                                 {:type :konserve/buffer-too-small :buffer-size buffer-size})))
+             char-array (make-array Character/TYPE (quot buffer-size 4))
              size (.read ^StringReader bis ^chars char-array)]
          (try
            (when-not (= size -1)

--- a/src/konserve/node_filestore.cljs
+++ b/src/konserve/node_filestore.cljs
@@ -103,12 +103,15 @@
     (let [buffer (js/Buffer.from value-arr)
           pos (+ storage-layout/header-size meta-size)
           bytes-written (iofs/write fd buffer {:position pos})]
-      (verify-write-size (alength buffer) bytes-written)))
+      (verify-write-size (alength buffer) bytes-written)
+      ;; The value is the last segment, so the file ends here.
+      (fs.ftruncateSync fd (+ pos (alength buffer)))))
   (-write-binary [_this meta-size blob _env]
     (let [buffer  (js/Buffer.from blob)
           pos     (+ storage-layout/header-size meta-size)
           bytes-written (iofs/write fd buffer {:position pos})]
-      (verify-write-size (alength buffer) bytes-written)))
+      (verify-write-size (alength buffer) bytes-written)
+      (fs.ftruncateSync fd (+ pos (alength buffer)))))
   Object
   (force [_this _] (fs.fsyncSync fd))
   (close [this]
@@ -192,17 +195,32 @@
                    (put! out buf)))))))
 
 (defn- afwrite
-  "Write buffer to the fd. yields ?err"
+  "Write ALL of `buf` at `pos`. yields ?err
+
+   A short write is re-issued from where it stopped. `?byte-count` used to be
+   ignored, so a short `fs.write` published a truncated staging blob as a
+   success — the async twin of what the sync path's `verify-write-size` catches."
   [fd buf pos]
   (let [buf (js/Buffer.from buf)
-        offset 0
         len (alength buf)]
     (with-promise out
-      (fs.write fd buf offset len pos
-                (fn [?err ?byte-count _]
-                  (if ?err
-                    (put! out ?err)
-                    (close! out)))))))
+      (letfn [(step [offset p]
+                (if (< offset len)
+                  (fs.write fd buf offset (- len offset) p
+                            (fn [?err ?n _]
+                              (if ?err
+                                (put! out ?err)
+                                (step (+ offset ?n) (+ p ?n)))))
+                  (close! out)))]
+        (step 0 pos)))))
+
+(defn- aftruncate
+  "Cut the file at `size`. yields ?err"
+  [fd size]
+  (with-promise out
+    (fs.ftruncate fd size
+                  (fn [?err]
+                    (if ?err (put! out ?err) (close! out))))))
 
 (defn- afsize
   "The size of the file in bytes. yields ;=> [?err ?size]"
@@ -254,7 +272,10 @@
                          (fn [?err]
                            (if (some? ?err)
                              (put! out ?err)
-                             (close! out)))))
+                             ;; See -write-value: the file ends where the stream did.
+                             (fs.ftruncate fd (+ pos (.-bytesWritten wstream))
+                                           (fn [?err]
+                                             (if ?err (put! out ?err) (close! out))))))))
       (catch js/Error e
         (put! out e)))))
 
@@ -287,7 +308,10 @@
   (-write-value [_this value-arr meta-size _env] ;=> ch<?err>
     (let [buffer (js/Buffer.from value-arr)
           pos (+ storage-layout/header-size meta-size)]
-      (afwrite fd buffer pos)))
+      ;; The value is the last segment, so the file ends here — in `:in-place?`
+      ;; mode the file is reused, and a shorter value kept the old tail.
+      (go (or (<! (afwrite fd buffer pos))
+              (<! (aftruncate fd (+ pos (alength buffer))))))))
   (-write-binary [_this meta-size blob env]
     (afwrite-binary fd meta-size blob env)) ;=> ch<?err>
   Object
@@ -541,10 +565,12 @@
     (if (:sync? env)
       (list-files base (.-ephemeral? this))
       (list-files-async base (.-ephemeral? this))))
-  (-copy [this from to env]
+  (-copy [_this from to env]
+    ;; `base`, as `-atomic-move` passes: `this` is the record, and every
+    ;; in-place write (which copies a `.backup` first) died on it.
     (if (:sync? env)
-      (copy this from to env)
-      (copy-async this from to env)))
+      (copy base from to env)
+      (copy-async base from to env)))
   (-atomic-move [_this from to env]
     (if (:sync? env)
       (atomic-move base from to env)

--- a/test/konserve/simulation_crash_test.clj
+++ b/test/konserve/simulation_crash_test.clj
@@ -162,9 +162,13 @@
            #"Simulated crash at after-sync"
            (sync-assoc! store :key {:new-value true})))
 
-      ;; At this point, .new file exists but original is unchanged
-      (is (seq (crash/get-pending-new-files state-atom))
-          "Pending .new file should exist")
+      ;; The simulated crash is a THROWN exception, and a throw is not a process
+      ;; death: `update-blob`'s finally still runs and removes the staging file
+      ;; it never moved (a per-writer `.new` that nothing later overwrites). So
+      ;; nothing is pending here — only a real crash, where no finally runs,
+      ;; leaves one behind. The original is unchanged either way.
+      (is (empty? (crash/get-pending-new-files state-atom))
+          "A failed write cleans up its own staging file")
 
       (crash/simulate-crash! state-atom)
       (crash/clear-crash-point! crash-point-atom)

--- a/test/konserve/write_ordering_test.clj
+++ b/test/konserve/write_ordering_test.clj
@@ -1,0 +1,83 @@
+(ns konserve.write-ordering-test
+  "The target blob must be CLOSED before `.new` is moved over it.
+
+   Not observable on Linux by outcome — POSIX renames over an open file — which
+   is exactly why it needs pinning here: the ordering can regress and every
+   Linux suite stays green, and the first place it shows is a Windows build
+   refusing the rename. So the test records the backing's protocol calls and
+   asserts the order directly.
+
+   Recorded through a DELEGATING BACKING, not `with-redefs`. A protocol call on
+   a record that implements the protocol inline compiles to a direct interface
+   call (`InvokeExpr.emitProto`) and never consults the var, so a redef of
+   `-create-blob` or `-atomic-move` is simply not seen. `-close` on a
+   `FileChannel` is an `extend-type`, goes through the var, and IS seen — which
+   is how an earlier version of this test recorded three closes and no move and
+   reported a failure that told you nothing."
+  (:require [clojure.test :refer [deftest is testing]]
+            [konserve.core :as k]
+            [konserve.filestore :refer [connect-fs-store delete-store]]
+            [konserve.impl.storage-layout :as sl]
+            [konserve.protocols :as kp])
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(defn- fresh-path []
+  (str (Files/createTempDirectory "konserve-ordering-" (make-array FileAttribute 0)) "/store"))
+
+(defn- recording-backing
+  "The real backing, with `-create-blob` and `-atomic-move` logged to `events`.
+   Implements exactly what `BackingFilestore` does — PBackingStore and
+   PConditionalWrite — so `io-operation` takes the same path it would unwrapped."
+  [real events created]
+  (reify
+    kp/PConditionalWrite
+    (-conditional-write-domain [_] (kp/-conditional-write-domain real))
+    sl/PBackingStore
+    (-create-blob [_ store-key env]
+      (let [blob (sl/-create-blob real store-key env)]
+        (swap! created assoc blob store-key)
+        (swap! events conj [:create store-key])
+        blob))
+    (-atomic-move [_ from to env]
+      (swap! events conj [:move to])
+      (sl/-atomic-move real from to env))
+    (-delete-blob [_ store-key env] (sl/-delete-blob real store-key env))
+    (-migratable [_ key store-key env] (sl/-migratable real key store-key env))
+    (-migrate [_ mk kv s rh wh env] (sl/-migrate real mk kv s rh wh env))
+    (-copy [_ from to env] (sl/-copy real from to env))
+    (-create-store [_ env] (sl/-create-store real env))
+    (-delete-store [_ env] (sl/-delete-store real env))
+    (-sync-store [_ env] (sl/-sync-store real env))
+    (-keys [_ env] (sl/-keys real env))
+    (-blob-exists? [_ store-key env] (sl/-blob-exists? real store-key env))
+    (-store-exists? [_ env] (sl/-store-exists? real env))
+    (-handle-foreign-key [_ mk s rh wh env] (sl/-handle-foreign-key real mk s rh wh env))))
+
+(deftest target-closed-before-atomic-move
+  (testing "rename-mode write: -close on the target precedes -atomic-move onto it"
+    (let [path       (fresh-path)
+          plain      (connect-fs-store path :opts {:sync? true})
+          events     (atom [])
+          created    (atom {})
+          store      (assoc plain :backing (recording-backing (:backing plain) events created))
+          orig-close sl/-close]
+      ;; A first value, so the second write has an existing target to hold open.
+      (k/assoc-in store [:k] 1 {:sync? true})
+      (reset! events [])
+      ;; `-close` is on FileChannel via extend-type, so a redef does reach it.
+      (with-redefs [sl/-close (fn [blob env]
+                                (swap! events conj [:close (get @created blob)])
+                                (orig-close blob env))]
+        (k/assoc-in store [:k] 2 {:sync? true}))
+      (let [ev         @events
+            move       (first (filter #(= :move (first %)) ev))
+            target-key (second move)
+            close-idx  (.indexOf ^java.util.List ev [:close target-key])
+            move-idx   (.indexOf ^java.util.List ev move)]
+        (is (some? move) (str "a rename-mode write moves .new over the target; events: " (pr-str ev)))
+        (is (<= 0 close-idx) (str "the target " target-key " is closed; events: " (pr-str ev)))
+        (is (< close-idx move-idx)
+            (str "target closed at " close-idx " but moved over at " move-idx "; events: " (pr-str ev))))
+      (is (= 2 (k/get-in store [:k] nil {:sync? true})) "and the value still landed")
+      (delete-store path))))

--- a/test/konserve/write_path_hardening_test.clj
+++ b/test/konserve/write_path_hardening_test.clj
@@ -66,16 +66,21 @@
 
 (deftest reader-input-keeps-surrogate-pairs
   (testing "a Reader whose chunks split UTF-16 surrogate pairs still encodes them as UTF-8"
-    ;; Tiny buffers force one char per chunk, so every emoji straddles a
-    ;; boundary; 8 gives two, 1024 the ordinary case.
-    (doseq [buffer-size [4 5 8 1024]]
+    ;; Tiny buffers force one or two chars per chunk, so every emoji straddles
+    ;; a boundary; 8 gives two chars, 1024 the ordinary case. Three inputs:
+    ;; pairs on boundaries; "€€", whose second 3-byte char OVERFLOWS a 4- or
+    ;; 5-byte buffer and is handed over on the EOF call — after which the
+    ;; caller calls once more, and an encoder used after its flush throws;
+    ;; and a trailing lone high surrogate, which is malformed and must
+    ;; become the same replacement `String.getBytes` produces.
+    (doseq [buffer-size [4 5 8 1024]
+            s           [(apply str (repeat 40 "a😀b")) "€€" (str "ab" (char 0xD83D))]]
       (let [path  (fresh-path)
-            store (connect-fs-store path :buffer-size buffer-size :opts {:sync? true})
-            s     (apply str (repeat 40 "a😀b"))]
+            store (connect-fs-store path :buffer-size buffer-size :opts {:sync? true})]
         (is (= buffer-size (:buffer-size store)) "the buffer size under test took effect")
         (k/bassoc store :k (java.io.StringReader. s) {:sync? true})
         (is (= (seq (.getBytes s "UTF-8")) (seq (read-bytes store :k {:sync? true})))
-            (str "buffer-size " buffer-size ": pairs split across chunks must not become replacement bytes"))
+            (str "buffer-size " buffer-size ", input " (pr-str s)))
         (delete-store path)))))
 
 (deftest dissoc-is-ordered-against-a-fenced-write

--- a/test/konserve/write_path_hardening_test.clj
+++ b/test/konserve/write_path_hardening_test.clj
@@ -5,7 +5,8 @@
             [clojure.core.async :refer [<!!]]
             [konserve.binary :as kb]
             [konserve.core :as k]
-            [konserve.filestore :refer [connect-fs-store delete-store]])
+            [konserve.filestore :refer [connect-fs-store delete-store]]
+            [konserve.impl.defaults :as d])
   (:import [java.io InputStream ByteArrayInputStream]
            [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]))
@@ -45,32 +46,54 @@
         (delete-store path)))))
 
 (deftest shorter-write-does-not-keep-the-old-tail
-  (testing "a shorter value over a longer one is exactly the shorter value"
-    (doseq [in-place? [false true]]
+  (testing "in-place mode: a shorter value over a longer one is exactly the shorter value"
+    ;; In-place only — a rename-mode write always lands in a fresh staging
+    ;; file, so it cannot keep a tail and would pass this without truncating.
+    (doseq [sync? [true false]]
       (let [path  (fresh-path)
-            store (connect-fs-store path :config {:in-place? in-place?} :opts {:sync? true})]
-        (k/bassoc store :k (byte-array 100 (byte 1)) {:sync? true})
-        (k/bassoc store :k (byte-array 3 (byte 2)) {:sync? true})
-        (is (= [2 2 2] (seq (read-bytes store :k {:sync? true})))
-            (str "in-place? " in-place? ": the file must be truncated to the new value"))
+            store (connect-fs-store path :config {:in-place? true} :opts {:sync? true})
+            opts  {:sync? sync?}
+            run   (fn [op] (if sync? (op) (<!! (op))))]
+        (run #(k/bassoc store :bin (byte-array 100 (byte 1)) opts))
+        (run #(k/bassoc store :bin (byte-array 3 (byte 2)) opts))
+        (is (= [2 2 2] (seq (read-bytes store :bin opts)))
+            (str "sync? " sync? ": binary — the file must be truncated to the new value"))
+        (run #(k/assoc-in store [:edn] (apply str (repeat 5000 "x")) opts))
+        (run #(k/assoc-in store [:edn] "short" opts))
+        (is (= "short" (run #(k/get-in store [:edn] nil opts)))
+            (str "sync? " sync? ": edn — the value segment is truncated too"))
         (delete-store path)))))
 
 (deftest dissoc-is-ordered-against-a-fenced-write
   (testing "a delete on a fenceable key takes the sidecar lock, so it cannot slip inside a fenced write"
-    (let [path (fresh-path)
+    ;; Both ways a caller obtains a token. `k/revision` is the one that used to
+    ;; hand it out WITHOUT creating the sidecar, so the delete found nothing to
+    ;; lock and slipped inside the fenced write.
+    (doseq [[token-source token] [[:with-revision? #(second (k/get-in % [:k] nil {:sync? true :with-revision? true}))]
+                                  [:k/revision      #(k/revision % :k {:sync? true})]]]
+      (let [path (fresh-path)
           ;; Two stores on one path: separate lock registries, like two processes.
-          a    (connect-fs-store path :opts {:sync? true})
-          b    (connect-fs-store path :opts {:sync? true})]
-      (k/assoc-in a [:k] :v0 {:sync? true})
-      (let [[_ rev] (k/get-in a [:k] nil {:sync? true :with-revision? true})
-            writer  (future
-                      ;; Holds the sidecar lock for the whole fenced write.
-                      (k/update-in a [:k] (fn [_] (Thread/sleep 400) :from-a)
-                                   {:sync? true :expected-revision rev}))]
-        (Thread/sleep 100)
-        ;; Arrives while A is mid-write. Must WAIT for A, then delete.
-        (k/dissoc b :k {:sync? true})
-        @writer
-        (is (nil? (k/get-in a [:k] nil {:sync? true}))
-            "the delete ran after the fenced write it was ordered behind; the key must not reappear"))
-      (delete-store path))))
+            a    (connect-fs-store path :opts {:sync? true})
+            b    (connect-fs-store path :opts {:sync? true})]
+        (k/assoc-in a [:k] :v0 {:sync? true})
+        (let [rev      (token a)
+              _        (is (.exists (java.io.File. path (str (d/key->store-key :k) d/cas-lock-suffix)))
+                           (str token-source ": handing out a revision token makes the key fenceable — "
+                                "the sidecar must exist before any fenced write, or an unconditional "
+                                "writer or delete that probes first finds nothing to be ordered by"))
+              entered  (promise)   ; the writer is inside its locked update
+              proceed  (promise)   ; ... and stays there until we say so
+              writer   (future
+                         (k/update-in a [:k] (fn [_] (deliver entered true) @proceed :from-a)
+                                      {:sync? true :expected-revision rev}))]
+          @entered
+        ;; A is provably inside the fenced write, holding the sidecar lock.
+          (let [deleter (future (k/dissoc b :k {:sync? true}) :deleted)]
+            (is (= ::blocked (deref deleter 200 ::blocked))
+                (str token-source ": the delete must wait for the fenced write, not slip inside it"))
+            (deliver proceed true)
+            (is (= :from-a (second @writer)) "the fenced write completes: update-in yields [old new]")
+            (is (= :deleted (deref deleter 5000 ::stuck)) "then the delete runs")
+            (is (nil? (k/get-in a [:k] nil {:sync? true}))
+                (str token-source ": delete after write — the key is gone and does not reappear"))))
+        (delete-store path)))))

--- a/test/konserve/write_path_hardening_test.clj
+++ b/test/konserve/write_path_hardening_test.clj
@@ -64,6 +64,20 @@
             (str "sync? " sync? ": edn — the value segment is truncated too"))
         (delete-store path)))))
 
+(deftest reader-input-keeps-surrogate-pairs
+  (testing "a Reader whose chunks split UTF-16 surrogate pairs still encodes them as UTF-8"
+    ;; Tiny buffers force one char per chunk, so every emoji straddles a
+    ;; boundary; 8 gives two, 1024 the ordinary case.
+    (doseq [buffer-size [4 5 8 1024]]
+      (let [path  (fresh-path)
+            store (connect-fs-store path :buffer-size buffer-size :opts {:sync? true})
+            s     (apply str (repeat 40 "a😀b"))]
+        (is (= buffer-size (:buffer-size store)) "the buffer size under test took effect")
+        (k/bassoc store :k (java.io.StringReader. s) {:sync? true})
+        (is (= (seq (.getBytes s "UTF-8")) (seq (read-bytes store :k {:sync? true})))
+            (str "buffer-size " buffer-size ": pairs split across chunks must not become replacement bytes"))
+        (delete-store path)))))
+
 (deftest dissoc-is-ordered-against-a-fenced-write
   (testing "a delete on a fenceable key takes the sidecar lock, so it cannot slip inside a fenced write"
     ;; Both ways a caller obtains a token. `k/revision` is the one that used to

--- a/test/konserve/write_path_hardening_test.clj
+++ b/test/konserve/write_path_hardening_test.clj
@@ -1,0 +1,76 @@
+(ns konserve.write-path-hardening-test
+  "One test per finding of the write-path review, each written to FAIL on the
+   code it was written against."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.core.async :refer [<!!]]
+            [konserve.binary :as kb]
+            [konserve.core :as k]
+            [konserve.filestore :refer [connect-fs-store delete-store]])
+  (:import [java.io InputStream ByteArrayInputStream]
+           [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(defn- fresh-path []
+  (str (Files/createTempDirectory "konserve-hardening-" (make-array FileAttribute 0)) "/store"))
+
+(defn- short-reads
+  "An InputStream that hands out at most `max` bytes per read — what a socket,
+   a pipe, or any stream that is not a byte array does routinely."
+  ^InputStream [^bytes data ^long max]
+  (let [inner (ByteArrayInputStream. data)]
+    (proxy [InputStream] []
+      (read
+        ([] (.read inner))
+        ([^bytes buf] (.read ^InputStream this buf 0 (alength buf)))
+        ([^bytes buf off len] (.read inner buf off (min (long len) max)))))))
+
+(defn- read-bytes [store key opts]
+  (let [r (k/bget store key (kb/to-bytes opts) opts)]
+    (if (:sync? opts) r (<!! r))))
+
+(deftest short-reads-do-not-shift-the-value
+  (testing "a binary written from a stream that returns short reads is intact (sync and async)"
+    (doseq [sync? [true false]]
+      (let [path  (fresh-path)
+            ;; Connect synchronously — an async connect yields a channel — and
+            ;; exercise the async path per operation, as the binary tests do.
+            store (connect-fs-store path :opts {:sync? true})
+            data  (byte-array (map #(mod % 251) (range 100000)))
+            opts  {:sync? sync?}]
+        (if sync?
+          (k/bassoc store :k (short-reads data 777) opts)
+          (<!! (k/bassoc store :k (short-reads data 777) opts)))
+        (is (= (seq data) (seq (read-bytes store :k opts)))
+            (str "sync? " sync? ": a fixed stride over short reads leaves holes and shifts the tail"))
+        (delete-store path)))))
+
+(deftest shorter-write-does-not-keep-the-old-tail
+  (testing "a shorter value over a longer one is exactly the shorter value"
+    (doseq [in-place? [false true]]
+      (let [path  (fresh-path)
+            store (connect-fs-store path :config {:in-place? in-place?} :opts {:sync? true})]
+        (k/bassoc store :k (byte-array 100 (byte 1)) {:sync? true})
+        (k/bassoc store :k (byte-array 3 (byte 2)) {:sync? true})
+        (is (= [2 2 2] (seq (read-bytes store :k {:sync? true})))
+            (str "in-place? " in-place? ": the file must be truncated to the new value"))
+        (delete-store path)))))
+
+(deftest dissoc-is-ordered-against-a-fenced-write
+  (testing "a delete on a fenceable key takes the sidecar lock, so it cannot slip inside a fenced write"
+    (let [path (fresh-path)
+          ;; Two stores on one path: separate lock registries, like two processes.
+          a    (connect-fs-store path :opts {:sync? true})
+          b    (connect-fs-store path :opts {:sync? true})]
+      (k/assoc-in a [:k] :v0 {:sync? true})
+      (let [[_ rev] (k/get-in a [:k] nil {:sync? true :with-revision? true})
+            writer  (future
+                      ;; Holds the sidecar lock for the whole fenced write.
+                      (k/update-in a [:k] (fn [_] (Thread/sleep 400) :from-a)
+                                   {:sync? true :expected-revision rev}))]
+        (Thread/sleep 100)
+        ;; Arrives while A is mid-write. Must WAIT for A, then delete.
+        (k/dissoc b :k {:sync? true})
+        @writer
+        (is (nil? (k/get-in a [:k] nil {:sync? true}))
+            "the delete ran after the fenced write it was ordered behind; the key must not reappear"))
+      (delete-store path))))


### PR DESCRIPTION
fix: close the target before moving .new over it, and retry the move on Windows

The second Windows bug behind datahike's native CI, after #186 fixed the first.
`create-database` — the first writes a store ever sees — failed with

    …\dh-test-store\03ac….ksv.new -> …\dh-test-store\03ac….ksv

No reason suffix: that is `AccessDeniedException(source, target, null)` from
`Files/move`. Windows refuses to replace a file that has ANY open handle. POSIX
renames underneath one, which is why nothing on Linux or macOS ever noticed.

## What held the handle

Our own process. In the write path, `-create-blob` opens the target with
WRITE|READ|CREATE — creating an empty `.ksv` for a brand-new key — and a
FileLock is taken on it (`:lock-blob?` defaults to true). `update-blob`, which
writes `.new` and moves it over the target, ran INSIDE the try/finally that
closes and unlocks that target. So at the moment of the move the target was
open and locked by us, on every platform; only Windows objects.

## The fix, and why it loses nothing

In rename mode the target is now released and closed right after `old` is read
and the revision checked — everything it was opened for is done — and before
`update-blob` runs. In-place mode (`:in-place? true`, which edits that very
file with no rename) keeps both, unchanged.

The lock released early never guarded the move. konserve's own `.cas` docstring
says why: a lock lives on an INODE, and the rename detaches the one it was
taken on, so two rename-writers can each hold a lock on a different inode and
both believe they were serialized. That is the reason the `.cas` sidecar exists
for fenced writes — it is never renamed — and the sidecar's lock is held across
`update-blob` exactly as before. Unfenced cross-process RMW to one key was and
remains outside the contract ("single writer per runtime, or coordinate
above"); in-process writes to a key are serialized by `go-locked` regardless.
Writes are never torn: the rename is atomic on every platform.

`-atomic-move` in the filestore additionally retries on AccessDeniedException
with jittered backoff, bounded (~1s, the same budget `get-lock` gives
contention). That is for the one case no locking scheme reaches: a READER in
another process holding the target open, which POSIX renames under and Windows
waits out. Bounded, so a handle held indefinitely surfaces as the error it is.

## Implementation note

`io-operation`'s go block sits at the JVM's 64KB method limit — the first
version of this hit "Method code too large!". The early release is therefore
two small `async+sync` helpers (`release-held-lock!`, `close-held-blob!`), each
one park from the state machine, and the `finally`s call the same helpers,
which makes the block slightly SMALLER than before.

## The regression test, and what it took to write one

`write-ordering-test` pins the invariant directly: `-close` on the target
precedes `-atomic-move` onto it. It is not observable by outcome on Linux, which
is exactly why it needs pinning — the ordering can regress with every Linux
suite green, and the first place it shows is a Windows build.

It records calls through a DELEGATING BACKING, not `with-redefs`. That matters
enough to record: a protocol call on a record that implements the protocol
inline compiles to a direct interface call (`InvokeExpr.emitProto`) and never
consults the var, so a redef of `-create-blob` or `-atomic-move` is not seen
at all — while `-close` on a FileChannel (an `extend-type`) is. An earlier
version of the test redefined all three, recorded three closes and no move, and
"failed" identically on the fixed and unfixed code.

Mutation-checked: against the unpatched write path the test fails and names
the order — `[:create target] [:create .new] [:close .new] [:move → target] …
[:close target]`, "target closed at 5 but moved over at 3". Against this
branch: 4 assertions, 0 failures.

## Verified

- Full suite with :zstd on this branch: every pre-existing test passes (the one
  run that showed failures was the earlier, broken version of the new test).
  A clean final run is posted on this PR.
- cljfmt clean.

Not verified here, and cannot be: the Windows rename itself. Datahike#1022
prints the exception class now, so a third Windows bug, if there is one, will
name itself.
