### PR TITLE
Coordinate durable root publication with GC sweeps

### DIFF
--- a/src/konserve/gc.cljc
+++ b/src/konserve/gc.cljc
@@ -86,10 +86,13 @@
 
    Passing a raw `(utils/now)` is correct only on a store no writer guards.
 
-   `opts :coordination-token` may carry the exclusive token from
-   `konserve.gc-coordination/begin-collection!`. `sweep!` checks it before
-   enumeration and every destructive batch. The durable coordination key is
-   always preserved, whether or not a token is supplied."
+   `opts :coordination-token` carries the exclusive token from
+   `konserve.gc-coordination/begin-collection!`. Once durable coordination has
+   been activated for a store, a token is mandatory; an independent tokenless
+   collector fails closed instead of bypassing publishers. A legacy store with
+   no coordination record retains tokenless behavior. `sweep!` checks authority
+   before enumeration and every destructive batch. The durable coordination key
+   is always preserved."
   ([store whitelist cutoff]
    (sweep! store whitelist cutoff 1000 {}))
   ([store whitelist cutoff batch-size]
@@ -101,9 +104,8 @@
     (go-try-
      (let [sync? (:sync? opts)
            coordination-token (:coordination-token opts)
-           _ (when coordination-token
-               (<?- (coord/assert-collection! store coordination-token
-                                              (select-keys opts [:sync?]))))
+           _ (<?- (coord/assert-sweep-authorized! store coordination-token
+                                                  (select-keys opts [:sync?])))
            to-delete (->> (<?- (k/keys store (select-keys opts [:sync?])))
                           (filter (fn [{:keys [key last-write] :as meta}]
                                     (not
@@ -119,15 +121,24 @@
         (reduce<?-
          (fn [deleted-files batch]
            (go-try-
-            (when coordination-token
-              (<?- (coord/assert-collection! store coordination-token
-                                             (select-keys opts [:sync?]))))
+            (<?- (coord/assert-sweep-authorized! store coordination-token
+                                                 (select-keys opts [:sync?])))
             (if (utils/multi-key-capable? store)
               ;; one round trip for the whole batch where the backing allows it
               (let [keys-to-delete (mapv :key batch)]
                 (<?- (k/multi-dissoc store keys-to-delete (select-keys opts [:sync?])))
                 (into deleted-files keys-to-delete))
-              (do (<?- (delete-batch! store batch sync?))
-                  (into deleted-files (map :key batch))))))
+              (let [results (<?- (delete-batch! store batch sync?))]
+                ;; In async mode `async/merge` transports a per-key failure as
+                ;; an element inside the result vector. `<?-` only sees the
+                ;; vector itself, so surface the nested failure explicitly
+                ;; instead of claiming every key was deleted.
+                (when-let [error (some #(when (instance?
+                                               #?(:clj Throwable :cljs js/Error)
+                                               %)
+                                          %)
+                                       results)]
+                  (throw error))
+                (into deleted-files (map :key batch))))))
          #{}
          to-delete)))))))

--- a/src/konserve/gc.cljc
+++ b/src/konserve/gc.cljc
@@ -1,6 +1,7 @@
 (ns konserve.gc
   (:require [clojure.core.async :as async]
             [konserve.core :as k]
+            [konserve.gc-coordination :as coord]
             #?(:clj [konserve.utils :as utils :refer [async+sync *default-sync-translation*]]
                :cljs [konserve.utils :as utils :refer [*default-sync-translation*]
                       :refer-macros [async+sync]])
@@ -83,7 +84,12 @@
    after the caller's mark — the broken order above, wearing the appearance of
    safety. Only the caller is in a position to interleave the two correctly.
 
-   Passing a raw `(utils/now)` is correct only on a store no writer guards."
+   Passing a raw `(utils/now)` is correct only on a store no writer guards.
+
+   `opts :coordination-token` may carry the exclusive token from
+   `konserve.gc-coordination/begin-collection!`. `sweep!` checks it before
+   enumeration and every destructive batch. The durable coordination key is
+   always preserved, whether or not a token is supplied."
   ([store whitelist cutoff]
    (sweep! store whitelist cutoff 1000 {}))
   ([store whitelist cutoff batch-size]
@@ -94,10 +100,15 @@
     *default-sync-translation*
     (go-try-
      (let [sync? (:sync? opts)
+           coordination-token (:coordination-token opts)
+           _ (when coordination-token
+               (<?- (coord/assert-collection! store coordination-token
+                                              (select-keys opts [:sync?]))))
            to-delete (->> (<?- (k/keys store (select-keys opts [:sync?])))
                           (filter (fn [{:keys [key last-write] :as meta}]
                                     (not
-                                     (or (contains? whitelist key)
+                                     (or (contains? coord/coordination-root-keys key)
+                                         (contains? whitelist key)
                                          (<= (epoch-ms cutoff)
                                              (epoch-ms (if last-write
                                                          last-write
@@ -108,6 +119,9 @@
         (reduce<?-
          (fn [deleted-files batch]
            (go-try-
+            (when coordination-token
+              (<?- (coord/assert-collection! store coordination-token
+                                             (select-keys opts [:sync?]))))
             (if (utils/multi-key-capable? store)
               ;; one round trip for the whole batch where the backing allows it
               (let [keys-to-delete (mapv :key batch)]

--- a/src/konserve/gc_coordination.cljc
+++ b/src/konserve/gc_coordination.cljc
@@ -1,0 +1,217 @@
+(ns konserve.gc-coordination
+  "Durable coordination between root publication and mark/sweep collection.
+
+   `konserve.gc-guard` protects newly written values until their pointer lands.
+   This namespace protects the opposite transition: publishing a pointer to
+   OLD objects after a collector has already marked roots. A timestamp cutoff
+   cannot protect those objects because their writes may be arbitrarily old.
+
+   The protocol is a durable reader/writer fence in one conditional-write
+   domain. Root publishers briefly hold publication tokens; one collector holds
+   the exclusive token from its authoritative root snapshot through sweep.
+
+   Tokens deliberately do not expire. Konserve cannot currently make a delete
+   batch conditional on this coordination record, so automatically stealing an
+   expired collector token would be unsafe: a paused old collector could resume
+   between checking its token and deleting a batch. A crashed collector therefore
+   fails closed and needs operator recovery after proving it cannot resume."
+  (:require [konserve.core :as k]
+            #?(:clj [konserve.utils :refer [async+sync *default-sync-translation*]]
+               :cljs [konserve.utils :refer [*default-sync-translation*]
+                      :refer-macros [async+sync]])
+            #?(:clj [superv.async :refer [go-try- <?-]]
+               :cljs [superv.async :refer-macros [go-try- <?-]]))
+  #?(:clj (:import [java.util Date])))
+
+(def coordination-key :konserve/gc-coordination)
+
+(def coordination-root-keys
+  "Konserve-internal keys a collector must never sweep."
+  #{coordination-key})
+
+(defn- now [] #?(:clj (Date.) :cljs (js/Date.)))
+
+(defn- new-id [] #?(:clj (java.util.UUID/randomUUID) :cljs (random-uuid)))
+
+(defn- revision-mismatch? [e]
+  (= :konserve/revision-mismatch (:type (ex-data e))))
+
+(defn- initial-state []
+  {:format-version 1
+   :epoch 0
+   :collector nil
+   :publishers {}})
+
+(defn- validate-state [state]
+  (when-not (and (map? state)
+                 (= 1 (:format-version state))
+                 (nat-int? (:epoch state))
+                 (map? (:publishers state)))
+    (throw (ex-info "Invalid durable GC coordination state."
+                    {:type :konserve/invalid-gc-coordination-state
+                     :state state})))
+  state)
+
+(defn- require-domain! [store required-domain]
+  (when-not (k/conditional-write? store required-domain)
+    (throw
+     (ex-info
+      (str "Durable GC coordination requires conditional writes reaching "
+           (pr-str required-domain) ".")
+      {:type :konserve/gc-coordination-domain-insufficient
+       :required-domain required-domain
+       :actual-domain (k/conditional-write-domain store)}))))
+
+(defn- update-state!
+  [store f {:keys [required-domain] :as opts}]
+  (let [required-domain (or required-domain :process)
+        io-opts (dissoc opts :required-domain :owner)]
+    (require-domain! store required-domain)
+    (async+sync
+     (:sync? io-opts) *default-sync-translation*
+     (go-try-
+      (loop [attempt 0]
+        (let [[stored revision]
+              (<?- (k/get store coordination-key nil
+                          (assoc io-opts :with-revision? true)))
+              state (validate-state (or stored (initial-state)))
+              updated (validate-state (f state))
+              result (try
+                       (<?- (k/assoc store coordination-key updated
+                                     (assoc io-opts :expected-revision revision)))
+                       updated
+                       (catch #?(:clj Throwable :cljs :default) e
+                         (if (revision-mismatch? e) ::retry (throw e))))]
+          (if (= ::retry result)
+            (if (< attempt 63)
+              (recur (inc attempt))
+              (throw
+               (ex-info "Durable GC coordination did not converge."
+                        {:type :konserve/gc-coordination-contention
+                         :attempts (inc attempt)})))
+            result)))))))
+
+(defn state
+  "Read the durable coordination state, or the empty initial state."
+  ([store] (state store {:sync? false}))
+  ([store opts]
+   (async+sync
+    (:sync? opts) *default-sync-translation*
+    (go-try-
+     (validate-state
+      (or (<?- (k/get store coordination-key nil opts))
+          (initial-state)))))))
+
+(defn begin-publication!
+  "Acquire a short-lived root-publication token.
+
+   Throws `:konserve/gc-collection-active` instead of waiting when a collector
+   owns the fence. The caller may retry. Hold the token only around publication
+   of branch heads, pins, aliases, or other pointers that can name old objects;
+   long value/build work happens before it."
+  ([store] (begin-publication! store {}))
+  ([store {:keys [owner] :as opts}]
+   (let [id (new-id)
+         token {:kind :publication :id id}]
+     (async+sync
+      (:sync? opts) *default-sync-translation*
+      (go-try-
+       (<?- (update-state!
+             store
+             (fn [state]
+               (when-let [collector (:collector state)]
+                 (throw
+                  (ex-info "A GC collection currently fences root publication."
+                           {:type :konserve/gc-collection-active
+                            :collector collector})))
+               (assoc-in state [:publishers id]
+                         {:id id :owner owner :started-at (now)}))
+             opts))
+       token)))))
+
+(defn end-publication!
+  "Release a publication token. Idempotent after the token has disappeared."
+  ([store token] (end-publication! store token {}))
+  ([store {:keys [kind id] :as token} opts]
+   (when-not (and (= :publication kind) (some? id))
+     (throw (ex-info "Invalid GC publication token."
+                     {:type :konserve/invalid-gc-coordination-token
+                      :token token})))
+   (update-state! store #(update % :publishers dissoc id) opts)))
+
+(defn begin-collection!
+  "Acquire the exclusive collector token.
+
+   Throws when a publisher or collector is active. After acquisition, take the
+   authoritative root snapshot, mark, sweep, then call `end-collection!` in a
+   `finally`. The returned epoch is diagnostic and will support backend-fenced
+   deletion later; it is not presently a recoverable lease."
+  ([store] (begin-collection! store {}))
+  ([store {:keys [owner] :as opts}]
+   (let [id (new-id)
+         token* (atom nil)]
+     (async+sync
+      (:sync? opts) *default-sync-translation*
+      (go-try-
+       (<?- (update-state!
+             store
+             (fn [state]
+               (when-let [collector (:collector state)]
+                 (throw
+                  (ex-info "Another GC collection already owns the durable fence."
+                           {:type :konserve/gc-collection-active
+                            :collector collector})))
+               (when (seq (:publishers state))
+                 (throw
+                  (ex-info "Root publication is active; collection must retry."
+                           {:type :konserve/gc-publication-active
+                            :publishers (vals (:publishers state))})))
+               (let [epoch (inc (:epoch state))
+                     token {:kind :collection :id id :epoch epoch}]
+                 (reset! token* token)
+                 (assoc state
+                        :epoch epoch
+                        :collector {:id id :epoch epoch :owner owner
+                                    :started-at (now)})))
+             opts))
+       @token*)))))
+
+(defn end-collection!
+  "Release the exclusive collector token. A different token cannot release it."
+  ([store token] (end-collection! store token {}))
+  ([store {:keys [kind id epoch] :as token} opts]
+   (when-not (and (= :collection kind) (some? id) (nat-int? epoch))
+     (throw (ex-info "Invalid GC collection token."
+                     {:type :konserve/invalid-gc-coordination-token
+                      :token token})))
+   (update-state!
+    store
+    (fn [state]
+      (if-let [collector (:collector state)]
+        (if (= [id epoch] ((juxt :id :epoch) collector))
+          (assoc state :collector nil)
+          (throw
+           (ex-info "A GC token cannot release another collector's fence."
+                    {:type :konserve/gc-collection-token-mismatch
+                     :token token :collector collector})))
+        state))
+    opts)))
+
+(defn assert-collection!
+  "Raise unless `token` still owns the durable collection fence."
+  ([store token] (assert-collection! store token {:sync? false}))
+  ([store {:keys [kind id epoch] :as token} opts]
+   (when-not (and (= :collection kind) (some? id) (nat-int? epoch))
+     (throw (ex-info "Invalid GC collection token."
+                     {:type :konserve/invalid-gc-coordination-token
+                      :token token})))
+   (async+sync
+    (:sync? opts) *default-sync-translation*
+    (go-try-
+     (let [collector (:collector (<?- (state store opts)))]
+       (when-not (= [id epoch] ((juxt :id :epoch) collector))
+         (throw
+          (ex-info "The GC collection token no longer owns the durable fence."
+                   {:type :konserve/gc-collection-token-lost
+                    :token token :collector collector})))
+       token)))))

--- a/src/konserve/gc_coordination.cljc
+++ b/src/konserve/gc_coordination.cljc
@@ -1,21 +1,34 @@
 (ns konserve.gc-coordination
   "Durable coordination between root publication and mark/sweep collection.
 
-   `konserve.gc-guard` protects newly written values until their pointer lands.
-   This namespace protects the opposite transition: publishing a pointer to
-   OLD objects after a collector has already marked roots. A timestamp cutoff
-   cannot protect those objects because their writes may be arbitrarily old.
+   `konserve.gc-guard` protects newly written values until their pointer lands,
+   but only inside one process. This namespace provides the durable equivalent
+   and also protects the opposite transition: publishing a pointer to OLD
+   objects after a collector has already marked roots. A timestamp cutoff cannot
+   protect old objects because their writes may be arbitrarily old.
 
    The protocol is a durable reader/writer fence in one conditional-write
-   domain. Root publishers briefly hold publication tokens; one collector holds
-   the exclusive token from its authoritative root snapshot through sweep.
+   domain. Publishers hold publication tokens across their unreachable-value
+   interval; one collector holds the exclusive token from its authoritative
+   root snapshot through sweep.
+
+   A publisher that writes new values MUST acquire its token before the first
+   value becomes visible in the store and retain it through pointer publication.
+   A publisher that only names an already-complete old graph may acquire it just
+   before publishing the pointer. This lets one fence cover both GC races.
 
    Tokens deliberately do not expire. Konserve cannot currently make a delete
    batch conditional on this coordination record, so automatically stealing an
    expired collector token would be unsafe: a paused old collector could resume
-   between checking its token and deleting a batch. A crashed collector therefore
-   fails closed and needs operator recovery after proving it cannot resume."
+   between checking its token and deleting a batch. A crashed publisher OR
+   collector therefore fails closed and needs operator recovery after proving it
+   cannot resume."
   (:require [konserve.core :as k]
+            [konserve.protocols :as kp]
+            #?(:clj [clojure.core.async :as async]
+               :cljs [clojure.core.async :as async :include-macros true])
+            #?(:clj [clojure.core.async.impl.protocols :as async-proto]
+               :cljs [cljs.core.async.impl.protocols :as async-proto])
             #?(:clj [konserve.utils :refer [async+sync *default-sync-translation*]]
                :cljs [konserve.utils :refer [*default-sync-translation*]
                       :refer-macros [async+sync]])
@@ -33,8 +46,21 @@
 
 (defn- new-id [] #?(:clj (java.util.UUID/randomUUID) :cljs (random-uuid)))
 
-(defn- revision-mismatch? [e]
-  (= :konserve/revision-mismatch (:type (ex-data e))))
+(defn- error-value? [x]
+  (instance? #?(:clj Throwable :cljs js/Error) x))
+
+(defn- read-port? [x]
+  (satisfies? async-proto/ReadPort x))
+
+(defn- callback-shape-error [expected actual]
+  (ex-info (str "Managed GC callback must return " expected ".")
+           {:type :konserve/gc-coordination-callback-shape
+            :expected expected
+            :actual-type (type actual)}))
+
+(defn- revision-mismatch? [x]
+  (and (error-value? x)
+       (= :konserve/revision-mismatch (:type (ex-data x)))))
 
 (defn- initial-state []
   {:format-version 1
@@ -46,7 +72,17 @@
   (when-not (and (map? state)
                  (= 1 (:format-version state))
                  (nat-int? (:epoch state))
-                 (map? (:publishers state)))
+                 (map? (:publishers state))
+                 (every? (fn [[id publisher]]
+                           (and (uuid? id)
+                                (map? publisher)
+                                (= id (:id publisher))))
+                         (:publishers state))
+                 (or (nil? (:collector state))
+                     (let [collector (:collector state)]
+                       (and (map? collector)
+                            (uuid? (:id collector))
+                            (nat-int? (:epoch collector))))))
     (throw (ex-info "Invalid durable GC coordination state."
                     {:type :konserve/invalid-gc-coordination-state
                      :state state})))
@@ -62,34 +98,97 @@
        :required-domain required-domain
        :actual-domain (k/conditional-write-domain store)}))))
 
-(defn- update-state!
-  [store f {:keys [required-domain] :as opts}]
-  (let [required-domain (or required-domain :process)
-        io-opts (dissoc opts :required-domain :owner)]
+(defn- token-context [store required-domain]
+  {:required-domain required-domain
+   :store-id (kp/store-id store)})
+
+(defn- require-token-context! [store token]
+  (let [required-domain (:required-domain token)
+        actual-store-id (kp/store-id store)]
+    (when-not required-domain
+      (throw (ex-info "A GC coordination token is missing its required domain."
+                      {:type :konserve/invalid-gc-coordination-token
+                       :token token})))
     (require-domain! store required-domain)
-    (async+sync
-     (:sync? io-opts) *default-sync-translation*
-     (go-try-
+    (when-not (= (:store-id token) actual-store-id)
+      (throw (ex-info "A GC coordination token belongs to a different store."
+                      {:type :konserve/gc-coordination-store-mismatch
+                       :token-store-id (:store-id token)
+                       :actual-store-id actual-store-id})))
+    token))
+
+(defn- apply-state-update [f stored require-active?]
+  (try
+    (when (and require-active? (nil? stored))
+      (throw
+       (ex-info "Durable GC coordination has not been activated for this store."
+                {:type :konserve/gc-coordination-not-active})))
+    {:value (-> (or stored (initial-state))
+                validate-state
+                f
+                validate-state)}
+    (catch #?(:clj Throwable :cljs js/Error) e
+      {:error e})))
+
+(defn- contention-error [attempt]
+  (ex-info "Durable GC coordination did not converge."
+           {:type :konserve/gc-coordination-contention
+            :attempts (inc attempt)}))
+
+(defn- update-state!
+  [store f {:keys [required-domain require-active?] :as opts}]
+  (let [required-domain (or required-domain :process)
+        io-opts (dissoc opts :required-domain :require-active? :owner :id)]
+    (require-domain! store required-domain)
+    ;; Plain `k/update` is atomic only within one store handle. The durable fence
+    ;; must serialize handles/processes at the backing's DECLARED domain, which
+    ;; is exactly the revision-bearing read + expected-revision write contract.
+    ;; Keep explicit sync/async loops: wrapping the catch/recur form in
+    ;; `async+sync` hits a core.async CLJS macroexpansion bug.
+    (if (:sync? io-opts)
       (loop [attempt 0]
         (let [[stored revision]
-              (<?- (k/get store coordination-key nil
-                          (assoc io-opts :with-revision? true)))
-              state (validate-state (or stored (initial-state)))
-              updated (validate-state (f state))
-              result (try
-                       (<?- (k/assoc store coordination-key updated
-                                     (assoc io-opts :expected-revision revision)))
-                       updated
-                       (catch #?(:clj Throwable :cljs :default) e
-                         (if (revision-mismatch? e) ::retry (throw e))))]
-          (if (= ::retry result)
-            (if (< attempt 63)
-              (recur (inc attempt))
-              (throw
-               (ex-info "Durable GC coordination did not converge."
-                        {:type :konserve/gc-coordination-contention
-                         :attempts (inc attempt)})))
-            result)))))))
+              (k/get store coordination-key nil
+                     (assoc io-opts :with-revision? true))
+              {:keys [value error]} (apply-state-update f stored require-active?)]
+          (if error
+            (throw error)
+            (let [write-result
+                  (try
+                    (k/assoc store coordination-key value
+                             (assoc io-opts :expected-revision revision))
+                    nil
+                    (catch #?(:clj Throwable :cljs js/Error) e e))]
+              (cond
+                (revision-mismatch? write-result)
+                (if (< attempt 63)
+                  (recur (inc attempt))
+                  (throw (contention-error attempt)))
+
+                (error-value? write-result) (throw write-result)
+                :else value)))))
+      (async/go-loop [attempt 0]
+        (let [read-result
+              (async/<! (k/get store coordination-key nil
+                               (assoc io-opts :with-revision? true)))]
+          (if (error-value? read-result)
+            read-result
+            (let [[stored revision] read-result
+                  {:keys [value error]} (apply-state-update f stored require-active?)]
+              (if error
+                error
+                (let [write-result
+                      (async/<! (k/assoc
+                                 store coordination-key value
+                                 (assoc io-opts :expected-revision revision)))]
+                  (cond
+                    (revision-mismatch? write-result)
+                    (if (< attempt 63)
+                      (recur (inc attempt))
+                      (contention-error attempt))
+
+                    (error-value? write-result) write-result
+                    :else value))))))))))
 
 (defn state
   "Read the durable coordination state, or the empty initial state."
@@ -102,17 +201,52 @@
       (or (<?- (k/get store coordination-key nil opts))
           (initial-state)))))))
 
-(defn begin-publication!
-  "Acquire a short-lived root-publication token.
+(defn active?
+  "Has this store completed the explicit coordination bootstrap? Unlike
+   [[state]], this distinguishes an absent record from an active empty state."
+  ([store] (active? store {:sync? false}))
+  ([store opts]
+   (async+sync
+    (:sync? opts) *default-sync-translation*
+    (go-try-
+     (boolean (<?- (k/get store coordination-key nil opts)))))))
 
-   Throws `:konserve/gc-collection-active` instead of waiting when a collector
-   owns the fence. The caller may retry. Hold the token only around publication
-   of branch heads, pins, aliases, or other pointers that can name old objects;
-   long value/build work happens before it."
+(defn activate!
+  "Persist the empty coordination record and make coordinated collection
+   mandatory for this store.
+
+   Bootstrap this once while no legacy uncoordinated sweep is running. A
+   tokenless `konserve.gc/sweep!` remains available only while this record is
+   absent, so old stores can be migrated deliberately rather than changing
+   semantics merely by upgrading a dependency."
+  ([store] (activate! store {}))
+  ([store opts]
+   (update-state! store identity opts)))
+
+(defn begin-publication!
+  "Acquire a root-publication token.
+
+   The store must first be initialized with [[activate!]] during a quiescent
+   migration. Throws `:konserve/gc-collection-active` instead of waiting when a
+   collector owns the fence. The caller may retry.
+
+   If the operation writes NEW unreachable values, acquire this token BEFORE
+   the first such write and retain it until the branch head, pin, alias, or
+   equivalent root has landed. Preparing values before the token recreates the
+   cross-process values-then-pointer sweep race this protocol closes. If the
+   operation only publishes a pointer to an already-complete OLD object graph,
+   acquiring immediately before the pointer write is sufficient. Expensive CPU
+   preparation that writes nothing may happen before acquisition."
   ([store] (begin-publication! store {}))
   ([store {:keys [owner] :as opts}]
-   (let [id (new-id)
-         token {:kind :publication :id id}]
+   (let [id (or (:id opts) (new-id))
+         required-domain (or (:required-domain opts) :process)
+         context (token-context store required-domain)
+         token (merge {:kind :publication :id id} context)]
+     (when-not (uuid? id)
+       (throw (ex-info "A GC publication id must be a UUID."
+                       {:type :konserve/invalid-gc-coordination-token
+                        :id id})))
      (async+sync
       (:sync? opts) *default-sync-translation*
       (go-try-
@@ -124,66 +258,129 @@
                   (ex-info "A GC collection currently fences root publication."
                            {:type :konserve/gc-collection-active
                             :collector collector})))
-               (assoc-in state [:publishers id]
-                         {:id id :owner owner :started-at (now)}))
-             opts))
+               (if-let [publisher (get-in state [:publishers id])]
+                 (do
+                   (when-not (= (merge {:owner owner} context)
+                                (select-keys publisher
+                                             [:owner :required-domain :store-id]))
+                     (throw
+                      (ex-info "A GC publication id is already owned by another operation."
+                               {:type :konserve/gc-coordination-id-collision
+                                :id id :publisher publisher})))
+                   state)
+                 (assoc-in state [:publishers id]
+                           (merge {:id id :owner owner :started-at (now)}
+                                  context))))
+             (assoc opts :require-active? true)))
        token)))))
+
+(defn assert-publication!
+  "Raise unless `token` still owns a durable publication slot. Long-running
+   publishers must call this immediately before landing the root pointer."
+  ([store token] (assert-publication! store token {:sync? false}))
+  ([store {:keys [kind id] :as token} opts]
+   (when-not (and (= :publication kind) (uuid? id))
+     (throw (ex-info "Invalid GC publication token."
+                     {:type :konserve/invalid-gc-coordination-token
+                      :token token})))
+   (require-token-context! store token)
+   (async+sync
+    (:sync? opts) *default-sync-translation*
+    (go-try-
+     (let [publisher (get-in (<?- (state store opts)) [:publishers id])]
+       (when-not (= (select-keys token [:required-domain :store-id])
+                    (select-keys publisher [:required-domain :store-id]))
+         (throw
+          (ex-info "The GC publication token no longer owns a durable slot."
+                   {:type :konserve/gc-publication-token-lost
+                    :token token :publisher publisher}))))
+     token))))
 
 (defn end-publication!
   "Release a publication token. Idempotent after the token has disappeared."
   ([store token] (end-publication! store token {}))
   ([store {:keys [kind id] :as token} opts]
-   (when-not (and (= :publication kind) (some? id))
+   (when-not (and (= :publication kind) (uuid? id))
      (throw (ex-info "Invalid GC publication token."
                      {:type :konserve/invalid-gc-coordination-token
                       :token token})))
-   (update-state! store #(update % :publishers dissoc id) opts)))
+   (require-token-context! store token)
+   (update-state! store #(update % :publishers dissoc id)
+                  (assoc opts
+                         :required-domain (:required-domain token)
+                         :require-active? true))))
 
 (defn begin-collection!
   "Acquire the exclusive collector token.
 
-   Throws when a publisher or collector is active. After acquisition, take the
-   authoritative root snapshot, mark, sweep, then call `end-collection!` in a
-   `finally`. The returned epoch is diagnostic and will support backend-fenced
-   deletion later; it is not presently a recoverable lease."
+   The store must first be initialized with [[activate!]] during a quiescent
+   migration. Throws when a publisher or collector is active. After acquisition,
+   take the authoritative root snapshot, mark, sweep, then call
+   `end-collection!`. Prefer [[run-collection!]] so asynchronous work is awaited.
+   The returned epoch is diagnostic and will support backend-fenced deletion
+   later; it is not presently a recoverable lease."
   ([store] (begin-collection! store {}))
   ([store {:keys [owner] :as opts}]
-   (let [id (new-id)
+   (let [id (or (:id opts) (new-id))
+         required-domain (or (:required-domain opts) :process)
+         context (token-context store required-domain)
          token* (atom nil)]
+     (when-not (uuid? id)
+       (throw (ex-info "A GC collection id must be a UUID."
+                       {:type :konserve/invalid-gc-coordination-token
+                        :id id})))
      (async+sync
       (:sync? opts) *default-sync-translation*
       (go-try-
        (<?- (update-state!
              store
              (fn [state]
-               (when-let [collector (:collector state)]
-                 (throw
-                  (ex-info "Another GC collection already owns the durable fence."
-                           {:type :konserve/gc-collection-active
-                            :collector collector})))
-               (when (seq (:publishers state))
-                 (throw
-                  (ex-info "Root publication is active; collection must retry."
-                           {:type :konserve/gc-publication-active
-                            :publishers (vals (:publishers state))})))
-               (let [epoch (inc (:epoch state))
-                     token {:kind :collection :id id :epoch epoch}]
-                 (reset! token* token)
-                 (assoc state
-                        :epoch epoch
-                        :collector {:id id :epoch epoch :owner owner
-                                    :started-at (now)})))
-             opts))
+               (if-let [collector (:collector state)]
+                 (if (= id (:id collector))
+                   (do
+                     (when-not (= (merge {:owner owner} context)
+                                  (select-keys collector
+                                               [:owner :required-domain :store-id]))
+                       (throw
+                        (ex-info "A GC collection id is already owned by another operation."
+                                 {:type :konserve/gc-coordination-id-collision
+                                  :id id :collector collector})))
+                     (reset! token* (merge {:kind :collection
+                                            :id id
+                                            :epoch (:epoch collector)}
+                                           context))
+                     state)
+                   (throw
+                    (ex-info "Another GC collection already owns the durable fence."
+                             {:type :konserve/gc-collection-active
+                              :collector collector})))
+                 (do
+                   (when (seq (:publishers state))
+                     (throw
+                      (ex-info "Root publication is active; collection must retry."
+                               {:type :konserve/gc-publication-active
+                                :publishers (vals (:publishers state))})))
+                   (let [epoch (inc (:epoch state))
+                         token (merge {:kind :collection :id id :epoch epoch}
+                                      context)]
+                     (reset! token* token)
+                     (assoc state
+                            :epoch epoch
+                            :collector (merge {:id id :epoch epoch :owner owner
+                                               :started-at (now)}
+                                              context))))))
+             (assoc opts :require-active? true)))
        @token*)))))
 
 (defn end-collection!
   "Release the exclusive collector token. A different token cannot release it."
   ([store token] (end-collection! store token {}))
   ([store {:keys [kind id epoch] :as token} opts]
-   (when-not (and (= :collection kind) (some? id) (nat-int? epoch))
+   (when-not (and (= :collection kind) (uuid? id) (nat-int? epoch))
      (throw (ex-info "Invalid GC collection token."
                      {:type :konserve/invalid-gc-coordination-token
                       :token token})))
+   (require-token-context! store token)
    (update-state!
     store
     (fn [state]
@@ -195,16 +392,19 @@
                     {:type :konserve/gc-collection-token-mismatch
                      :token token :collector collector})))
         state))
-    opts)))
+    (assoc opts
+           :required-domain (:required-domain token)
+           :require-active? true))))
 
 (defn assert-collection!
   "Raise unless `token` still owns the durable collection fence."
   ([store token] (assert-collection! store token {:sync? false}))
   ([store {:keys [kind id epoch] :as token} opts]
-   (when-not (and (= :collection kind) (some? id) (nat-int? epoch))
+   (when-not (and (= :collection kind) (uuid? id) (nat-int? epoch))
      (throw (ex-info "Invalid GC collection token."
                      {:type :konserve/invalid-gc-coordination-token
                       :token token})))
+   (require-token-context! store token)
    (async+sync
     (:sync? opts) *default-sync-translation*
     (go-try-
@@ -215,3 +415,97 @@
                    {:type :konserve/gc-collection-token-lost
                     :token token :collector collector})))
        token)))))
+
+(defn assert-sweep-authorized!
+  "Authorize one destructive sweep step.
+
+   A collection token is mandatory after [[activate!]]. Tokenless sweep remains
+   available only for a legacy store whose coordination record is absent. This
+   deliberately fails closed so an independent collector cannot bypass an
+   active publisher.
+
+   The first activation must be bootstrapped while no legacy sweep is running;
+   no protocol layered above arbitrary delete operations can fence a deletion
+   that began before the protocol existed."
+  ([store token] (assert-sweep-authorized! store token {:sync? false}))
+  ([store token opts]
+   (if token
+     (assert-collection! store token opts)
+     (async+sync
+      (:sync? opts) *default-sync-translation*
+      (go-try-
+       (when (<?- (k/get store coordination-key nil opts))
+         (throw
+          (ex-info "This store has durable GC coordination enabled; sweep requires a collection token."
+                   {:type :konserve/gc-coordination-token-required})))
+       nil)))))
+
+(defn- invoke-managed [f token opts]
+  (try
+    (f token opts)
+    (catch #?(:clj Throwable :cljs js/Error) e e)))
+
+(defn- combined-lifecycle-error [work-error release-error]
+  (ex-info "A managed GC operation and its fence release both failed."
+           {:type :konserve/gc-coordination-operation-and-release-failed
+            :work-error work-error
+            :release-error release-error}))
+
+(defn- finish-managed [result release-result]
+  (cond
+    (and (error-value? result) (error-value? release-result))
+    (combined-lifecycle-error result release-result)
+
+    (error-value? result) result
+    (error-value? release-result) release-result
+    :else result))
+
+(defn- run-managed!
+  [begin! end! store f opts]
+  (if (:sync? opts)
+    (let [token (begin! store opts)
+          invoked (invoke-managed f token opts)
+          result (if (and (not (error-value? invoked)) (read-port? invoked))
+                   (callback-shape-error "a value in sync mode, not a channel" invoked)
+                   invoked)
+          release-result (try
+                           (end! store token opts)
+                           nil
+                           (catch #?(:clj Throwable :cljs js/Error) e e))
+          outcome (finish-managed result release-result)]
+      (if (error-value? outcome) (throw outcome) outcome))
+    (async/go
+      (let [token-result (async/<! (begin! store opts))]
+        (if (error-value? token-result)
+          token-result
+          (let [token token-result
+                pending (invoke-managed f token opts)
+                result (cond
+                         (error-value? pending) pending
+                         (not (read-port? pending))
+                         (callback-shape-error "a core.async channel in async mode" pending)
+                         :else (async/<! pending))
+                release-result (async/<! (end! store token opts))]
+            (finish-managed result release-result)))))))
+
+(defn run-publication!
+  "Acquire a publication token, run `f`, await its result, and then release.
+
+   `f` receives `[token io-opts]`. In async mode it must return a channel; in
+   sync mode it returns a value. The token spans the complete unreferenced-value
+   interval, but `f` must still call [[assert-publication!]] immediately before
+   landing its root pointer."
+  ([store f] (run-publication! store f {}))
+  ([store f opts]
+   (run-managed! begin-publication! end-publication! store f opts)))
+
+(defn run-collection!
+  "Acquire the exclusive token, run `f`, await its result, and only then release.
+
+   `f` receives `[token io-opts]`. In async mode it must return a channel; in
+   sync mode it returns a value. Prefer this bracket to a caller-side
+   `try/finally`: merely creating an async sweep channel is not completion, and
+   releasing at that point reopens publication while deletes are still running."
+  ([store f] (run-collection! store f {}))
+  ([store f opts]
+   (run-managed! begin-collection! end-collection! store f opts)))

--- a/test/konserve/gc_coordination_test.clj
+++ b/test/konserve/gc_coordination_test.clj
@@ -1,12 +1,14 @@
 (ns konserve.gc-coordination-test
-  (:require [clojure.core.async :refer [<!!]]
+  (:require [clojure.core.async :as async :refer [<!! >!!]]
             [clojure.test :refer [deftest is testing]]
             [konserve.core :as k]
             [konserve.filestore :refer [connect-fs-store delete-store]]
             [konserve.gc :as gc]
             [konserve.gc-coordination :as coord]
-            [konserve.memory :refer [new-mem-store]])
-  (:import [java.util Date]))
+            [konserve.memory :refer [new-mem-store]]
+            [konserve.protocols :as kp])
+  (:import [java.util Date]
+           [java.util.concurrent CountDownLatch]))
 
 (defn- take!! [x]
   (let [v (<!! x)]
@@ -15,10 +17,28 @@
 (defn- thrown-data [f]
   (try (f) nil (catch clojure.lang.ExceptionInfo e (ex-data e))))
 
+(defn- delivered [value]
+  (let [ch (async/promise-chan)]
+    (async/put! ch value)
+    ch))
+
+(deftest acquisition-requires-explicit-quiescent-activation
+  (let [store (new-mem-store (atom {}) {:sync? true})]
+    (is (false? (take!! (coord/active? store))))
+    (is (= :konserve/gc-coordination-not-active
+           (:type (thrown-data
+                   #(take!! (coord/begin-publication! store))))))
+    (is (= :konserve/gc-coordination-not-active
+           (:type (thrown-data
+                   #(take!! (coord/begin-collection! store))))))
+    (take!! (coord/activate! store))
+    (is (true? (take!! (coord/active? store))))))
+
 (deftest publication-and-collection-exclude-one-another
   (let [backing (atom {})
         writer-store (new-mem-store backing {:sync? true})
         collector-store (new-mem-store backing {:sync? true})]
+    (take!! (coord/activate! writer-store))
     (testing "a publisher visible through another store handle fences collection"
       (let [publication (take!! (coord/begin-publication! writer-store))]
         (is (= :konserve/gc-publication-active
@@ -44,6 +64,7 @@
 
 (deftest only-the-owning-collector-token-can-release-the-fence
   (let [store (new-mem-store (atom {}) {:sync? true})
+        _ (take!! (coord/activate! store))
         token (take!! (coord/begin-collection! store))
         impostor (assoc token :id (random-uuid))]
     (is (= :konserve/gc-collection-token-mismatch
@@ -66,6 +87,7 @@
 
 (deftest synchronous-api-and-concurrent-publishers
   (let [store (new-mem-store (atom {}) {:sync? true})
+        _ (coord/activate! store {:sync? true})
         tokens (doall (map deref
                            (repeatedly
                             20
@@ -83,6 +105,7 @@
 (deftest sweep-preserves-coordination-and-validates-the-token
   (let [store (new-mem-store (atom {}) {:sync? true})
         cutoff (Date. Long/MAX_VALUE)]
+    (take!! (coord/activate! store))
     (k/assoc store :keep :live {:sync? true})
     (k/assoc store :garbage :dead {:sync? true})
     (let [collection (take!! (coord/begin-collection! store))]
@@ -100,11 +123,149 @@
       (is (= :dead (k/get store :later-garbage nil {:sync? true}))
           "a lost token aborts before deleting anything"))))
 
+(deftest activated-coordination-cannot-be-bypassed-by-tokenless-sweep
+  (let [store (new-mem-store (atom {}) {:sync? true})
+        cutoff (Date. Long/MAX_VALUE)]
+    (take!! (coord/activate! store))
+    (k/assoc store :candidate :unpublished {:sync? true})
+    (is (= :konserve/gc-coordination-token-required
+           (:type (thrown-data
+                   #(take!! (gc/sweep! store #{} cutoff))))))
+    (is (= :unpublished (k/get store :candidate nil {:sync? true})))
+    (let [collection (take!! (coord/begin-collection! store))]
+      (is (= #{:candidate}
+             (take!! (gc/sweep! store #{} cutoff 1000
+                                {:coordination-token collection}))))
+      (take!! (coord/end-collection! store collection)))))
+
+(deftest acquire-is-idempotent-by-caller-operation-id
+  (let [store (new-mem-store (atom {}) {:sync? true})
+        publication-id (random-uuid)
+        collection-id (random-uuid)
+        publication-opts {:id publication-id :owner {:job :writer}}]
+    (take!! (coord/activate! store))
+    (let [first-token (take!! (coord/begin-publication! store publication-opts))
+          retry-token (take!! (coord/begin-publication! store publication-opts))]
+      (is (= first-token retry-token))
+      (is (= 1 (count (:publishers (take!! (coord/state store)))))
+          "a lost response can be retried without leaking another slot")
+      (take!! (coord/assert-publication! store first-token))
+      (take!! (coord/end-publication! store first-token)))
+    (let [opts {:id collection-id :owner {:job :collector}}
+          first-token (take!! (coord/begin-collection! store opts))
+          retry-token (take!! (coord/begin-collection! store opts))]
+      (is (= first-token retry-token))
+      (take!! (coord/end-collection! store first-token)))))
+
+(deftest tokens-are-bound-to-store-identity
+  (let [id-a (random-uuid)
+        id-b (random-uuid)
+        store-a (assoc (new-mem-store (atom {}) {:sync? true})
+                       kp/store-config-key {:id id-a})
+        store-b (assoc (new-mem-store (atom {}) {:sync? true})
+                       kp/store-config-key {:id id-b})
+        _ (take!! (coord/activate! store-a))
+        token (take!! (coord/begin-publication! store-a))]
+    (is (= :konserve/gc-coordination-store-mismatch
+           (:type (thrown-data
+                   #(take!! (coord/assert-publication! store-b token))))))
+    (take!! (coord/end-publication! store-a token))))
+
+(deftest managed-async-collection-releases-only-after-work-delivers
+  (let [store (new-mem-store (atom {}) {:sync? true})
+        started (async/promise-chan)
+        finish (async/promise-chan)
+        _ (take!! (coord/activate! store))
+        result (coord/run-collection!
+                store
+                (fn [token _]
+                  (async/put! started token)
+                  finish))]
+    (is (= :collection (:kind (<!! started))))
+    (is (= :konserve/gc-collection-active
+           (:type (thrown-data
+                   #(take!! (coord/begin-publication! store))))))
+    (>!! finish :finished)
+    (is (= :finished (take!! result)))
+    (let [publication (take!! (coord/begin-publication! store))]
+      (take!! (coord/end-publication! store publication)))))
+
+(deftest managed-async-publication-releases-only-after-work-delivers
+  (let [store (new-mem-store (atom {}) {:sync? true})
+        started (async/promise-chan)
+        finish (async/promise-chan)
+        _ (take!! (coord/activate! store))
+        result (coord/run-publication!
+                store
+                (fn [token _]
+                  (async/put! started token)
+                  finish))]
+    (is (= :publication (:kind (<!! started))))
+    (is (= :konserve/gc-publication-active
+           (:type (thrown-data
+                   #(take!! (coord/begin-collection! store))))))
+    (>!! finish :published)
+    (is (= :published (take!! result)))
+    (let [collection (take!! (coord/begin-collection! store))]
+      (take!! (coord/end-collection! store collection)))))
+
+(deftest managed-collection-releases-after-callback-failures
+  (let [store (new-mem-store (atom {}) {:sync? true})
+        _ (take!! (coord/activate! store))
+        thrown (ex-info "callback threw" {:case :throw})
+        delivered-error (ex-info "callback delivered" {:case :deliver})]
+    (is (= :throw
+           (:case (ex-data
+                   (<!! (coord/run-collection!
+                         store (fn [_ _] (throw thrown))))))))
+    (is (nil? (:collector (take!! (coord/state store)))))
+    (is (= :deliver
+           (:case (ex-data
+                   (<!! (coord/run-collection!
+                         store (fn [_ _] (delivered delivered-error))))))))
+    (is (nil? (:collector (take!! (coord/state store)))))))
+
+(deftest managed-collection-reports-work-and-release-failures
+  (let [store (new-mem-store (atom {}) {:sync? true})
+        _ (take!! (coord/activate! store))
+        work-error (ex-info "work failed" {:case :work})
+        release-error (ex-info "release failed" {:case :release})]
+    (with-redefs [coord/end-collection!
+                  (fn [_ _ _] (delivered release-error))]
+      (let [result (<!! (coord/run-collection!
+                         store (fn [_ _] (delivered work-error))))]
+        (is (= :konserve/gc-coordination-operation-and-release-failed
+               (:type (ex-data result))))
+        (is (= work-error (:work-error (ex-data result))))
+        (is (= release-error (:release-error (ex-data result))))))))
+
+(deftest managed-brackets-reject-wrong-callback-shapes-and-release
+  (doseq [[label run! active-key]
+          [[:publication coord/run-publication! :publishers]
+           [:collection coord/run-collection! :collector]]]
+    (let [store (new-mem-store (atom {}) {:sync? true})
+          _ (take!! (coord/activate! store))
+          async-result (<!! (run! store (fn [_ _] :plain-value)))]
+      (is (= :konserve/gc-coordination-callback-shape
+             (:type (ex-data async-result)))
+          (str label " rejects a plain value in async mode"))
+      (is (empty? (get (take!! (coord/state store)) active-key))
+          (str label " async shape failure releases its fence"))
+      (is (= :konserve/gc-coordination-callback-shape
+             (:type
+              (thrown-data
+               #(run! store (fn [_ _] (delivered :later)) {:sync? true}))))
+          (str label " rejects a channel in sync mode"))
+      (is (empty? (get (take!! (coord/state store)) active-key))
+          (str label " sync shape failure releases its fence")))))
+
 (deftest filestore-handles-share-the-machine-domain-fence
   (let [folder (str "/tmp/konserve-gc-coordination-" (random-uuid))]
     (try
       (let [writer-store (take!! (connect-fs-store folder))
             collector-store (take!! (connect-fs-store folder))
+            _ (take!! (coord/activate!
+                       writer-store {:required-domain :machine}))
             publication
             (take!! (coord/begin-publication!
                      writer-store {:required-domain :machine}))]
@@ -124,4 +285,37 @@
                  (take!! (coord/assert-collection! writer-store collection))))
           (take!! (coord/end-collection!
                    collector-store collection {:required-domain :machine}))))
+      (finally (delete-store folder)))))
+
+(deftest filestore-cas-preserves-concurrent-publishers-across-handles
+  (let [folder (str "/tmp/konserve-gc-coordination-cas-" (random-uuid))]
+    (try
+      (let [store-a (take!! (connect-fs-store folder))
+            store-b (take!! (connect-fs-store folder))
+            n 24
+            ready (CountDownLatch. n)
+            start (CountDownLatch. 1)
+            _ (coord/activate! store-a {:sync? true :required-domain :machine})
+            futures
+            (mapv (fn [i]
+                    (future
+                      (.countDown ready)
+                      (.await start)
+                      (let [store (if (even? i) store-a store-b)]
+                        [store
+                         (coord/begin-publication!
+                          store {:sync? true
+                                 :required-domain :machine
+                                 :id (random-uuid)
+                                 :owner {:worker i}})])))
+                  (range n))]
+        (.await ready)
+        (.countDown start)
+        (let [acquired (mapv deref futures)]
+          (is (= n (count (:publishers
+                           (coord/state store-a {:sync? true}))))
+              "revision CAS must not lose a publisher registered through another handle")
+          (doseq [[store token] acquired]
+            (coord/end-publication!
+             store token {:sync? true :required-domain :machine}))))
       (finally (delete-store folder)))))

--- a/test/konserve/gc_coordination_test.clj
+++ b/test/konserve/gc_coordination_test.clj
@@ -1,0 +1,127 @@
+(ns konserve.gc-coordination-test
+  (:require [clojure.core.async :refer [<!!]]
+            [clojure.test :refer [deftest is testing]]
+            [konserve.core :as k]
+            [konserve.filestore :refer [connect-fs-store delete-store]]
+            [konserve.gc :as gc]
+            [konserve.gc-coordination :as coord]
+            [konserve.memory :refer [new-mem-store]])
+  (:import [java.util Date]))
+
+(defn- take!! [x]
+  (let [v (<!! x)]
+    (if (instance? Throwable v) (throw v) v)))
+
+(defn- thrown-data [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (ex-data e))))
+
+(deftest publication-and-collection-exclude-one-another
+  (let [backing (atom {})
+        writer-store (new-mem-store backing {:sync? true})
+        collector-store (new-mem-store backing {:sync? true})]
+    (testing "a publisher visible through another store handle fences collection"
+      (let [publication (take!! (coord/begin-publication! writer-store))]
+        (is (= :konserve/gc-publication-active
+               (:type (thrown-data
+                       #(take!! (coord/begin-collection! collector-store))))))
+        (take!! (coord/end-publication! writer-store publication))))
+
+    (testing "the collector fences old-root publication until release"
+      (let [collection (take!! (coord/begin-collection! collector-store))]
+        (is (= :konserve/gc-collection-active
+               (:type (thrown-data
+                       #(take!! (coord/begin-publication! writer-store))))))
+        (is (= (select-keys collection [:id :epoch])
+               (select-keys (:collector (take!! (coord/state writer-store)))
+                            [:id :epoch]))
+            "the durable state exposes the owning id and epoch")
+        (take!! (coord/end-collection! collector-store collection))
+        (let [publication (take!! (coord/begin-publication! writer-store))]
+          (take!! (coord/end-publication! writer-store publication)))))
+
+    (is (nil? (:collector (take!! (coord/state collector-store)))))
+    (is (empty? (:publishers (take!! (coord/state collector-store)))))))
+
+(deftest only-the-owning-collector-token-can-release-the-fence
+  (let [store (new-mem-store (atom {}) {:sync? true})
+        token (take!! (coord/begin-collection! store))
+        impostor (assoc token :id (random-uuid))]
+    (is (= :konserve/gc-collection-token-mismatch
+           (:type (thrown-data
+                   #(take!! (coord/end-collection! store impostor))))))
+    (is (some? (:collector (take!! (coord/state store))))
+        "the failed release left the real fence intact")
+    (take!! (coord/end-collection! store token))
+    (take!! (coord/end-collection! store token))
+    (is (nil? (:collector (take!! (coord/state store)))))))
+
+(deftest requested-coordination-domain-is-enforced
+  (let [store (new-mem-store (atom {}) {:sync? true})]
+    (is (= :process (k/conditional-write-domain store)))
+    (is (= :konserve/gc-coordination-domain-insufficient
+           (:type
+            (thrown-data
+             #(take!!
+               (coord/begin-collection! store {:required-domain :machine}))))))))
+
+(deftest synchronous-api-and-concurrent-publishers
+  (let [store (new-mem-store (atom {}) {:sync? true})
+        tokens (doall (map deref
+                           (repeatedly
+                            20
+                            #(future
+                               (coord/begin-publication! store {:sync? true})))))]
+    (is (= 20 (count (:publishers (coord/state store {:sync? true})))))
+    (doseq [token tokens]
+      (coord/end-publication! store token {:sync? true}))
+    (let [collection (coord/begin-collection! store {:sync? true})]
+      (is (= collection
+             (coord/assert-collection! store collection {:sync? true})))
+      (coord/end-collection! store collection {:sync? true}))
+    (is (empty? (:publishers (coord/state store {:sync? true}))))))
+
+(deftest sweep-preserves-coordination-and-validates-the-token
+  (let [store (new-mem-store (atom {}) {:sync? true})
+        cutoff (Date. Long/MAX_VALUE)]
+    (k/assoc store :keep :live {:sync? true})
+    (k/assoc store :garbage :dead {:sync? true})
+    (let [collection (take!! (coord/begin-collection! store))]
+      (is (= #{:garbage}
+             (take!! (gc/sweep! store #{:keep} cutoff 1000
+                                {:coordination-token collection}))))
+      (is (map? (k/get store coord/coordination-key nil {:sync? true})))
+      (take!! (coord/end-collection! store collection))
+      (k/assoc store :later-garbage :dead {:sync? true})
+      (is (= :konserve/gc-collection-token-lost
+             (:type
+              (thrown-data
+               #(take!! (gc/sweep! store #{} cutoff 1000
+                                   {:coordination-token collection}))))))
+      (is (= :dead (k/get store :later-garbage nil {:sync? true}))
+          "a lost token aborts before deleting anything"))))
+
+(deftest filestore-handles-share-the-machine-domain-fence
+  (let [folder (str "/tmp/konserve-gc-coordination-" (random-uuid))]
+    (try
+      (let [writer-store (take!! (connect-fs-store folder))
+            collector-store (take!! (connect-fs-store folder))
+            publication
+            (take!! (coord/begin-publication!
+                     writer-store {:required-domain :machine}))]
+        (is (= :machine (k/conditional-write-domain writer-store)))
+        (is (= :konserve/gc-publication-active
+               (:type
+                (thrown-data
+                 #(take!!
+                   (coord/begin-collection!
+                    collector-store {:required-domain :machine}))))))
+        (take!! (coord/end-publication!
+                 writer-store publication {:required-domain :machine}))
+        (let [collection
+              (take!! (coord/begin-collection!
+                       collector-store {:required-domain :machine}))]
+          (is (= collection
+                 (take!! (coord/assert-collection! writer-store collection))))
+          (take!! (coord/end-collection!
+                   collector-store collection {:required-domain :machine}))))
+      (finally (delete-store folder)))))


### PR DESCRIPTION
## Summary

- add an explicitly activated durable reader/writer fence between root publishers and one mark/sweep collector
- hold publication tokens across the full first-unreachable-write through root-publication interval
- serialize independent store handles with revision-bearing compare-and-set
- validate the exclusive token before enumeration and every destructive batch
- provide managed sync/async brackets that await callback completion and always release
- bind tokens to the caller-selected conditional-write domain and logical store id

## Why

The existing process-local GC guard protects new values before their pointer lands. It cannot protect another process, nor the inverse race: a branch, pin, or alias may publish a pointer to old objects after the collector marked roots but before sweep. A cutoff cannot help because those objects may be arbitrarily old.

Tokens deliberately do not expire. Destructive batches cannot yet be atomically fenced by the coordination record, so stealing an expired token would let a paused old owner resume after recovery. A crashed publisher or collector therefore fails closed and requires audited operator recovery.

Activation is explicit and must happen once during a quiescent migration. Before activation, existing tokenless collection remains compatible; after activation, tokenless sweep fails before enumeration. This avoids silently changing an old stores memory model merely by upgrading Konserve.

This PR provides the store-level primitive only. Datahike integration will acquire a publication token before creating unreachable immutable values, assert it immediately before publishing the root, and hold a collection token from the authoritative primary/external-root snapshot through all sweeps.

## Validation

- full JVM suite: 273 tests, 4,291 assertions, 0 failures
- focused coordination suite: 16 tests, 53 assertions, including concurrent publishers across independent file-store handles
- ClojureScript compilation of konserve.gc and its coordination dependency
- callback-shape, delivered/thrown error, combined cleanup-error, caller-id retry, store-id mismatch, explicit activation, tokenless sweep, and domain tests