### PR TITLE
Metrics from inside: every operation reports to registered sinks, no store wrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ All notable, user-visible changes to konserve are documented here.
 
 ### Added
 - **Metrics, without wrapping a store.** `konserve.metrics` reports every
-  operation to one process-wide sink — `(konserve.metrics/set-sink! f)`, a
-  `(fn [event])` — at three levels: `:api` (what a caller waits for, per
-  `get-in`/`assoc-in`/…), `:io` (the backend's own work per blob operation,
-  below the lock — the S3 round trip, the fsync — with bytes written), and
-  `:lock` (the wait for the in-process key lock). Events carry the store's
-  `:backend` and `:store-id`, which `connect-store`/`create-store` now also
-  stamp into a `DefaultStore`'s `:config`. No store changes identity or type,
-  every backend on `DefaultStore` is covered, and with no sink the cost is one
-  deref per operation.
+  operation to a process-wide registry of sinks — `(add-sink! id f)` /
+  `(remove-sink! id)`, each a `(fn [event])` — at three levels: `:api` (what
+  a caller waits for, per public function), `:io` (the backend's own work per
+  blob operation, below the lock — the S3 round trip, the fsync — with the
+  bytes a write serialized), and `:lock` (the wait for the in-process key
+  lock). Events carry the store's `:backend` and `:store-id`, which
+  `connect-store`/`create-store` now also stamp, namespaced, into a
+  `DefaultStore`'s `:config`. No store changes identity or type, every
+  backend on `DefaultStore` is covered, a throwing sink is logged and never
+  fails an operation, and with no sink the cost is one deref per measurement
+  site.
 
 ### Fixed
 - **Connecting to an existing IndexedDB store opens it again.** The previous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable, user-visible changes to konserve are documented here.
 
 ## Unreleased
 
+### Added
+- **Metrics, without wrapping a store.** `konserve.metrics` reports every
+  operation to one process-wide sink — `(konserve.metrics/set-sink! f)`, a
+  `(fn [event])` — at three levels: `:api` (what a caller waits for, per
+  `get-in`/`assoc-in`/…), `:io` (the backend's own work per blob operation,
+  below the lock — the S3 round trip, the fsync — with bytes written), and
+  `:lock` (the wait for the in-process key lock). Events carry the store's
+  `:backend` and `:store-id`, which `connect-store`/`create-store` now also
+  stamp into a `DefaultStore`'s `:config`. No store changes identity or type,
+  every backend on `DefaultStore` is covered, and with no sink the cost is one
+  deref per operation.
+
 ### Fixed
 - **Connecting to an existing IndexedDB store opens it again.** The previous
   fix (connect no longer writes) skipped `-create-store` for a store that

--- a/README.org
+++ b/README.org
@@ -450,6 +450,40 @@ like store synchronization, change logging, or triggering side effects.
 Hooks are invoked at the API layer (in =konserve.core=), so they work consistently
 across all store backends. Stores must implement the =PWriteHookStore= protocol.
 
+*** Metrics
+
+Every store operation reports to one process-wide sink, with no store wrapped
+and no store changing identity: the labels come from the store's own config.
+Install a sink — any =(fn [event])= — and every backend on =DefaultStore=
+(file, S3, GCS, JDBC, …) reports at three levels:
+
+#+BEGIN_SRC clojure
+  (require '[konserve.metrics :as metrics])
+
+  (metrics/set-sink! (fn [event] (println event)))
+  ;; {:backend :file :store-id #uuid "…" :op :assoc-in  :level :api  :nanos 812345}
+  ;; {:backend :file :store-id #uuid "…" :op :lock      :level :lock :nanos 2100}
+  ;; {:backend :file :store-id #uuid "…" :op :write-edn :level :io   :bytes 4096}
+  ;; {:backend :file :store-id #uuid "…" :op :write-edn :level :io   :nanos 640000}
+
+  (metrics/set-sink! nil)   ; off again; without a sink the cost is one deref per op
+#+END_SRC
+
+- =:api= is what a caller waits for — lock wait, serialization and I/O
+  together — one event per =get-in=, =assoc-in=, =bget=, =multi-assoc=, …,
+  with =:error= (the exception's class name) when the call threw.
+- =:io= is the backend alone, below the lock, per blob operation
+  (=:read-edn=, =:write-edn=, =:write-binary=, =:delete=) — the S3 round trip,
+  the fsync — plus a =:bytes= event for what a write serialized.
+- =:lock= is the wait for the in-process key lock, the number that explains
+  contention between writers.
+
+The =:backend= and =:store-id= labels are the =:backend= and =:id= of the
+config passed to =connect-store= / =create-store=; a store opened through a
+backend's own connect function has no id and is labelled by its backing's type.
+A sink aggregates as it likes — per =[backend store-id op]= histograms for
+Prometheus, or an atom in a test.
+
 *** Garbage Collection
 
 Konserve has a garbage collector that can be called manually when the store gets

--- a/README.org
+++ b/README.org
@@ -452,37 +452,50 @@ across all store backends. Stores must implement the =PWriteHookStore= protocol.
 
 *** Metrics
 
-Every store operation reports to one process-wide sink, with no store wrapped
-and no store changing identity: the labels come from the store's own config.
-Install a sink — any =(fn [event])= — and every backend on =DefaultStore=
-(file, S3, GCS, JDBC, …) reports at three levels:
+Every store operation reports to a process-wide registry of named sinks, with
+no store wrapped and no store changing identity: the labels come from the
+config the store was connected with. Register a sink — any =(fn [event])= —
+and every backend on =DefaultStore= (file, S3, GCS, JDBC, …) reports at three
+levels:
 
 #+BEGIN_SRC clojure
   (require '[konserve.metrics :as metrics])
 
-  (metrics/set-sink! (fn [event] (println event)))
-  ;; {:backend :file :store-id #uuid "…" :op :assoc-in  :level :api  :nanos 812345}
+  (metrics/add-sink! ::log (fn [event] (println event)))
   ;; {:backend :file :store-id #uuid "…" :op :lock      :level :lock :nanos 2100}
   ;; {:backend :file :store-id #uuid "…" :op :write-edn :level :io   :bytes 4096}
   ;; {:backend :file :store-id #uuid "…" :op :write-edn :level :io   :nanos 640000}
+  ;; {:backend :file :store-id #uuid "…" :op :assoc-in  :level :api  :nanos 812345}
 
-  (metrics/set-sink! nil)   ; off again; without a sink the cost is one deref per op
+  (metrics/remove-sink! ::log)
 #+END_SRC
 
 - =:api= is what a caller waits for — lock wait, serialization and I/O
-  together — one event per =get-in=, =assoc-in=, =bget=, =multi-assoc=, …,
-  with =:error= (the exception's class name) when the call threw.
+  together — one event per public function (=get-in=, =assoc-in=, =bget=,
+  =multi-assoc=, =keys=, …), with =:error= (the exception's class name) when
+  it threw. A call rejected before it reaches the store produces none; a
+  function that delegates (=get= to =get-in=) reports as what it delegates to.
 - =:io= is the backend alone, below the lock, per blob operation
-  (=:read-edn=, =:write-edn=, =:write-binary=, =:delete=) — the S3 round trip,
-  the fsync — plus a =:bytes= event for what a write serialized.
+  (=:read-edn=, =:write-edn=, =:write-binary=, =:delete=, =:multi-read=, …)
+  from the first byte of a backup copy or header read to the end of the move,
+  with the read of the old value before a write as =:read-old=; plus a
+  =:bytes= event for what a write serialized (metadata and value; not the
+  header, not a streamed binary).
 - =:lock= is the wait for the in-process key lock, the number that explains
-  contention between writers.
+  contention between writers; a lock-free store has no wait and no event.
+
+Two rules for a sink, because it runs on the operation's own thread: it must
+be thread-safe (events from concurrent operations interleave; each is
+self-contained, so aggregation needs no ordering) and non-blocking — count
+into atomics, or hand events to a buffered channel drained elsewhere. A sink
+that throws is logged and skipped; it never fails the operation it observed.
 
 The =:backend= and =:store-id= labels are the =:backend= and =:id= of the
 config passed to =connect-store= / =create-store=; a store opened through a
-backend's own connect function has no id and is labelled by its backing's type.
-A sink aggregates as it likes — per =[backend store-id op]= histograms for
-Prometheus, or an atom in a test.
+backend's own connect function has no id and is labelled by its backing's
+type. With no sink registered the cost is one deref per measurement site and
+nothing else. A sink aggregates as it likes — per =[backend store-id op]=
+histograms for Prometheus, or an atom in a test.
 
 *** Garbage Collection
 

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -238,9 +238,9 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :exists? :api
-                                             (<?- (maybe-go-locked
-                                                   store key
-                                                   (<?- (-exists? store key opts))))))))
+                                             (maybe-go-locked
+                                              store key
+                                              (<?- (-exists? store key opts)))))))
 
 (defn get-in
   "Returns the value stored described by key. Returns nil if the key
@@ -262,9 +262,9 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :get-in :api
-                                             (<?- (maybe-go-locked
-                                                   store (first key-vec)
-                                                   (<?- (-get-in store key-vec not-found opts))))))))
+                                             (maybe-go-locked
+                                              store (first key-vec)
+                                              (<?- (-get-in store key-vec not-found opts)))))))
 
 (defn get
   "Returns the value stored described by key. Returns nil if the key
@@ -296,12 +296,12 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :get-meta :api
-                                             (<?- (maybe-go-locked
-                                                   store key
-                                                   (let [a (<?- (-get-meta store key opts))]
-                                                     (if (some? a)
-                                                       a
-                                                       not-found))))))))
+                                             (maybe-go-locked
+                                              store key
+                                              (let [a (<?- (-get-meta store key opts))]
+                                                (if (some? a)
+                                                  a
+                                                  not-found)))))))
 
 (def absent
   "The `:expected-revision` that means THE KEY MUST NOT EXIST — the create half of
@@ -375,7 +375,9 @@
    (when-not (conditional-write? store)
      (throw (ex-info "This store has no revisions to read: it cannot make a write conditional on one."
                      {:type :konserve/conditional-write-unsupported :store (type store)})))
-   (-revision store key opts)))
+   (if (:sync? opts)
+     (konserve.metrics/measured store :revision :api (-revision store key opts))
+     (konserve.metrics/measured-go store :revision :api (-revision store key opts)))))
 
 (defn check-conditional-supported!
   "Throw unless `store` can honour an `:expected-revision` in `opts`.
@@ -474,11 +476,11 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :update-in :api
-                                             (<?- (go-locked
-                                                   store (first key-vec)
-                                                   (let [base (partial meta-update (first key-vec) :edn)
-                                                         mfn  (if meta-up-fn (fn [old] (meta-up-fn (base old))) base)
-                                                         result (<?- (-update-in store key-vec mfn up-fn opts))
+                                             (go-locked
+                                              store (first key-vec)
+                                              (let [base (partial meta-update (first key-vec) :edn)
+                                                    mfn  (if meta-up-fn (fn [old] (meta-up-fn (base old))) base)
+                                                    result (<?- (-update-in store key-vec mfn up-fn opts))
                       ;; `:with-revision?` makes the result `[[old new] revision]`
                       ;; rather than `[old new]`, so destructuring it as the plain
                       ;; shape put the REVISION TOKEN in the hook's `:value` — and
@@ -486,13 +488,13 @@
                       ;; would replicate the token as the key's data. The hook
                       ;; reports the value either way; the revision is the caller's
                       ;; business, not the replica's.
-                                                         [old-val new-val] (if (:with-revision? opts) (first result) result)]
-                                                     (invoke-write-hooks! store {:api-op :update-in
-                                                                                 :key (first key-vec)
-                                                                                 :key-vec key-vec
-                                                                                 :old-value old-val
-                                                                                 :value new-val})
-                                                     result)))))))
+                                                    [old-val new-val] (if (:with-revision? opts) (first result) result)]
+                                                (invoke-write-hooks! store {:api-op :update-in
+                                                                            :key (first key-vec)
+                                                                            :key-vec key-vec
+                                                                            :old-value old-val
+                                                                            :value new-val})
+                                                result))))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn update
@@ -536,16 +538,16 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :assoc-in :api
-                                             (<?- (go-locked
-                                                   store (first key-vec)
-                                                   (let [base   (partial meta-update (first key-vec) :edn)
-                                                         mfn    (if meta-up-fn (fn [old] (meta-up-fn (base old))) base)
-                                                         result (<?- (-assoc-in store key-vec mfn val opts))]
-                                                     (invoke-write-hooks! store {:api-op :assoc-in
-                                                                                 :key (first key-vec)
-                                                                                 :key-vec key-vec
-                                                                                 :value val})
-                                                     result)))))))
+                                             (go-locked
+                                              store (first key-vec)
+                                              (let [base   (partial meta-update (first key-vec) :edn)
+                                                    mfn    (if meta-up-fn (fn [old] (meta-up-fn (base old))) base)
+                                                    result (<?- (-assoc-in store key-vec mfn val opts))]
+                                                (invoke-write-hooks! store {:api-op :assoc-in
+                                                                            :key (first key-vec)
+                                                                            :key-vec key-vec
+                                                                            :value val})
+                                                result))))))
 
 (defn assoc
   "Associates the key to the value. This is a simple top-level overwrite
@@ -577,15 +579,15 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :assoc :api
-                                             (<?- (maybe-go-locked
-                                                   store key
-                                                   (let [mfn    (if meta
-                                                                  (fn [old] (clojure.core/merge meta (meta-update key :edn old)))
-                                                                  (partial meta-update key :edn))
-                                                         result (<?- (-assoc-in store [key] mfn val opts))]
-                                                     (invoke-write-hooks! store (cond-> {:api-op :assoc :key key :value val}
-                                                                                  meta (clojure.core/assoc :meta meta)))
-                                                     result)))))))
+                                             (maybe-go-locked
+                                              store key
+                                              (let [mfn    (if meta
+                                                             (fn [old] (clojure.core/merge meta (meta-update key :edn old)))
+                                                             (partial meta-update key :edn))
+                                                    result (<?- (-assoc-in store [key] mfn val opts))]
+                                                (invoke-write-hooks! store (cond-> {:api-op :assoc :key key :value val}
+                                                                             meta (clojure.core/assoc :meta meta)))
+                                                result))))))
 
 (defn multi-get
   "Atomically retrieves multiple values by keys.
@@ -630,21 +632,21 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :multi-get :api
-                                             (<?- (go-try-
-                                                   (try
-                                                     (<?- (-multi-get store keys opts))
-                                                     (catch #?(:clj Exception :cljs js/Error) e
+                                             (go-try-
+                                              (try
+                                                (<?- (-multi-get store keys opts))
+                                                (catch #?(:clj Exception :cljs js/Error) e
                     ;; Backend might throw an exception indicating it doesn't support multi-key operations
                     ;; even though the store implements the protocol
-                                                       #?(:clj
-                                                          (if (and (instance? clojure.lang.ExceptionInfo e)
-                                                                   (= :not-supported (:type (ex-data e))))
-                                                            (throw (ex-info "Backing store does not support multi-key operations"
-                                                                            {:store-type (type store)
-                                                                             :cause e
-                                                                             :reason (:reason (ex-data e))}))
-                                                            (throw e))
-                                                          :cljs (throw e))))))))))
+                                                  #?(:clj
+                                                     (if (and (instance? clojure.lang.ExceptionInfo e)
+                                                              (= :not-supported (:type (ex-data e))))
+                                                       (throw (ex-info "Backing store does not support multi-key operations"
+                                                                       {:store-type (type store)
+                                                                        :cause e
+                                                                        :reason (:reason (ex-data e))}))
+                                                       (throw e))
+                                                     :cljs (throw e)))))))))
 
 (defn uniform-meta
   "Build a per-key meta map applying the same `meta` to every key — a convenience
@@ -757,12 +759,12 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :multi-assoc :api
-                                             (<?- (go-try-
-                                                   (let [meta-all (:meta-all opts)
-                                                         _ (when (and meta meta-all)
-                                                             (throw (#?(:clj ex-info :cljs js/Error.)
-                                                                     "Pass either a per-key `meta` or `:meta-all`, not both"
-                                                                     {:type :konserve/ambiguous-meta})))
+                                             (go-try-
+                                              (let [meta-all (:meta-all opts)
+                                                    _ (when (and meta meta-all)
+                                                        (throw (#?(:clj ex-info :cljs js/Error.)
+                                                                "Pass either a per-key `meta` or `:meta-all`, not both"
+                                                                {:type :konserve/ambiguous-meta})))
                       ;; UNIFORM ANNOTATION NEEDS NO KEYS, and that is the whole
                       ;; point of `:meta-all`. `uniform-meta` existed to turn one
                       ;; annotation into a per-key map, which meant DERIVING THE
@@ -771,13 +773,13 @@
                       ;; `(uniform-meta (keys m) ..)` on `{[:a 1] v}` produced
                       ;; `{:a ..}` and the annotation was silently dropped.
                       ;; Naming the two intents removes the guess entirely.
-                                                         mfn    (cond
-                                                                  meta-all
-                                                                  (fn [key type old] (clojure.core/merge meta-all (meta-update key type old)))
-                                                                  meta
+                                                    mfn    (cond
+                                                             meta-all
+                                                             (fn [key type old] (clojure.core/merge meta-all (meta-update key type old)))
+                                                             meta
                                ;; per-key meta map: `(get meta key)` (nil ⇒ just the built meta)
-                                                                  (fn [key type old] (clojure.core/merge (clojure.core/get meta key) (meta-update key type old)))
-                                                                  :else meta-update)
+                                                             (fn [key type old] (clojure.core/merge (clojure.core/get meta key) (meta-update key type old)))
+                                                             :else meta-update)
                       ;; A `meta` MAP THAT NAMES NO KEY OF THIS BATCH IS ALWAYS A
                       ;; MISTAKE, and it used to be a silent one: the write
                       ;; succeeded and the annotation vanished. `uniform-meta`
@@ -792,31 +794,31 @@
                       ;; is the documented mixed-batch case -- immutable nodes
                       ;; plus the mutable pointer that makes them reachable --
                       ;; so a single overlapping key is enough to be intentional.
-                                                         _ (when (seq meta)
-                                                             (let [ks (set (kv-keys kvs))]
-                                                               (when-not (some ks (clojure.core/keys meta))
-                                                                 (throw (#?(:clj ex-info :cljs js/Error.)
-                                                                         (str "multi-assoc: none of `meta`'s keys appear in `kvs`, "
-                                                                              "so no value would receive it. If this came from "
-                                                                              "`uniform-meta`, pass the kv-map itself, name the keys, "
-                                                                              "or use {:meta-all m} in opts.")
-                                                                         {:type :konserve/meta-keys-disjoint
-                                                                          :meta-keys (vec (clojure.core/keys meta))
-                                                                          :kvs-keys (vec ks)})))))
-                                                         result (try
-                                                                  (<?- (-multi-assoc store kvs mfn opts))
-                                                                  (catch #?(:clj Exception :cljs js/Error) e
+                                                    _ (when (seq meta)
+                                                        (let [ks (set (kv-keys kvs))]
+                                                          (when-not (some ks (clojure.core/keys meta))
+                                                            (throw (#?(:clj ex-info :cljs js/Error.)
+                                                                    (str "multi-assoc: none of `meta`'s keys appear in `kvs`, "
+                                                                         "so no value would receive it. If this came from "
+                                                                         "`uniform-meta`, pass the kv-map itself, name the keys, "
+                                                                         "or use {:meta-all m} in opts.")
+                                                                    {:type :konserve/meta-keys-disjoint
+                                                                     :meta-keys (vec (clojure.core/keys meta))
+                                                                     :kvs-keys (vec ks)})))))
+                                                    result (try
+                                                             (<?- (-multi-assoc store kvs mfn opts))
+                                                             (catch #?(:clj Exception :cljs js/Error) e
                                  ;; Backend might throw an exception indicating it doesn't support multi-key operations
                                  ;; even though the store implements the protocol
-                                                                    #?(:clj
-                                                                       (if (and (instance? clojure.lang.ExceptionInfo e)
-                                                                                (= :not-supported (:type (ex-data e))))
-                                                                         (throw (ex-info "Backing store does not support multi-key operations"
-                                                                                         {:store-type (type store)
-                                                                                          :cause e
-                                                                                          :reason (:reason (ex-data e))}))
-                                                                         (throw e))
-                                                                       :cljs (throw e))))]
+                                                               #?(:clj
+                                                                  (if (and (instance? clojure.lang.ExceptionInfo e)
+                                                                           (= :not-supported (:type (ex-data e))))
+                                                                    (throw (ex-info "Backing store does not support multi-key operations"
+                                                                                    {:store-type (type store)
+                                                                                     :cause e
+                                                                                     :reason (:reason (ex-data e))}))
+                                                                    (throw e))
+                                                                  :cljs (throw e))))]
                   ;; HOOKS ALWAYS SEE A PER-KEY MAP, whichever way the caller
                   ;; expressed it. `:meta-all` is expanded here and never escapes
                   ;; this namespace, so a consumer like konserve-sync keeps its
@@ -826,12 +828,12 @@
                   ;;
                   ;; Expanded ONLY when a hook is registered, so the write path
                   ;; still avoids building an N-entry map to say one thing.
-                                                     (invoke-write-hooks! store (cond-> {:api-op :multi-assoc :kvs kvs}
-                                                                                  meta     (clojure.core/assoc :meta meta)
-                                                                                  meta-all (clojure.core/assoc
-                                                                                            :meta (zipmap (kv-keys kvs)
-                                                                                                          (clojure.core/repeat meta-all)))))
-                                                     result)))))))
+                                                (invoke-write-hooks! store (cond-> {:api-op :multi-assoc :kvs kvs}
+                                                                             meta     (clojure.core/assoc :meta meta)
+                                                                             meta-all (clojure.core/assoc
+                                                                                       :meta (zipmap (kv-keys kvs)
+                                                                                                     (clojure.core/repeat meta-all)))))
+                                                result))))))
 
 (defn dissoc
   "Removes an entry from the store. "
@@ -843,13 +845,13 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :dissoc :api
-                                             (<?- (maybe-go-locked
-                                                   store key
-                                                   (let [result (<?- (-dissoc store key opts))]
-                                                     (when result
-                                                       (invoke-write-hooks! store {:api-op :dissoc
-                                                                                   :key key}))
-                                                     result)))))))
+                                             (maybe-go-locked
+                                              store key
+                                              (let [result (<?- (-dissoc store key opts))]
+                                                (when result
+                                                  (invoke-write-hooks! store {:api-op :dissoc
+                                                                              :key key}))
+                                                result))))))
 
 (defn multi-dissoc
   "Atomically dissociates multiple keys with flat keys.
@@ -882,21 +884,21 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :multi-dissoc :api
-                                             (<?- (go-try-
-                                                   (try
-                                                     (<?- (-multi-dissoc store keys opts))
-                                                     (catch #?(:clj Exception :cljs js/Error) e
+                                             (go-try-
+                                              (try
+                                                (<?- (-multi-dissoc store keys opts))
+                                                (catch #?(:clj Exception :cljs js/Error) e
                     ;; Backend might throw an exception indicating it doesn't support multi-key operations
                     ;; even though the store implements the protocol
-                                                       #?(:clj
-                                                          (if (and (instance? clojure.lang.ExceptionInfo e)
-                                                                   (= :not-supported (:type (ex-data e))))
-                                                            (throw (ex-info "Backing store does not support multi-key operations"
-                                                                            {:store-type (type store)
-                                                                             :cause e
-                                                                             :reason (:reason (ex-data e))}))
-                                                            (throw e))
-                                                          :cljs (throw e))))))))))
+                                                  #?(:clj
+                                                     (if (and (instance? clojure.lang.ExceptionInfo e)
+                                                              (= :not-supported (:type (ex-data e))))
+                                                       (throw (ex-info "Backing store does not support multi-key operations"
+                                                                       {:store-type (type store)
+                                                                        :cause e
+                                                                        :reason (:reason (ex-data e))}))
+                                                       (throw e))
+                                                     :cljs (throw e)))))))))
 
 (defn append
   "Append the Element to the log at the given key or create a new append log there.
@@ -909,20 +911,20 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :append :api
-                                             (<?- (go-locked
-                                                   store key
-                                                   (let [head (<?- (-get-in store [key] nil opts))
-                                                         [append-log? last-id first-id] head
-                                                         new-elem {:next nil
-                                                                   :elem elem}
-                                                         id (hasch/uuid)]
-                                                     (when (and head (not= append-log? :append-log))
-                                                       (throw (ex-info "This is not an append-log." {:key key})))
-                                                     (<?- (-update-in store [id] (partial meta-update key :append-log) (fn [_] new-elem) opts))
-                                                     (when first-id
-                                                       (<?- (-update-in store [last-id :next] (partial meta-update key :append-log) (fn [_] id) opts)))
-                                                     (<?- (-update-in store [key] (partial meta-update key :append-log) (fn [_] [:append-log id (or first-id id)]) opts))
-                                                     [first-id id])))))))
+                                             (go-locked
+                                              store key
+                                              (let [head (<?- (-get-in store [key] nil opts))
+                                                    [append-log? last-id first-id] head
+                                                    new-elem {:next nil
+                                                              :elem elem}
+                                                    id (hasch/uuid)]
+                                                (when (and head (not= append-log? :append-log))
+                                                  (throw (ex-info "This is not an append-log." {:key key})))
+                                                (<?- (-update-in store [id] (partial meta-update key :append-log) (fn [_] new-elem) opts))
+                                                (when first-id
+                                                  (<?- (-update-in store [last-id :next] (partial meta-update key :append-log) (fn [_] id) opts)))
+                                                (<?- (-update-in store [key] (partial meta-update key :append-log) (fn [_] [:append-log id (or first-id id)]) opts))
+                                                [first-id id]))))))
 
 (defn log
   "Loads the whole append log stored at key."
@@ -933,18 +935,18 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :log :api
-                                             (<?- (go-try-
-                                                   (let [head (<?- (get store key nil opts))
-                                                         [append-log? _last-id first-id] head]
-                                                     (when (and head (not= append-log? :append-log))
-                                                       (throw (ex-info "This is not an append-log." {:key key})))
-                                                     (when first-id
-                                                       (loop [{:keys [next elem]} (<?- (get store first-id nil opts))
-                                                              hist []]
-                                                         (if next
-                                                           (recur (<?- (get store next nil opts))
-                                                                  (conj hist elem))
-                                                           (conj hist elem)))))))))))
+                                             (go-try-
+                                              (let [head (<?- (get store key nil opts))
+                                                    [append-log? _last-id first-id] head]
+                                                (when (and head (not= append-log? :append-log))
+                                                  (throw (ex-info "This is not an append-log." {:key key})))
+                                                (when first-id
+                                                  (loop [{:keys [next elem]} (<?- (get store first-id nil opts))
+                                                         hist []]
+                                                    (if next
+                                                      (recur (<?- (get store next nil opts))
+                                                             (conj hist elem))
+                                                      (conj hist elem))))))))))
 
 (defn reduce-log
   "Loads the append log and applies reduce-fn over it."
@@ -955,19 +957,19 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :reduce-log :api
-                                             (<?- (go-try-
-                                                   (let [head (<?- (get store key nil opts))
-                                                         [append-log? last-id first-id] head]
-                                                     (when (and head (not= append-log? :append-log))
-                                                       (throw (ex-info "This is not an append-log." {:key key})))
-                                                     (if first-id
-                                                       (loop [id first-id
-                                                              acc acc]
-                                                         (let [{:keys [next elem]} (<?- (get store id nil opts))]
-                                                           (if (and next (not= id last-id))
-                                                             (recur next (reduce-fn acc elem))
-                                                             (reduce-fn acc elem))))
-                                                       acc))))))))
+                                             (go-try-
+                                              (let [head (<?- (get store key nil opts))
+                                                    [append-log? last-id first-id] head]
+                                                (when (and head (not= append-log? :append-log))
+                                                  (throw (ex-info "This is not an append-log." {:key key})))
+                                                (if first-id
+                                                  (loop [id first-id
+                                                         acc acc]
+                                                    (let [{:keys [next elem]} (<?- (get store id nil opts))]
+                                                      (if (and next (not= id last-id))
+                                                        (recur next (reduce-fn acc elem))
+                                                        (reduce-fn acc elem))))
+                                                  acc)))))))
 
 (defn bget
   "Calls locked-cb with a platform specific binary representation inside the lock.
@@ -1009,9 +1011,9 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :bget :api
-                                             (<?- (maybe-go-locked
-                                                   store key
-                                                   (<?- (-bget store key locked-cb opts))))))))
+                                             (maybe-go-locked
+                                              store key
+                                              (<?- (-bget store key locked-cb opts)))))))
 
 (defn bassoc
   "Copies given value (InputStream, Reader, File, byte[] or String on
@@ -1024,13 +1026,13 @@
    (async+sync (:sync? opts)
                *default-sync-translation*
                (konserve.metrics/measured-go store :bassoc :api
-                                             (<?- (maybe-go-locked
-                                                   store key
-                                                   (let [result (<?- (-bassoc store key (partial meta-update key :binary) val opts))]
-                                                     (invoke-write-hooks! store {:api-op :bassoc
-                                                                                 :key key
-                                                                                 :value val})
-                                                     result)))))))
+                                             (maybe-go-locked
+                                              store key
+                                              (let [result (<?- (-bassoc store key (partial meta-update key :binary) val opts))]
+                                                (invoke-write-hooks! store {:api-op :bassoc
+                                                                            :key key
+                                                                            :value val})
+                                                result))))))
 
 (defn keys
   "Return a channel that will yield all top-level keys currently in the store."
@@ -1038,7 +1040,9 @@
    (keys store {:sync? false}))
   ([store opts]
    (log/trace :konserve/keys "fetching keys")
-   (-keys store opts)))
+   (if (:sync? opts)
+     (konserve.metrics/measured store :keys :api (-keys store opts))
+     (konserve.metrics/measured-go store :keys :api (-keys store opts)))))
 
 (defn assoc-serializers
   "Assoc the given serializers onto the store, taking effect immediately."

--- a/src/konserve/core.cljc
+++ b/src/konserve/core.cljc
@@ -13,8 +13,10 @@
             [konserve.impl.defaults :as defaults]
             [konserve.store :as store]
             [superv.async :refer [go-try- <?-]]
+            [konserve.metrics]
             [replikativ.logging :as log])
-  #?(:cljs (:require-macros [konserve.core :refer [go-locked locked maybe-go-locked maybe-locked]])))
+  #?(:cljs (:require-macros [konserve.core :refer [go-locked locked maybe-go-locked maybe-locked]]
+                            [konserve.metrics])))
 
 ;; ACID
 
@@ -183,7 +185,9 @@
          k# ~key
          l# (get-lock s# k#)]
      (try
-       (wait l#)
+       (let [t0# (konserve.metrics/start)]
+         (wait l#)
+         (konserve.metrics/finish! s# :lock :lock t0#))
        (log/trace :konserve/acquired-spin-lock {:key k#})
        ~@code
        (finally
@@ -197,7 +201,11 @@
           k# ~key
           l# (get-lock s# k#)]
       (try
-        (<?- l#)
+        ;; Closure-free on purpose: this macro is inlined wherever a store is
+        ;; locked, and a go block per lock would blow up a method's size.
+        (let [t0# (konserve.metrics/start)]
+          (<?- l#)
+          (konserve.metrics/finish! s# :lock :lock t0#))
         (log/trace :konserve/acquired-go-lock {:key k#})
         ~@code
         (finally
@@ -229,9 +237,10 @@
    (log/trace :konserve/exists? {:key key})
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (maybe-go-locked
-                store key
-                (<?- (-exists? store key opts))))))
+               (konserve.metrics/measured-go store :exists? :api
+                                             (<?- (maybe-go-locked
+                                                   store key
+                                                   (<?- (-exists? store key opts))))))))
 
 (defn get-in
   "Returns the value stored described by key. Returns nil if the key
@@ -252,9 +261,10 @@
    (log/trace :konserve/get-in {:key-vec key-vec})
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (maybe-go-locked
-                store (first key-vec)
-                (<?- (-get-in store key-vec not-found opts))))))
+               (konserve.metrics/measured-go store :get-in :api
+                                             (<?- (maybe-go-locked
+                                                   store (first key-vec)
+                                                   (<?- (-get-in store key-vec not-found opts))))))))
 
 (defn get
   "Returns the value stored described by key. Returns nil if the key
@@ -285,12 +295,13 @@
    (log/trace :konserve/get-meta {:key key})
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (maybe-go-locked
-                store key
-                (let [a (<?- (-get-meta store key opts))]
-                  (if (some? a)
-                    a
-                    not-found))))))
+               (konserve.metrics/measured-go store :get-meta :api
+                                             (<?- (maybe-go-locked
+                                                   store key
+                                                   (let [a (<?- (-get-meta store key opts))]
+                                                     (if (some? a)
+                                                       a
+                                                       not-found))))))))
 
 (def absent
   "The `:expected-revision` that means THE KEY MUST NOT EXIST — the create half of
@@ -462,11 +473,12 @@
    (check-conditional-supported! store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (go-locked
-                store (first key-vec)
-                (let [base (partial meta-update (first key-vec) :edn)
-                      mfn  (if meta-up-fn (fn [old] (meta-up-fn (base old))) base)
-                      result (<?- (-update-in store key-vec mfn up-fn opts))
+               (konserve.metrics/measured-go store :update-in :api
+                                             (<?- (go-locked
+                                                   store (first key-vec)
+                                                   (let [base (partial meta-update (first key-vec) :edn)
+                                                         mfn  (if meta-up-fn (fn [old] (meta-up-fn (base old))) base)
+                                                         result (<?- (-update-in store key-vec mfn up-fn opts))
                       ;; `:with-revision?` makes the result `[[old new] revision]`
                       ;; rather than `[old new]`, so destructuring it as the plain
                       ;; shape put the REVISION TOKEN in the hook's `:value` — and
@@ -474,13 +486,13 @@
                       ;; would replicate the token as the key's data. The hook
                       ;; reports the value either way; the revision is the caller's
                       ;; business, not the replica's.
-                      [old-val new-val] (if (:with-revision? opts) (first result) result)]
-                  (invoke-write-hooks! store {:api-op :update-in
-                                              :key (first key-vec)
-                                              :key-vec key-vec
-                                              :old-value old-val
-                                              :value new-val})
-                  result)))))
+                                                         [old-val new-val] (if (:with-revision? opts) (first result) result)]
+                                                     (invoke-write-hooks! store {:api-op :update-in
+                                                                                 :key (first key-vec)
+                                                                                 :key-vec key-vec
+                                                                                 :old-value old-val
+                                                                                 :value new-val})
+                                                     result)))))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn update
@@ -523,16 +535,17 @@
    (check-conditional-supported! store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (go-locked
-                store (first key-vec)
-                (let [base   (partial meta-update (first key-vec) :edn)
-                      mfn    (if meta-up-fn (fn [old] (meta-up-fn (base old))) base)
-                      result (<?- (-assoc-in store key-vec mfn val opts))]
-                  (invoke-write-hooks! store {:api-op :assoc-in
-                                              :key (first key-vec)
-                                              :key-vec key-vec
-                                              :value val})
-                  result)))))
+               (konserve.metrics/measured-go store :assoc-in :api
+                                             (<?- (go-locked
+                                                   store (first key-vec)
+                                                   (let [base   (partial meta-update (first key-vec) :edn)
+                                                         mfn    (if meta-up-fn (fn [old] (meta-up-fn (base old))) base)
+                                                         result (<?- (-assoc-in store key-vec mfn val opts))]
+                                                     (invoke-write-hooks! store {:api-op :assoc-in
+                                                                                 :key (first key-vec)
+                                                                                 :key-vec key-vec
+                                                                                 :value val})
+                                                     result)))))))
 
 (defn assoc
   "Associates the key to the value. This is a simple top-level overwrite
@@ -563,15 +576,16 @@
    (check-conditional-supported! store opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (maybe-go-locked
-                store key
-                (let [mfn    (if meta
-                               (fn [old] (clojure.core/merge meta (meta-update key :edn old)))
-                               (partial meta-update key :edn))
-                      result (<?- (-assoc-in store [key] mfn val opts))]
-                  (invoke-write-hooks! store (cond-> {:api-op :assoc :key key :value val}
-                                               meta (clojure.core/assoc :meta meta)))
-                  result)))))
+               (konserve.metrics/measured-go store :assoc :api
+                                             (<?- (maybe-go-locked
+                                                   store key
+                                                   (let [mfn    (if meta
+                                                                  (fn [old] (clojure.core/merge meta (meta-update key :edn old)))
+                                                                  (partial meta-update key :edn))
+                                                         result (<?- (-assoc-in store [key] mfn val opts))]
+                                                     (invoke-write-hooks! store (cond-> {:api-op :assoc :key key :value val}
+                                                                                  meta (clojure.core/assoc :meta meta)))
+                                                     result)))))))
 
 (defn multi-get
   "Atomically retrieves multiple values by keys.
@@ -615,21 +629,22 @@
                                                        :reason "Store doesn't implement PMultiKeyEDNValueStore protocol or multi-key support is disabled"}))))
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (go-try-
-                (try
-                  (<?- (-multi-get store keys opts))
-                  (catch #?(:clj Exception :cljs js/Error) e
+               (konserve.metrics/measured-go store :multi-get :api
+                                             (<?- (go-try-
+                                                   (try
+                                                     (<?- (-multi-get store keys opts))
+                                                     (catch #?(:clj Exception :cljs js/Error) e
                     ;; Backend might throw an exception indicating it doesn't support multi-key operations
                     ;; even though the store implements the protocol
-                    #?(:clj
-                       (if (and (instance? clojure.lang.ExceptionInfo e)
-                                (= :not-supported (:type (ex-data e))))
-                         (throw (ex-info "Backing store does not support multi-key operations"
-                                         {:store-type (type store)
-                                          :cause e
-                                          :reason (:reason (ex-data e))}))
-                         (throw e))
-                       :cljs (throw e))))))))
+                                                       #?(:clj
+                                                          (if (and (instance? clojure.lang.ExceptionInfo e)
+                                                                   (= :not-supported (:type (ex-data e))))
+                                                            (throw (ex-info "Backing store does not support multi-key operations"
+                                                                            {:store-type (type store)
+                                                                             :cause e
+                                                                             :reason (:reason (ex-data e))}))
+                                                            (throw e))
+                                                          :cljs (throw e))))))))))
 
 (defn uniform-meta
   "Build a per-key meta map applying the same `meta` to every key — a convenience
@@ -741,12 +756,13 @@
                                                        :reason "Store doesn't implement PMultiKeyEDNValueStore protocol or multi-key support is disabled"}))))
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (go-try-
-                (let [meta-all (:meta-all opts)
-                      _ (when (and meta meta-all)
-                          (throw (#?(:clj ex-info :cljs js/Error.)
-                                  "Pass either a per-key `meta` or `:meta-all`, not both"
-                                  {:type :konserve/ambiguous-meta})))
+               (konserve.metrics/measured-go store :multi-assoc :api
+                                             (<?- (go-try-
+                                                   (let [meta-all (:meta-all opts)
+                                                         _ (when (and meta meta-all)
+                                                             (throw (#?(:clj ex-info :cljs js/Error.)
+                                                                     "Pass either a per-key `meta` or `:meta-all`, not both"
+                                                                     {:type :konserve/ambiguous-meta})))
                       ;; UNIFORM ANNOTATION NEEDS NO KEYS, and that is the whole
                       ;; point of `:meta-all`. `uniform-meta` existed to turn one
                       ;; annotation into a per-key map, which meant DERIVING THE
@@ -755,13 +771,13 @@
                       ;; `(uniform-meta (keys m) ..)` on `{[:a 1] v}` produced
                       ;; `{:a ..}` and the annotation was silently dropped.
                       ;; Naming the two intents removes the guess entirely.
-                      mfn    (cond
-                               meta-all
-                               (fn [key type old] (clojure.core/merge meta-all (meta-update key type old)))
-                               meta
+                                                         mfn    (cond
+                                                                  meta-all
+                                                                  (fn [key type old] (clojure.core/merge meta-all (meta-update key type old)))
+                                                                  meta
                                ;; per-key meta map: `(get meta key)` (nil ⇒ just the built meta)
-                               (fn [key type old] (clojure.core/merge (clojure.core/get meta key) (meta-update key type old)))
-                               :else meta-update)
+                                                                  (fn [key type old] (clojure.core/merge (clojure.core/get meta key) (meta-update key type old)))
+                                                                  :else meta-update)
                       ;; A `meta` MAP THAT NAMES NO KEY OF THIS BATCH IS ALWAYS A
                       ;; MISTAKE, and it used to be a silent one: the write
                       ;; succeeded and the annotation vanished. `uniform-meta`
@@ -776,31 +792,31 @@
                       ;; is the documented mixed-batch case -- immutable nodes
                       ;; plus the mutable pointer that makes them reachable --
                       ;; so a single overlapping key is enough to be intentional.
-                      _ (when (seq meta)
-                          (let [ks (set (kv-keys kvs))]
-                            (when-not (some ks (clojure.core/keys meta))
-                              (throw (#?(:clj ex-info :cljs js/Error.)
-                                      (str "multi-assoc: none of `meta`'s keys appear in `kvs`, "
-                                           "so no value would receive it. If this came from "
-                                           "`uniform-meta`, pass the kv-map itself, name the keys, "
-                                           "or use {:meta-all m} in opts.")
-                                      {:type :konserve/meta-keys-disjoint
-                                       :meta-keys (vec (clojure.core/keys meta))
-                                       :kvs-keys (vec ks)})))))
-                      result (try
-                               (<?- (-multi-assoc store kvs mfn opts))
-                               (catch #?(:clj Exception :cljs js/Error) e
+                                                         _ (when (seq meta)
+                                                             (let [ks (set (kv-keys kvs))]
+                                                               (when-not (some ks (clojure.core/keys meta))
+                                                                 (throw (#?(:clj ex-info :cljs js/Error.)
+                                                                         (str "multi-assoc: none of `meta`'s keys appear in `kvs`, "
+                                                                              "so no value would receive it. If this came from "
+                                                                              "`uniform-meta`, pass the kv-map itself, name the keys, "
+                                                                              "or use {:meta-all m} in opts.")
+                                                                         {:type :konserve/meta-keys-disjoint
+                                                                          :meta-keys (vec (clojure.core/keys meta))
+                                                                          :kvs-keys (vec ks)})))))
+                                                         result (try
+                                                                  (<?- (-multi-assoc store kvs mfn opts))
+                                                                  (catch #?(:clj Exception :cljs js/Error) e
                                  ;; Backend might throw an exception indicating it doesn't support multi-key operations
                                  ;; even though the store implements the protocol
-                                 #?(:clj
-                                    (if (and (instance? clojure.lang.ExceptionInfo e)
-                                             (= :not-supported (:type (ex-data e))))
-                                      (throw (ex-info "Backing store does not support multi-key operations"
-                                                      {:store-type (type store)
-                                                       :cause e
-                                                       :reason (:reason (ex-data e))}))
-                                      (throw e))
-                                    :cljs (throw e))))]
+                                                                    #?(:clj
+                                                                       (if (and (instance? clojure.lang.ExceptionInfo e)
+                                                                                (= :not-supported (:type (ex-data e))))
+                                                                         (throw (ex-info "Backing store does not support multi-key operations"
+                                                                                         {:store-type (type store)
+                                                                                          :cause e
+                                                                                          :reason (:reason (ex-data e))}))
+                                                                         (throw e))
+                                                                       :cljs (throw e))))]
                   ;; HOOKS ALWAYS SEE A PER-KEY MAP, whichever way the caller
                   ;; expressed it. `:meta-all` is expanded here and never escapes
                   ;; this namespace, so a consumer like konserve-sync keeps its
@@ -810,12 +826,12 @@
                   ;;
                   ;; Expanded ONLY when a hook is registered, so the write path
                   ;; still avoids building an N-entry map to say one thing.
-                  (invoke-write-hooks! store (cond-> {:api-op :multi-assoc :kvs kvs}
-                                               meta     (clojure.core/assoc :meta meta)
-                                               meta-all (clojure.core/assoc
-                                                         :meta (zipmap (kv-keys kvs)
-                                                                       (clojure.core/repeat meta-all)))))
-                  result)))))
+                                                     (invoke-write-hooks! store (cond-> {:api-op :multi-assoc :kvs kvs}
+                                                                                  meta     (clojure.core/assoc :meta meta)
+                                                                                  meta-all (clojure.core/assoc
+                                                                                            :meta (zipmap (kv-keys kvs)
+                                                                                                          (clojure.core/repeat meta-all)))))
+                                                     result)))))))
 
 (defn dissoc
   "Removes an entry from the store. "
@@ -826,13 +842,14 @@
    (refuse-conditional-unsupported! "dissoc" opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (maybe-go-locked
-                store key
-                (let [result (<?- (-dissoc store key opts))]
-                  (when result
-                    (invoke-write-hooks! store {:api-op :dissoc
-                                                :key key}))
-                  result)))))
+               (konserve.metrics/measured-go store :dissoc :api
+                                             (<?- (maybe-go-locked
+                                                   store key
+                                                   (let [result (<?- (-dissoc store key opts))]
+                                                     (when result
+                                                       (invoke-write-hooks! store {:api-op :dissoc
+                                                                                   :key key}))
+                                                     result)))))))
 
 (defn multi-dissoc
   "Atomically dissociates multiple keys with flat keys.
@@ -864,21 +881,22 @@
                                                        :reason "Store doesn't implement PMultiKeyEDNValueStore protocol or multi-key support is disabled"}))))
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (go-try-
-                (try
-                  (<?- (-multi-dissoc store keys opts))
-                  (catch #?(:clj Exception :cljs js/Error) e
+               (konserve.metrics/measured-go store :multi-dissoc :api
+                                             (<?- (go-try-
+                                                   (try
+                                                     (<?- (-multi-dissoc store keys opts))
+                                                     (catch #?(:clj Exception :cljs js/Error) e
                     ;; Backend might throw an exception indicating it doesn't support multi-key operations
                     ;; even though the store implements the protocol
-                    #?(:clj
-                       (if (and (instance? clojure.lang.ExceptionInfo e)
-                                (= :not-supported (:type (ex-data e))))
-                         (throw (ex-info "Backing store does not support multi-key operations"
-                                         {:store-type (type store)
-                                          :cause e
-                                          :reason (:reason (ex-data e))}))
-                         (throw e))
-                       :cljs (throw e))))))))
+                                                       #?(:clj
+                                                          (if (and (instance? clojure.lang.ExceptionInfo e)
+                                                                   (= :not-supported (:type (ex-data e))))
+                                                            (throw (ex-info "Backing store does not support multi-key operations"
+                                                                            {:store-type (type store)
+                                                                             :cause e
+                                                                             :reason (:reason (ex-data e))}))
+                                                            (throw e))
+                                                          :cljs (throw e))))))))))
 
 (defn append
   "Append the Element to the log at the given key or create a new append log there.
@@ -890,20 +908,21 @@
    (refuse-conditional-unsupported! "append" opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (go-locked
-                store key
-                (let [head (<?- (-get-in store [key] nil opts))
-                      [append-log? last-id first-id] head
-                      new-elem {:next nil
-                                :elem elem}
-                      id (hasch/uuid)]
-                  (when (and head (not= append-log? :append-log))
-                    (throw (ex-info "This is not an append-log." {:key key})))
-                  (<?- (-update-in store [id] (partial meta-update key :append-log) (fn [_] new-elem) opts))
-                  (when first-id
-                    (<?- (-update-in store [last-id :next] (partial meta-update key :append-log) (fn [_] id) opts)))
-                  (<?- (-update-in store [key] (partial meta-update key :append-log) (fn [_] [:append-log id (or first-id id)]) opts))
-                  [first-id id])))))
+               (konserve.metrics/measured-go store :append :api
+                                             (<?- (go-locked
+                                                   store key
+                                                   (let [head (<?- (-get-in store [key] nil opts))
+                                                         [append-log? last-id first-id] head
+                                                         new-elem {:next nil
+                                                                   :elem elem}
+                                                         id (hasch/uuid)]
+                                                     (when (and head (not= append-log? :append-log))
+                                                       (throw (ex-info "This is not an append-log." {:key key})))
+                                                     (<?- (-update-in store [id] (partial meta-update key :append-log) (fn [_] new-elem) opts))
+                                                     (when first-id
+                                                       (<?- (-update-in store [last-id :next] (partial meta-update key :append-log) (fn [_] id) opts)))
+                                                     (<?- (-update-in store [key] (partial meta-update key :append-log) (fn [_] [:append-log id (or first-id id)]) opts))
+                                                     [first-id id])))))))
 
 (defn log
   "Loads the whole append log stored at key."
@@ -913,18 +932,19 @@
    (log/trace :konserve/log {:key key})
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (go-try-
-                (let [head (<?- (get store key nil opts))
-                      [append-log? _last-id first-id] head]
-                  (when (and head (not= append-log? :append-log))
-                    (throw (ex-info "This is not an append-log." {:key key})))
-                  (when first-id
-                    (loop [{:keys [next elem]} (<?- (get store first-id nil opts))
-                           hist []]
-                      (if next
-                        (recur (<?- (get store next nil opts))
-                               (conj hist elem))
-                        (conj hist elem)))))))))
+               (konserve.metrics/measured-go store :log :api
+                                             (<?- (go-try-
+                                                   (let [head (<?- (get store key nil opts))
+                                                         [append-log? _last-id first-id] head]
+                                                     (when (and head (not= append-log? :append-log))
+                                                       (throw (ex-info "This is not an append-log." {:key key})))
+                                                     (when first-id
+                                                       (loop [{:keys [next elem]} (<?- (get store first-id nil opts))
+                                                              hist []]
+                                                         (if next
+                                                           (recur (<?- (get store next nil opts))
+                                                                  (conj hist elem))
+                                                           (conj hist elem)))))))))))
 
 (defn reduce-log
   "Loads the append log and applies reduce-fn over it."
@@ -934,19 +954,20 @@
    (log/trace :konserve/reduce-log {:key key})
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (go-try-
-                (let [head (<?- (get store key nil opts))
-                      [append-log? last-id first-id] head]
-                  (when (and head (not= append-log? :append-log))
-                    (throw (ex-info "This is not an append-log." {:key key})))
-                  (if first-id
-                    (loop [id first-id
-                           acc acc]
-                      (let [{:keys [next elem]} (<?- (get store id nil opts))]
-                        (if (and next (not= id last-id))
-                          (recur next (reduce-fn acc elem))
-                          (reduce-fn acc elem))))
-                    acc))))))
+               (konserve.metrics/measured-go store :reduce-log :api
+                                             (<?- (go-try-
+                                                   (let [head (<?- (get store key nil opts))
+                                                         [append-log? last-id first-id] head]
+                                                     (when (and head (not= append-log? :append-log))
+                                                       (throw (ex-info "This is not an append-log." {:key key})))
+                                                     (if first-id
+                                                       (loop [id first-id
+                                                              acc acc]
+                                                         (let [{:keys [next elem]} (<?- (get store id nil opts))]
+                                                           (if (and next (not= id last-id))
+                                                             (recur next (reduce-fn acc elem))
+                                                             (reduce-fn acc elem))))
+                                                       acc))))))))
 
 (defn bget
   "Calls locked-cb with a platform specific binary representation inside the lock.
@@ -987,9 +1008,10 @@
    (log/trace :konserve/bget {:key key})
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (maybe-go-locked
-                store key
-                (<?- (-bget store key locked-cb opts))))))
+               (konserve.metrics/measured-go store :bget :api
+                                             (<?- (maybe-go-locked
+                                                   store key
+                                                   (<?- (-bget store key locked-cb opts))))))))
 
 (defn bassoc
   "Copies given value (InputStream, Reader, File, byte[] or String on
@@ -1001,13 +1023,14 @@
    (refuse-conditional-unsupported! "bassoc" opts)
    (async+sync (:sync? opts)
                *default-sync-translation*
-               (maybe-go-locked
-                store key
-                (let [result (<?- (-bassoc store key (partial meta-update key :binary) val opts))]
-                  (invoke-write-hooks! store {:api-op :bassoc
-                                              :key key
-                                              :value val})
-                  result)))))
+               (konserve.metrics/measured-go store :bassoc :api
+                                             (<?- (maybe-go-locked
+                                                   store key
+                                                   (let [result (<?- (-bassoc store key (partial meta-update key :binary) val opts))]
+                                                     (invoke-write-hooks! store {:api-op :bassoc
+                                                                                 :key key
+                                                                                 :value val})
+                                                     result)))))))
 
 (defn keys
   "Return a channel that will yield all top-level keys currently in the store."

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -629,7 +629,11 @@
                  (finally
                    (when binary?
                      (Files/delete data-path))
-                   (.close ^AsynchronousFileChannel c-data-file))))))
+                   ;; A FileChannel on the synchronous path, an
+                   ;; AsynchronousFileChannel otherwise: both are Channels.
+                   ;; The cast to the async one made every synchronous v1
+                   ;; migration throw ClassCastException at its close.
+                   (.close ^java.nio.channels.Channel c-data-file))))))
 
 (defn- migrate-file-v2
   "Migration Function For Konserve Version, who has Meta and Data Bases.

--- a/src/konserve/filestore.clj
+++ b/src/konserve/filestore.clj
@@ -597,6 +597,11 @@
                                              :encryptor  encryptor
                                              :store-key  store-key
                                              :buffer-size buffer-size
+                                             ;; The store's config and mode travel
+                                             ;; with the env: `update-blob` picks
+                                             ;; its arm and its metrics labels there.
+                                             :config     (:config env)
+                                             :sync?      sync?
                                              :base base
                                              :key-vec [nkey]
                                              :up-fn-meta (fn [_] meta)}
@@ -669,6 +674,8 @@
                                             :compressor compressor
                                             :encryptor  encryptor
                                             :buffer-size buffer-size
+                                            :config     (:config env)
+                                            :sync?      sync?
                                             :base base
                                             :store-key  store-key
                                             :key-vec [key]

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -60,7 +60,7 @@
 
 #?(:cljs (extend-type js/Uint8Array ICounted (-count [this] (alength this))))
 
-(defn update-blob
+(defn update-blob*
   "This function writes first the meta-size, then the meta-data and then the
   actual updated data into the underlying backing store."
   [backing store-key serializer write-handlers
@@ -114,11 +114,10 @@
                                               serializer compressor encryptor meta-size)
           new-blob             (<?- (-create-blob backing new-store-key env))
           new-blob-closed?     (atom false)]
-      (let [t0 (metrics/start)
-            r (try
-                (<?- (-write-header new-blob header env))
-                (<?- (-write-meta new-blob meta-arr env))
-                (if (= operation :write-binary)
+      (try
+        (<?- (-write-header new-blob header env))
+        (<?- (-write-meta new-blob meta-arr env))
+        (if (= operation :write-binary)
           ;; Normalize here so no backing has to. `bassoc` documents five input
           ;; shapes; before this, only the filestore handled any but bytes, and
           ;; every other backing silently mishandled the rest — konserve-s3
@@ -127,53 +126,53 @@
           ;; the caller's input untouched, which is what lets a value larger
           ;; than the heap be written at all: Lucene's DEFAULT merge policy
           ;; tops out at 5 GB per segment, and a byte array at 2 GB.
-                  (<?- (-write-binary new-blob meta-size
-                                      (if (-streaming-binary-write? new-blob)
-                                        input
-                                        #?(:clj (nio/blob->bytes input) :cljs input))
-                                      env))
-                  (let [value-arr (to-array value)]
-                    (metrics/bytes! {:config config} operation (+ meta-size (count value-arr)))
-                    (<?- (-write-value new-blob value-arr meta-size env))))
+          (let [input (if (-streaming-binary-write? new-blob)
+                        input
+                        #?(:clj (nio/blob->bytes input) :cljs input))]
+            (when-let [n #?(:clj (when (bytes? input) (alength ^bytes input))
+                            :cljs (when (instance? js/Uint8Array input) (.-length input)))]
+              (metrics/bytes! config operation (+ meta-size n)))
+            (<?- (-write-binary new-blob meta-size input env)))
+          (let [value-arr (to-array value)]
+            (metrics/bytes! config operation (+ meta-size (count value-arr)))
+            (<?- (-write-value new-blob value-arr meta-size env))))
 
-                (when (:sync-blob? config)
-                  (log/trace :konserve/syncing-blob {:key key})
-                  (<?- (-sync new-blob env)))
+        (when (:sync-blob? config)
+          (log/trace :konserve/syncing-blob {:key key})
+          (<?- (-sync new-blob env)))
         ;; Marked before the call: a close that throws after releasing the
         ;; resource must not be closed again from the `finally`.
-                (reset! new-blob-closed? true)
-                (<?- (-close new-blob env))
+        (reset! new-blob-closed? true)
+        (<?- (-close new-blob env))
 
-                (when-not (:in-place? config)
-                  (log/trace :konserve/moving-blob {:key key})
-                  (<?- (-atomic-move backing new-store-key store-key env))
-                  (reset! moved? true))
+        (when-not (:in-place? config)
+          (log/trace :konserve/moving-blob {:key key})
+          (<?- (-atomic-move backing new-store-key store-key env))
+          (reset! moved? true))
 
-                (when (:sync-blob? config)
-                  (log/trace :konserve/syncing-store {:key key})
-                  (<?- (-sync-store backing env)))
+        (when (:sync-blob? config)
+          (log/trace :konserve/syncing-store {:key key})
+          (<?- (-sync-store backing env)))
 
         ;; Clean up backup after successful write
-                (when (and (:in-place? config) (not (:no-backup? config)))
-                  (log/trace :konserve/deleting-backup-blob {:backup-store-key backup-store-key :key key})
-                  (<?- (-delete-blob backing backup-store-key env)))
+        (when (and (:in-place? config) (not (:no-backup? config)))
+          (log/trace :konserve/deleting-backup-blob {:backup-store-key backup-store-key :key key})
+          (<?- (-delete-blob backing backup-store-key env)))
 
-                (if (= operation :write-edn) [old-value value] true)
-                (finally
+        (if (= operation :write-edn) [old-value value] true)
+        (finally
           ;; Once. `-close` is idempotent on a FileChannel by spec, but that is
           ;; the filestore's property, not the protocol's.
-                  (when-not @new-blob-closed?
-                    (<?- (-close new-blob env)))
+          (when-not @new-blob-closed?
+            (<?- (-close new-blob env)))
           ;; A staging file that never got moved is ours to remove: with a
           ;; per-writer name nothing later overwrites it, so a failed write
           ;; would otherwise leave a complete-looking `.new` behind for good.
           ;; Best effort — this runs while an exception may be propagating,
           ;; and a cleanup failure must not replace it.
-                  (when (and (not (:in-place? config)) (not @moved?))
-                    (try (<?- (-delete-blob backing new-store-key env))
-                         (catch #?(:clj Exception :cljs js/Error) _ nil)))))]
-        (metrics/finish! {:config config} operation :io t0)
-        r)))))
+          (when (and (not (:in-place? config)) (not @moved?))
+            (try (<?- (-delete-blob backing new-store-key env))
+                 (catch #?(:clj Exception :cljs js/Error) _ nil)))))))))
 
 (defn read-header [ac serializers env]
   (let [{:keys [sync? store-key]} env]
@@ -188,7 +187,7 @@
                                         :store-key store-key
                                         :arr (seq arr)})))))))))
 
-(defn read-blob
+(defn read-blob*
   "Read meta, edn or binary from blob."
   [blob read-handlers serializers {:keys [sync? operation locked-cb config _store-key] :as env}]
   (async+sync
@@ -211,45 +210,44 @@
                            ;; default and is what the tests used.
                            ((encryptor (:encryptor config)) (compressor serializer))
                            read-handlers)]
-      (let [t0 (metrics/start)
-            r       (case operation
-                      :read-meta #?(:cljs (fn-read (<?- (-read-meta blob meta-size env)))
-                                    :clj
-                                    (let [bais-read (ByteArrayInputStream.
-                                                     (<?- (-read-meta blob meta-size env)))
-                                          value     (fn-read bais-read)
-                                          _         (.close bais-read)]
-                                      value))
-                      :read-edn #?(:cljs (fn-read (<?- (-read-value blob meta-size env)))
-                                   :clj
-                                   (let [bais-read (ByteArrayInputStream.
-                                                    (<?- (-read-value blob meta-size env)))
-                                         value     (fn-read bais-read)
-                                         _         (.close bais-read)]
-                                     value))
-                      :write-binary #?(:cljs
-                                       (let [meta (fn-read (<?- (-read-meta blob meta-size env)))]
-                                         [meta nil])
-                                       :clj
-                                       (let [bais-read (ByteArrayInputStream.
-                                                        (<?- (-read-meta blob meta-size env)))
-                                             meta      (fn-read bais-read)
-                                             _         (.close bais-read)]
-                                         [meta nil]))
-                      :write-edn #?(:cljs
-                                    (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
-                                          value (fn-read (<?- (-read-value blob meta-size env)))]
-                                      [meta value])
-                                    :clj
-                                    (let [bais-meta  (ByteArrayInputStream.
-                                                      (<?- (-read-meta blob meta-size env)))
-                                          meta       (fn-read bais-meta)
-                                          _          (.close bais-meta)
-                                          bais-value (ByteArrayInputStream.
-                                                      (<?- (-read-value blob meta-size env)))
-                                          value     (fn-read bais-value)
-                                          _          (.close bais-value)]
-                                      [meta value]))
+      (case operation
+        :read-meta #?(:cljs (fn-read (<?- (-read-meta blob meta-size env)))
+                      :clj
+                      (let [bais-read (ByteArrayInputStream.
+                                       (<?- (-read-meta blob meta-size env)))
+                            value     (fn-read bais-read)
+                            _         (.close bais-read)]
+                        value))
+        :read-edn #?(:cljs (fn-read (<?- (-read-value blob meta-size env)))
+                     :clj
+                     (let [bais-read (ByteArrayInputStream.
+                                      (<?- (-read-value blob meta-size env)))
+                           value     (fn-read bais-read)
+                           _         (.close bais-read)]
+                       value))
+        :write-binary #?(:cljs
+                         (let [meta (fn-read (<?- (-read-meta blob meta-size env)))]
+                           [meta nil])
+                         :clj
+                         (let [bais-read (ByteArrayInputStream.
+                                          (<?- (-read-meta blob meta-size env)))
+                               meta      (fn-read bais-read)
+                               _         (.close bais-read)]
+                           [meta nil]))
+        :write-edn #?(:cljs
+                      (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
+                            value (fn-read (<?- (-read-value blob meta-size env)))]
+                        [meta value])
+                      :clj
+                      (let [bais-meta  (ByteArrayInputStream.
+                                        (<?- (-read-meta blob meta-size env)))
+                            meta       (fn-read bais-meta)
+                            _          (.close bais-meta)
+                            bais-value (ByteArrayInputStream.
+                                        (<?- (-read-value blob meta-size env)))
+                            value     (fn-read bais-value)
+                            _          (.close bais-value)]
+                        [meta value]))
         ;; Both segments, from the one pass the blob is already open for. The
         ;; write path has always done this (`:write-edn` below); a READ needs it
         ;; so a caller can obtain a value AND the revision it is at without a
@@ -257,23 +255,21 @@
         ;; is RACY: between reading the value and reading its revision another
         ;; writer can move both, and the caller would fence against a revision
         ;; that never belonged to the value it computed from.
-                      :read-edn-meta #?(:cljs
-                                        (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
-                                              value (fn-read (<?- (-read-value blob meta-size env)))]
-                                          [meta value])
-                                        :clj
-                                        (let [bais-meta  (ByteArrayInputStream.
-                                                          (<?- (-read-meta blob meta-size env)))
-                                              meta       (fn-read bais-meta)
-                                              _          (.close bais-meta)
-                                              bais-value (ByteArrayInputStream.
-                                                          (<?- (-read-value blob meta-size env)))
-                                              value      (fn-read bais-value)
-                                              _          (.close bais-value)]
-                                          [meta value]))
-                      :read-binary (<?- (-read-binary blob meta-size locked-cb env)))]
-        (metrics/finish! {:config config} operation :io t0)
-        r)))))
+        :read-edn-meta #?(:cljs
+                          (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
+                                value (fn-read (<?- (-read-value blob meta-size env)))]
+                            [meta value])
+                          :clj
+                          (let [bais-meta  (ByteArrayInputStream.
+                                            (<?- (-read-meta blob meta-size env)))
+                                meta       (fn-read bais-meta)
+                                _          (.close bais-meta)
+                                bais-value (ByteArrayInputStream.
+                                            (<?- (-read-value blob meta-size env)))
+                                value      (fn-read bais-value)
+                                _          (.close bais-value)]
+                            [meta value]))
+        :read-binary (<?- (-read-binary blob meta-size locked-cb env)))))))
 
 (declare get-lock cas-lock-suffix)
 
@@ -290,7 +286,7 @@
        (some? (protocols/-conditional-write-domain backing))
        (not (satisfies? protocols/PSelfConditionalWrite backing))))
 
-(defn delete-blob
+(defn delete-blob*
   "Remove/Delete key-value pair of backing store by given key. Returns true if the
    key existed and was deleted, false if it was absent.
 
@@ -305,39 +301,106 @@
   (async+sync
    (:sync? env) *default-sync-translation*
    (go-try-
-    (let [t0 (metrics/start)
-          r (let [{:keys [key-vec base ignore-existence? config]} env
-                  key          (first key-vec)
-                  store-key    (key->store-key key)
-                  on-error     (fn [e] (ex-info "Could not delete key."
-                                                {:key key :base base :exception e}))
+    (let [{:keys [key-vec base ignore-existence? config]} env
+          key          (first key-vec)
+          store-key    (key->store-key key)
+          on-error     (fn [e] (ex-info "Could not delete key."
+                                        {:key key :base base :exception e}))
           ;; A delete is a write. On a FENCEABLE key — one with a sidecar — it
           ;; has to take the sidecar's lock like every other writer, or a fenced
           ;; write can pass `check-revision!`, this delete can land, and the
           ;; fenced value can then land on top: both report success and a
           ;; deleted key reappears, with no serialization consistent with the
           ;; revision the writer was promised. Same probe the write path pays.
-                  cas-store-key (str store-key cas-lock-suffix)
-                  cas-blob      (when (and (needs-sidecar-lock? backing config)
-                                           (<?- (-blob-exists? backing cas-store-key env)))
-                                  (<?- (-create-blob backing cas-store-key env)))
-                  delete!       (fn [] (go-try-
-                                        (try (<?- (-delete-blob backing store-key env)) true
-                                             (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))))]
-              (try
-                (let [cas-lock (when cas-blob (<?- (get-lock cas-blob key env)))]
-                  (try
-                    (cond
+          cas-store-key (str store-key cas-lock-suffix)
+          cas-blob      (when (and (needs-sidecar-lock? backing config)
+                                   (<?- (-blob-exists? backing cas-store-key env)))
+                          (<?- (-create-blob backing cas-store-key env)))
+          delete!       (fn [] (go-try-
+                                (try (<?- (-delete-blob backing store-key env)) true
+                                     (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))))]
+      (try
+        (let [cas-lock (when cas-blob (<?- (get-lock cas-blob key env)))]
+          (try
+            (cond
               ;; opt-in fast path: no existed? boolean needed, idempotent delete.
-                      (and ignore-existence? (satisfies? PReadMissSafe backing)) (<?- (delete!))
-                      (<?- (-blob-exists? backing store-key env))                 (<?- (delete!))
-                      :else                                                      false)
-                    (finally
-                      (when cas-lock (<?- (-release cas-lock env))))))
-                (finally
-                  (when cas-blob (<?- (-close cas-blob env))))))]
-      (metrics/finish! {:config (:config env)} :delete :io t0)
-      r))))
+              (and ignore-existence? (satisfies? PReadMissSafe backing)) (<?- (delete!))
+              (<?- (-blob-exists? backing store-key env))                 (<?- (delete!))
+              :else                                                      false)
+            (finally
+              (when cas-lock (<?- (-release cas-lock env))))))
+        (finally
+          (when cas-blob (<?- (-close cas-blob env)))))))))
+
+;; ---------------------------------------------------------------------------
+;; Timed blob operations
+;; ---------------------------------------------------------------------------
+;;
+;; The `*` functions above do the work; these report it to `konserve.metrics`
+;; — the whole operation, from a backup copy or header read to the final
+;; move, with the exception's class when it threw. With no sink installed the
+;; inner channel (or value) is returned as it is: nothing added. Timing lives
+;; here, in a function of its own, rather than inside the operation's go
+;; block: a try/catch around a parking body is fine, but not one more closure
+;; inside `io-operation`, whose state machine already closes over more locals
+;; than the JVM lets a constructor take.
+
+(defn- preceding-write? [operation] (contains? #{:write-edn :write-binary} operation))
+
+(defn read-blob
+  "Read meta, edn or binary from blob — timed: the read of the old value that
+   precedes a write reports as `:read-old`, every other read as its operation."
+  [blob read-handlers serializers {:keys [sync? operation config] :as env}]
+  (let [t0 (metrics/start)]
+    (if-not t0
+      (read-blob* blob read-handlers serializers env)
+      (let [op (if (preceding-write? operation) :read-old operation)]
+        (async+sync
+         sync? *default-sync-translation*
+         (go-try-
+          (try
+            (let [r (<?- (read-blob* blob read-handlers serializers env))]
+              (metrics/finish! config op :io t0)
+              r)
+            (catch #?(:clj Exception :cljs js/Error) e
+              ;; A miss is not a failure of the backend.
+              (metrics/finish! config op :io t0 (when-not (store-key-not-found? e) e))
+              (throw e)))))))))
+
+(defn update-blob
+  "Write the meta and the updated value into the backing store — timed as one
+   `:write-edn`/`:write-binary` operation, backup copy and move included."
+  [backing store-key serializer write-handlers {:keys [sync? operation config] :as env} old]
+  (let [t0 (metrics/start)]
+    (if-not t0
+      (update-blob* backing store-key serializer write-handlers env old)
+      (async+sync
+       sync? *default-sync-translation*
+       (go-try-
+        (try
+          (let [r (<?- (update-blob* backing store-key serializer write-handlers env old))]
+            (metrics/finish! config operation :io t0)
+            r)
+          (catch #?(:clj Exception :cljs js/Error) e
+            (metrics/finish! config operation :io t0 e)
+            (throw e))))))))
+
+(defn delete-blob
+  "Remove the key's blob from the backing store — timed as `:delete`."
+  [backing env]
+  (let [t0 (metrics/start)]
+    (if-not t0
+      (delete-blob* backing env)
+      (async+sync
+       (:sync? env) *default-sync-translation*
+       (go-try-
+        (try
+          (let [r (<?- (delete-blob* backing env))]
+            (metrics/finish! (:config env) :delete :io t0)
+            r)
+          (catch #?(:clj Exception :cljs js/Error) e
+            (metrics/finish! (:config env) :delete :io t0 e)
+            (throw e))))))))
 
 (def ^:const max-lock-attempts 100)
 
@@ -1192,7 +1255,9 @@
                 {:keys [store-key-values processed-pairs]} prepared-data
 
                 ;; 2. Use the backing store's multi-write capability
-                multi-result (<?- (-multi-write-blobs backing store-key-values env))]
+                t0 (metrics/start)
+                multi-result (<?- (-multi-write-blobs backing store-key-values env))
+                _ (metrics/finish! config :multi-write :io t0)]
 
             ;; 3. Map the results back to original keys
             (into {} (map (fn [{:keys [key store-key]}]
@@ -1215,7 +1280,9 @@
               env (merge opts {:sync? sync?})
 
               ;; Use backing store's multi-delete capability
-              result (<?- (-multi-delete-blobs backing store-keys env))]
+              t0 (metrics/start)
+              result (<?- (-multi-delete-blobs backing store-keys env))
+              _ (metrics/finish! config :multi-delete :io t0)]
 
           ;; Map results back from store-keys to original keys
           (into {} (map (fn [key store-key]
@@ -1239,7 +1306,9 @@
               env (merge opts {:sync? sync?})
 
               ;; Use backing store's multi-read capability to get blobs
-              store-key-to-blob (<?- (-multi-read-blobs backing store-keys env))]
+              t0 (metrics/start)
+              store-key-to-blob (<?- (-multi-read-blobs backing store-keys env))
+              _ (metrics/finish! config :multi-read :io t0)]
 
           ;; Deserialize each blob and build result map (sparse - only found keys)
           (loop [result {}

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -1256,8 +1256,12 @@
 
                 ;; 2. Use the backing store's multi-write capability
                 t0 (metrics/start)
-                multi-result (<?- (-multi-write-blobs backing store-key-values env))
-                _ (metrics/finish! config :multi-write :io t0)]
+                multi-result (try (let [r (<?- (-multi-write-blobs backing store-key-values env))]
+                                    (metrics/finish! config :multi-write :io t0)
+                                    r)
+                                  (catch #?(:clj Throwable :cljs :default) e
+                                    (metrics/finish! config :multi-write :io t0 e)
+                                    (throw e)))]
 
             ;; 3. Map the results back to original keys
             (into {} (map (fn [{:keys [key store-key]}]
@@ -1281,8 +1285,12 @@
 
               ;; Use backing store's multi-delete capability
               t0 (metrics/start)
-              result (<?- (-multi-delete-blobs backing store-keys env))
-              _ (metrics/finish! config :multi-delete :io t0)]
+              result (try (let [r (<?- (-multi-delete-blobs backing store-keys env))]
+                            (metrics/finish! config :multi-delete :io t0)
+                            r)
+                          (catch #?(:clj Throwable :cljs :default) e
+                            (metrics/finish! config :multi-delete :io t0 e)
+                            (throw e)))]
 
           ;; Map results back from store-keys to original keys
           (into {} (map (fn [key store-key]
@@ -1307,8 +1315,12 @@
 
               ;; Use backing store's multi-read capability to get blobs
               t0 (metrics/start)
-              store-key-to-blob (<?- (-multi-read-blobs backing store-keys env))
-              _ (metrics/finish! config :multi-read :io t0)]
+              store-key-to-blob (try (let [r (<?- (-multi-read-blobs backing store-keys env))]
+                                       (metrics/finish! config :multi-read :io t0)
+                                       r)
+                                     (catch #?(:clj Throwable :cljs :default) e
+                                       (metrics/finish! config :multi-read :io t0 e)
+                                       (throw e)))]
 
           ;; Deserialize each blob and build result map (sparse - only found keys)
           (loop [result {}

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -4,6 +4,7 @@
    [clojure.core.async :refer [<! timeout] :as async]
    [clojure.string :refer [ends-with?]]
    [hasch.core :refer [uuid]]
+   [konserve.metrics :as metrics]
    [konserve.serializers :refer [key->serializer]]
    [konserve.compressor :refer [get-compressor null-compressor]]
    [konserve.encryptor :refer [get-encryptor null-encryptor]]
@@ -113,10 +114,11 @@
                                               serializer compressor encryptor meta-size)
           new-blob             (<?- (-create-blob backing new-store-key env))
           new-blob-closed?     (atom false)]
-      (try
-        (<?- (-write-header new-blob header env))
-        (<?- (-write-meta new-blob meta-arr env))
-        (if (= operation :write-binary)
+      (let [t0 (metrics/start)
+            r (try
+                (<?- (-write-header new-blob header env))
+                (<?- (-write-meta new-blob meta-arr env))
+                (if (= operation :write-binary)
           ;; Normalize here so no backing has to. `bassoc` documents five input
           ;; shapes; before this, only the filestore handled any but bytes, and
           ;; every other backing silently mishandled the rest — konserve-s3
@@ -125,50 +127,53 @@
           ;; the caller's input untouched, which is what lets a value larger
           ;; than the heap be written at all: Lucene's DEFAULT merge policy
           ;; tops out at 5 GB per segment, and a byte array at 2 GB.
-          (<?- (-write-binary new-blob meta-size
-                              (if (-streaming-binary-write? new-blob)
-                                input
-                                #?(:clj (nio/blob->bytes input) :cljs input))
-                              env))
-          (let [value-arr (to-array value)]
-            (<?- (-write-value new-blob value-arr meta-size env))))
+                  (<?- (-write-binary new-blob meta-size
+                                      (if (-streaming-binary-write? new-blob)
+                                        input
+                                        #?(:clj (nio/blob->bytes input) :cljs input))
+                                      env))
+                  (let [value-arr (to-array value)]
+                    (metrics/bytes! {:config config} operation (+ meta-size (count value-arr)))
+                    (<?- (-write-value new-blob value-arr meta-size env))))
 
-        (when (:sync-blob? config)
-          (log/trace :konserve/syncing-blob {:key key})
-          (<?- (-sync new-blob env)))
+                (when (:sync-blob? config)
+                  (log/trace :konserve/syncing-blob {:key key})
+                  (<?- (-sync new-blob env)))
         ;; Marked before the call: a close that throws after releasing the
         ;; resource must not be closed again from the `finally`.
-        (reset! new-blob-closed? true)
-        (<?- (-close new-blob env))
+                (reset! new-blob-closed? true)
+                (<?- (-close new-blob env))
 
-        (when-not (:in-place? config)
-          (log/trace :konserve/moving-blob {:key key})
-          (<?- (-atomic-move backing new-store-key store-key env))
-          (reset! moved? true))
+                (when-not (:in-place? config)
+                  (log/trace :konserve/moving-blob {:key key})
+                  (<?- (-atomic-move backing new-store-key store-key env))
+                  (reset! moved? true))
 
-        (when (:sync-blob? config)
-          (log/trace :konserve/syncing-store {:key key})
-          (<?- (-sync-store backing env)))
+                (when (:sync-blob? config)
+                  (log/trace :konserve/syncing-store {:key key})
+                  (<?- (-sync-store backing env)))
 
         ;; Clean up backup after successful write
-        (when (and (:in-place? config) (not (:no-backup? config)))
-          (log/trace :konserve/deleting-backup-blob {:backup-store-key backup-store-key :key key})
-          (<?- (-delete-blob backing backup-store-key env)))
+                (when (and (:in-place? config) (not (:no-backup? config)))
+                  (log/trace :konserve/deleting-backup-blob {:backup-store-key backup-store-key :key key})
+                  (<?- (-delete-blob backing backup-store-key env)))
 
-        (if (= operation :write-edn) [old-value value] true)
-        (finally
+                (if (= operation :write-edn) [old-value value] true)
+                (finally
           ;; Once. `-close` is idempotent on a FileChannel by spec, but that is
           ;; the filestore's property, not the protocol's.
-          (when-not @new-blob-closed?
-            (<?- (-close new-blob env)))
+                  (when-not @new-blob-closed?
+                    (<?- (-close new-blob env)))
           ;; A staging file that never got moved is ours to remove: with a
           ;; per-writer name nothing later overwrites it, so a failed write
           ;; would otherwise leave a complete-looking `.new` behind for good.
           ;; Best effort — this runs while an exception may be propagating,
           ;; and a cleanup failure must not replace it.
-          (when (and (not (:in-place? config)) (not @moved?))
-            (try (<?- (-delete-blob backing new-store-key env))
-                 (catch #?(:clj Exception :cljs js/Error) _ nil)))))))))
+                  (when (and (not (:in-place? config)) (not @moved?))
+                    (try (<?- (-delete-blob backing new-store-key env))
+                         (catch #?(:clj Exception :cljs js/Error) _ nil)))))]
+        (metrics/finish! {:config config} operation :io t0)
+        r)))))
 
 (defn read-header [ac serializers env]
   (let [{:keys [sync? store-key]} env]
@@ -206,44 +211,45 @@
                            ;; default and is what the tests used.
                            ((encryptor (:encryptor config)) (compressor serializer))
                            read-handlers)]
-      (case operation
-        :read-meta #?(:cljs (fn-read (<?- (-read-meta blob meta-size env)))
-                      :clj
-                      (let [bais-read (ByteArrayInputStream.
-                                       (<?- (-read-meta blob meta-size env)))
-                            value     (fn-read bais-read)
-                            _         (.close bais-read)]
-                        value))
-        :read-edn #?(:cljs (fn-read (<?- (-read-value blob meta-size env)))
-                     :clj
-                     (let [bais-read (ByteArrayInputStream.
-                                      (<?- (-read-value blob meta-size env)))
-                           value     (fn-read bais-read)
-                           _         (.close bais-read)]
-                       value))
-        :write-binary #?(:cljs
-                         (let [meta (fn-read (<?- (-read-meta blob meta-size env)))]
-                           [meta nil])
-                         :clj
-                         (let [bais-read (ByteArrayInputStream.
-                                          (<?- (-read-meta blob meta-size env)))
-                               meta      (fn-read bais-read)
-                               _         (.close bais-read)]
-                           [meta nil]))
-        :write-edn #?(:cljs
-                      (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
-                            value (fn-read (<?- (-read-value blob meta-size env)))]
-                        [meta value])
-                      :clj
-                      (let [bais-meta  (ByteArrayInputStream.
-                                        (<?- (-read-meta blob meta-size env)))
-                            meta       (fn-read bais-meta)
-                            _          (.close bais-meta)
-                            bais-value (ByteArrayInputStream.
-                                        (<?- (-read-value blob meta-size env)))
-                            value     (fn-read bais-value)
-                            _          (.close bais-value)]
-                        [meta value]))
+      (let [t0 (metrics/start)
+            r       (case operation
+                      :read-meta #?(:cljs (fn-read (<?- (-read-meta blob meta-size env)))
+                                    :clj
+                                    (let [bais-read (ByteArrayInputStream.
+                                                     (<?- (-read-meta blob meta-size env)))
+                                          value     (fn-read bais-read)
+                                          _         (.close bais-read)]
+                                      value))
+                      :read-edn #?(:cljs (fn-read (<?- (-read-value blob meta-size env)))
+                                   :clj
+                                   (let [bais-read (ByteArrayInputStream.
+                                                    (<?- (-read-value blob meta-size env)))
+                                         value     (fn-read bais-read)
+                                         _         (.close bais-read)]
+                                     value))
+                      :write-binary #?(:cljs
+                                       (let [meta (fn-read (<?- (-read-meta blob meta-size env)))]
+                                         [meta nil])
+                                       :clj
+                                       (let [bais-read (ByteArrayInputStream.
+                                                        (<?- (-read-meta blob meta-size env)))
+                                             meta      (fn-read bais-read)
+                                             _         (.close bais-read)]
+                                         [meta nil]))
+                      :write-edn #?(:cljs
+                                    (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
+                                          value (fn-read (<?- (-read-value blob meta-size env)))]
+                                      [meta value])
+                                    :clj
+                                    (let [bais-meta  (ByteArrayInputStream.
+                                                      (<?- (-read-meta blob meta-size env)))
+                                          meta       (fn-read bais-meta)
+                                          _          (.close bais-meta)
+                                          bais-value (ByteArrayInputStream.
+                                                      (<?- (-read-value blob meta-size env)))
+                                          value     (fn-read bais-value)
+                                          _          (.close bais-value)]
+                                      [meta value]))
         ;; Both segments, from the one pass the blob is already open for. The
         ;; write path has always done this (`:write-edn` below); a READ needs it
         ;; so a caller can obtain a value AND the revision it is at without a
@@ -251,21 +257,23 @@
         ;; is RACY: between reading the value and reading its revision another
         ;; writer can move both, and the caller would fence against a revision
         ;; that never belonged to the value it computed from.
-        :read-edn-meta #?(:cljs
-                          (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
-                                value (fn-read (<?- (-read-value blob meta-size env)))]
-                            [meta value])
-                          :clj
-                          (let [bais-meta  (ByteArrayInputStream.
-                                            (<?- (-read-meta blob meta-size env)))
-                                meta       (fn-read bais-meta)
-                                _          (.close bais-meta)
-                                bais-value (ByteArrayInputStream.
-                                            (<?- (-read-value blob meta-size env)))
-                                value      (fn-read bais-value)
-                                _          (.close bais-value)]
-                            [meta value]))
-        :read-binary (<?- (-read-binary blob meta-size locked-cb env)))))))
+                      :read-edn-meta #?(:cljs
+                                        (let [meta  (fn-read (<?- (-read-meta blob meta-size env)))
+                                              value (fn-read (<?- (-read-value blob meta-size env)))]
+                                          [meta value])
+                                        :clj
+                                        (let [bais-meta  (ByteArrayInputStream.
+                                                          (<?- (-read-meta blob meta-size env)))
+                                              meta       (fn-read bais-meta)
+                                              _          (.close bais-meta)
+                                              bais-value (ByteArrayInputStream.
+                                                          (<?- (-read-value blob meta-size env)))
+                                              value      (fn-read bais-value)
+                                              _          (.close bais-value)]
+                                          [meta value]))
+                      :read-binary (<?- (-read-binary blob meta-size locked-cb env)))]
+        (metrics/finish! {:config config} operation :io t0)
+        r)))))
 
 (declare get-lock cas-lock-suffix)
 
@@ -297,36 +305,39 @@
   (async+sync
    (:sync? env) *default-sync-translation*
    (go-try-
-    (let [{:keys [key-vec base ignore-existence? config]} env
-          key          (first key-vec)
-          store-key    (key->store-key key)
-          on-error     (fn [e] (ex-info "Could not delete key."
-                                        {:key key :base base :exception e}))
+    (let [t0 (metrics/start)
+          r (let [{:keys [key-vec base ignore-existence? config]} env
+                  key          (first key-vec)
+                  store-key    (key->store-key key)
+                  on-error     (fn [e] (ex-info "Could not delete key."
+                                                {:key key :base base :exception e}))
           ;; A delete is a write. On a FENCEABLE key — one with a sidecar — it
           ;; has to take the sidecar's lock like every other writer, or a fenced
           ;; write can pass `check-revision!`, this delete can land, and the
           ;; fenced value can then land on top: both report success and a
           ;; deleted key reappears, with no serialization consistent with the
           ;; revision the writer was promised. Same probe the write path pays.
-          cas-store-key (str store-key cas-lock-suffix)
-          cas-blob      (when (and (needs-sidecar-lock? backing config)
-                                   (<?- (-blob-exists? backing cas-store-key env)))
-                          (<?- (-create-blob backing cas-store-key env)))
-          delete!       (fn [] (go-try-
-                                (try (<?- (-delete-blob backing store-key env)) true
-                                     (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))))]
-      (try
-        (let [cas-lock (when cas-blob (<?- (get-lock cas-blob key env)))]
-          (try
-            (cond
+                  cas-store-key (str store-key cas-lock-suffix)
+                  cas-blob      (when (and (needs-sidecar-lock? backing config)
+                                           (<?- (-blob-exists? backing cas-store-key env)))
+                                  (<?- (-create-blob backing cas-store-key env)))
+                  delete!       (fn [] (go-try-
+                                        (try (<?- (-delete-blob backing store-key env)) true
+                                             (catch #?(:clj Exception :cljs js/Error) e (throw (on-error e))))))]
+              (try
+                (let [cas-lock (when cas-blob (<?- (get-lock cas-blob key env)))]
+                  (try
+                    (cond
               ;; opt-in fast path: no existed? boolean needed, idempotent delete.
-              (and ignore-existence? (satisfies? PReadMissSafe backing)) (<?- (delete!))
-              (<?- (-blob-exists? backing store-key env))                 (<?- (delete!))
-              :else                                                      false)
-            (finally
-              (when cas-lock (<?- (-release cas-lock env))))))
-        (finally
-          (when cas-blob (<?- (-close cas-blob env)))))))))
+                      (and ignore-existence? (satisfies? PReadMissSafe backing)) (<?- (delete!))
+                      (<?- (-blob-exists? backing store-key env))                 (<?- (delete!))
+                      :else                                                      false)
+                    (finally
+                      (when cas-lock (<?- (-release cas-lock env))))))
+                (finally
+                  (when cas-blob (<?- (-close cas-blob env))))))]
+      (metrics/finish! {:config (:config env)} :delete :io t0)
+      r))))
 
 (def ^:const max-lock-attempts 100)
 

--- a/src/konserve/impl/defaults.cljc
+++ b/src/konserve/impl/defaults.cljc
@@ -362,7 +362,7 @@
             (let [r (<?- (read-blob* blob read-handlers serializers env))]
               (metrics/finish! config op :io t0)
               r)
-            (catch #?(:clj Exception :cljs js/Error) e
+            (catch #?(:clj Throwable :cljs :default) e
               ;; A miss is not a failure of the backend.
               (metrics/finish! config op :io t0 (when-not (store-key-not-found? e) e))
               (throw e)))))))))
@@ -381,7 +381,7 @@
           (let [r (<?- (update-blob* backing store-key serializer write-handlers env old))]
             (metrics/finish! config operation :io t0)
             r)
-          (catch #?(:clj Exception :cljs js/Error) e
+          (catch #?(:clj Throwable :cljs :default) e
             (metrics/finish! config operation :io t0 e)
             (throw e))))))))
 
@@ -398,7 +398,7 @@
           (let [r (<?- (delete-blob* backing env))]
             (metrics/finish! (:config env) :delete :io t0)
             r)
-          (catch #?(:clj Exception :cljs js/Error) e
+          (catch #?(:clj Throwable :cljs :default) e
             (metrics/finish! (:config env) :delete :io t0 e)
             (throw e))))))))
 
@@ -1537,6 +1537,6 @@
                                                      :write-handlers      write-handlers
                                                      :buffer-size         buffer-size
                                                      :locks               (atom {})
-                                                     :config              complete-config
+                                                     :config              (metrics/with-backend-label complete-config backing)
                                                      :write-hooks         (atom {})})]
           store))))))

--- a/src/konserve/metrics.cljc
+++ b/src/konserve/metrics.cljc
@@ -91,7 +91,10 @@
   [x]
   (let [cfg  (or (:config x) x)
         spec (get x p/store-config-key)]
-    {:backend  (or (::backend cfg) (:backend spec) (type-label (:backing x)) :unknown)
+    {:backend  (or (::backend cfg) (:backend spec)
+                   (type-label (:backing x))
+                   (when (record? x) (type-label x))
+                   :unknown)
      :store-id (or (::store-id cfg) (:id spec))}))
 
 (defn- emit!

--- a/src/konserve/metrics.cljc
+++ b/src/konserve/metrics.cljc
@@ -3,125 +3,160 @@
 
    Every store operation passes through two narrow places — the API layer in
    `konserve.core` and the blob I/O in `konserve.impl.defaults` — and both
-   report here, to ONE process-wide `sink`: a `(fn [event])`, or nil. Nothing
-   wraps a store and no store changes identity; the labels come from the
-   store's own config. With no sink installed the cost is one deref per
-   operation.
+   report here, to a process-wide registry of named sinks. Nothing wraps a
+   store and no store changes identity: the labels come from the config the
+   store was connected with. Metrics are process-level by nature (a scrape is
+   of a process); scoping is by label, not by routing.
 
    An event is a map:
 
-     {:backend  :file            ; from the store's :config, or its type
-      :store-id #uuid \"…\"       ; :id of the store's config, when it has one
-      :op       :get-in           ; API op, blob op (:read-edn, :write-edn, …), or :lock
+     {:backend  :file            ; :backend of the connect/create config, or the store's type
+      :store-id #uuid \"…\"       ; :id of that config, when it has one
+      :op       :get-in           ; API op, blob op (:read-edn, :write-edn, :read-old, …), or :lock
       :level    :api | :io | :lock
       :nanos    12345             ; wall time of the operation
-      :error    \"ExceptionInfo\" ; when it threw, the exception's class name
-      :bytes    4096}             ; on a :bytes event: what was written
+      :error    \"ExceptionInfo\" ; when it threw: the exception's class name
+      :bytes    4096}             ; on a :bytes event: what a write serialized
 
    Three levels tell three stories. `:api` is what a caller waits for — lock
-   wait, serialization and I/O together. `:io` is the backend alone, below the
-   lock, per blob operation: the S3 round trip, the fsync. `:lock` is the wait
-   for the in-process key lock, the number that explains contention.
+   wait, serialization and I/O together, one event per public function; a
+   call rejected before it reaches the store (an unsupported option, a store
+   without the capability) produces none, and a function that delegates
+   (`get` to `get-in`, `update` to `update-in`) reports as what it delegates
+   to. `:io` is the backend alone, below the lock, per blob operation — the
+   S3 round trip, the fsync — from the first byte of a backup copy or header
+   read to the last of the move; the read of the old value before a write is
+   `:read-old`. `:lock` is the wait for the in-process key lock, absent on a
+   lock-free store, which has no wait.
 
-   A sink aggregates as it likes — `replikativ.metrics` folds events into
-   per-`[backend store-id op]` histograms for Prometheus; a test collects them
-   in an atom."
+   Two rules for a sink, both because it runs on the operation's own thread —
+   in the asynchronous arm a core.async dispatch thread, inside the completing
+   go block: it must be THREAD-SAFE (events from concurrent operations
+   interleave; each is self-contained, so aggregation needs no ordering) and
+   NON-BLOCKING, O(1) — count into atomics, or hand the event to a buffered
+   channel drained elsewhere. A sink that throws is logged and skipped; it
+   never fails the operation it observed.
+
+   Cost with no sink installed: one deref per measurement site — the API
+   function, the lock, the blob operation — and nothing else: no extra go
+   block, channel or allocation."
   (:require [clojure.core.async]
             [konserve.protocols :as p]
-            [superv.async])
+            [replikativ.logging :as log])
   #?(:cljs (:require-macros [konserve.metrics :refer [measured measured-go]]
-                            [clojure.core.async :refer [go]]
-                            [superv.async :refer [go-try-]])))
+                            [clojure.core.async :refer [go]])))
 
-(defonce ^{:doc "The one sink, `(fn [event])` or nil. See `set-sink!`."}
-  sink (atom nil))
+(defonce ^{:doc "id -> (fn [event]). See `add-sink!`."}
+  sinks (atom {}))
 
-(defn set-sink!
-  "Install `f` as the process-wide sink, or nil to stop recording."
-  [f]
-  (reset! sink f))
+(defn add-sink!
+  "Register `f`, a `(fn [event])`, under `id`; every event goes to every
+   registered sink. Returns `id`."
+  [id f]
+  (swap! sinks assoc id f)
+  id)
+
+(defn remove-sink!
+  "Unregister the sink under `id`."
+  [id]
+  (swap! sinks dissoc id)
+  nil)
 
 (defn now-nanos []
-  #?(:clj (System/nanoTime)
-     :cljs (* 1e6 (.now js/Date))))
+  #?(:clj  (System/nanoTime)
+     :cljs (* 1e6 (if (exists? js/performance) (.now js/performance) (.now js/Date)))))
 
 (defn labels
-  "The store's labels, `:backend` and `:store-id`, from the spec
-   `konserve.store/connect-store` stamped on it — on the store record itself
-   and on its `:config`, which is what a blob operation's `env` carries. A
-   store opened by a backend's own connect fn has no spec; it is labelled by
-   its backing's type, and its id is nil."
-  [store]
-  (let [spec (or (get store p/store-config-key) (:config store))]
-    {:backend  (or (:backend spec)
-                   #?(:clj (some-> (or (:backing store) store) class .getSimpleName .toLowerCase keyword)
+  "The labels of `x` — a store, or the `:config` map a blob operation carries:
+   `:backend` and `:store-id` from what `konserve.store/connect-store` stamped
+   (on the store under `store-config-key`, into a `DefaultStore`'s `:config`
+   under this namespace's keys). A store opened by a backend's own connect fn
+   has no id and is labelled by its backing's type."
+  [x]
+  (let [cfg  (or (:config x) x)
+        spec (get x p/store-config-key)]
+    {:backend  (or (::backend cfg) (:backend spec)
+                   #?(:clj (some-> (or (:backing x) x) class .getSimpleName .toLowerCase keyword)
                       :cljs :unknown))
-     :store-id (:id spec)}))
+     :store-id (or (::store-id cfg) (:id spec))}))
 
-(defn record!
-  "Send one event to `f`."
-  [f store op level t0 error]
-  (f (cond-> (assoc (labels store) :op op :level level :nanos (- (now-nanos) t0))
-       error (assoc :error #?(:clj (.getSimpleName (class error))
-                              :cljs (str (type error)))))))
+(defn- emit!
+  "One sink, one event, never an exception out."
+  [id f event]
+  (try (f event)
+       (catch #?(:clj Throwable :cljs :default) e
+         (log/warn :konserve/metrics-sink-failed {:sink id :error (str e)}))))
+
+(defn report!
+  "Send one event to every sink in `sinks`."
+  [sinks x op level t0 error]
+  (let [event (cond-> (assoc (labels x) :op op :level level :nanos (- (now-nanos) t0))
+                error (assoc :error #?(:clj (.getSimpleName (class error))
+                                       :cljs (str (type error)))))]
+    (doseq [[id f] sinks]
+      (emit! id f event))))
 
 (defn start
-  "The start time for a hand-placed measurement, or nil with no sink. For
-   code where `measured-go` cannot go — inside a large go block, where one
-   more closure over its locals is one too many for the JVM."
+  "The start of a hand-placed measurement, or nil with no sink installed."
   []
-  (when @sink (now-nanos)))
+  (when-not (empty? @sinks) (now-nanos)))
 
 (defn finish!
-  "Report the operation `start` began, if it began one."
-  [store op level t0]
-  (when t0
-    (when-let [f @sink]
-      (record! f store op level t0 nil))))
+  "Report the operation `start` began, if it began one; `error` when it threw."
+  ([x op level t0] (finish! x op level t0 nil))
+  ([x op level t0 error]
+   (when t0
+     (let [s @sinks]
+       (when-not (empty? s)
+         (report! s x op level t0 error))))))
 
 (defn bytes!
-  "Report `n` bytes written for `op` on `store` — its own event, so a sink can
-   count bytes per operation without the write's timing carrying them."
-  [store op n]
-  (when-let [f @sink]
-    (f (assoc (labels store) :op op :level :io :bytes n))))
+  "Report `n` bytes written for `op` on `x` — its own event, so a sink counts
+   bytes per operation without the write's timing carrying them."
+  [x op n]
+  (let [s @sinks]
+    (when-not (empty? s)
+      (let [event (assoc (labels x) :op op :level :io :bytes n)]
+        (doseq [[id f] s]
+          (emit! id f event))))))
 
 #?(:clj
    (defmacro measured
-     "Run `body` synchronously, reporting one event for `op` at `level` on
-      `store` — its wall time, and the exception's class if it threw (the
-      exception is rethrown). The synchronous twin of `measured-go`; konserve's
-      `async+sync` rewrites one into the other. The body appears once in the
-      expansion: with no sink it runs with one deref of overhead."
-     [store op level & body]
+     "Run `body` synchronously and report one event for `op` at `level` on
+      `x`: its wall time, and the exception's class if it threw (rethrown).
+      The synchronous twin of `measured-go`; konserve's `async+sync` rewrites
+      one into the other. With no sink: the body, and one deref."
+     [x op level & body]
      (let [catch-class (if (:ns &env) :default 'Throwable)]
-       `(let [f#  @sink
-              t0# (when f# (now-nanos))]
-          (try
-            (let [r# (do ~@body)]
-              (when f# (record! f# ~store ~op ~level t0# nil))
-              r#)
-            (catch ~catch-class e#
-              (when f# (record! f# ~store ~op ~level t0# e#))
-              (throw e#)))))))
+       `(let [s# @sinks]
+          (if (empty? s#)
+            (do ~@body)
+            (let [t0# (now-nanos)]
+              (try
+                (let [r# (do ~@body)]
+                  (report! s# ~x ~op ~level t0# nil)
+                  r#)
+                (catch ~catch-class e#
+                  (report! s# ~x ~op ~level t0# e#)
+                  (throw e#)))))))))
 
 #?(:clj
    (defmacro measured-go
-     "Run `body` in a go block and return a channel that delivers its result —
-      or its exception as a value, as `go-try-` does — reporting one event
-      when it does. Measuring on the channel rather than around the body keeps
-      a `try` out of the go block: core.async's IOC compiler does not take a
-      try/catch wrapped around a try/finally that parks. The body appears once
-      in the expansion, so a state machine is built for it once. Take with
-      `<?-`, which rethrows a delivered exception."
-     [store op level & body]
-     `(let [f#  @sink
-            t0# (when f# (now-nanos))
-            ch# (superv.async/go-try- ~@body)]
-        (if f#
+     "`body` evaluates to the operation's CHANNEL — what `go-try-` or
+      `go-locked` returned. With no sink that channel is returned as it is:
+      no go block, no wrapper. With sinks, a go block takes from it, reports
+      one event — the exception's class when the channel delivered one, as
+      `go-try-` does — and delivers the same result. Measuring on the channel
+      keeps a `try` out of the operation's go block, which core.async's IOC
+      compiler does not take around a body that parks inside a try/finally."
+     [x op level & body]
+     `(let [s#  @sinks
+            t0# (when-not (empty? s#) (now-nanos))
+            ch# (do ~@body)]
+        (if t0#
           (clojure.core.async/go
             (let [r# (clojure.core.async/<! ch#)]
-              (record! f# ~store ~op ~level t0#
+              (report! s# ~x ~op ~level t0#
                        (when (instance? ~(if (:ns &env) 'js/Error 'Throwable) r#) r#))
               r#))
           ch#))))

--- a/src/konserve/metrics.cljc
+++ b/src/konserve/metrics.cljc
@@ -66,18 +66,32 @@
   #?(:clj  (System/nanoTime)
      :cljs (* 1e6 (if (exists? js/performance) (.now js/performance) (.now js/Date)))))
 
+(defn type-label
+  "A keyword for `x`'s type, for a store that carries no config to label it
+   by: `konserve.filestore.BackingFilestore` → `:backingfilestore`."
+  [x]
+  #?(:clj  (some-> x class .getSimpleName .toLowerCase keyword)
+     :cljs (some-> x type pr-str keyword)))
+
+(defn with-backend-label
+  "`config` with `::backend` set from `backing`'s type unless a store spec
+   already named the backend — called where a DefaultStore is built, so the
+   `:config` map every blob operation carries labels itself the same way the
+   store does."
+  [config backing]
+  (cond-> config
+    (nil? (::backend config)) (assoc ::backend (type-label backing))))
+
 (defn labels
   "The labels of `x` — a store, or the `:config` map a blob operation carries:
    `:backend` and `:store-id` from what `konserve.store/connect-store` stamped
    (on the store under `store-config-key`, into a `DefaultStore`'s `:config`
    under this namespace's keys). A store opened by a backend's own connect fn
-   has no id and is labelled by its backing's type."
+   has no id and is labelled by its backing's type, at every level alike."
   [x]
   (let [cfg  (or (:config x) x)
         spec (get x p/store-config-key)]
-    {:backend  (or (::backend cfg) (:backend spec)
-                   #?(:clj (some-> (or (:backing x) x) class .getSimpleName .toLowerCase keyword)
-                      :cljs :unknown))
+    {:backend  (or (::backend cfg) (:backend spec) (type-label (:backing x)) :unknown)
      :store-id (or (::store-id cfg) (:id spec))}))
 
 (defn- emit!

--- a/src/konserve/metrics.cljc
+++ b/src/konserve/metrics.cljc
@@ -1,0 +1,127 @@
+(ns konserve.metrics
+  "Where the numbers come from.
+
+   Every store operation passes through two narrow places — the API layer in
+   `konserve.core` and the blob I/O in `konserve.impl.defaults` — and both
+   report here, to ONE process-wide `sink`: a `(fn [event])`, or nil. Nothing
+   wraps a store and no store changes identity; the labels come from the
+   store's own config. With no sink installed the cost is one deref per
+   operation.
+
+   An event is a map:
+
+     {:backend  :file            ; from the store's :config, or its type
+      :store-id #uuid \"…\"       ; :id of the store's config, when it has one
+      :op       :get-in           ; API op, blob op (:read-edn, :write-edn, …), or :lock
+      :level    :api | :io | :lock
+      :nanos    12345             ; wall time of the operation
+      :error    \"ExceptionInfo\" ; when it threw, the exception's class name
+      :bytes    4096}             ; on a :bytes event: what was written
+
+   Three levels tell three stories. `:api` is what a caller waits for — lock
+   wait, serialization and I/O together. `:io` is the backend alone, below the
+   lock, per blob operation: the S3 round trip, the fsync. `:lock` is the wait
+   for the in-process key lock, the number that explains contention.
+
+   A sink aggregates as it likes — `replikativ.metrics` folds events into
+   per-`[backend store-id op]` histograms for Prometheus; a test collects them
+   in an atom."
+  (:require [clojure.core.async]
+            [konserve.protocols :as p]
+            [superv.async])
+  #?(:cljs (:require-macros [konserve.metrics :refer [measured measured-go]]
+                            [clojure.core.async :refer [go]]
+                            [superv.async :refer [go-try-]])))
+
+(defonce ^{:doc "The one sink, `(fn [event])` or nil. See `set-sink!`."}
+  sink (atom nil))
+
+(defn set-sink!
+  "Install `f` as the process-wide sink, or nil to stop recording."
+  [f]
+  (reset! sink f))
+
+(defn now-nanos []
+  #?(:clj (System/nanoTime)
+     :cljs (* 1e6 (.now js/Date))))
+
+(defn labels
+  "The store's labels, `:backend` and `:store-id`, from the spec
+   `konserve.store/connect-store` stamped on it — on the store record itself
+   and on its `:config`, which is what a blob operation's `env` carries. A
+   store opened by a backend's own connect fn has no spec; it is labelled by
+   its backing's type, and its id is nil."
+  [store]
+  (let [spec (or (get store p/store-config-key) (:config store))]
+    {:backend  (or (:backend spec)
+                   #?(:clj (some-> (or (:backing store) store) class .getSimpleName .toLowerCase keyword)
+                      :cljs :unknown))
+     :store-id (:id spec)}))
+
+(defn record!
+  "Send one event to `f`."
+  [f store op level t0 error]
+  (f (cond-> (assoc (labels store) :op op :level level :nanos (- (now-nanos) t0))
+       error (assoc :error #?(:clj (.getSimpleName (class error))
+                              :cljs (str (type error)))))))
+
+(defn start
+  "The start time for a hand-placed measurement, or nil with no sink. For
+   code where `measured-go` cannot go — inside a large go block, where one
+   more closure over its locals is one too many for the JVM."
+  []
+  (when @sink (now-nanos)))
+
+(defn finish!
+  "Report the operation `start` began, if it began one."
+  [store op level t0]
+  (when t0
+    (when-let [f @sink]
+      (record! f store op level t0 nil))))
+
+(defn bytes!
+  "Report `n` bytes written for `op` on `store` — its own event, so a sink can
+   count bytes per operation without the write's timing carrying them."
+  [store op n]
+  (when-let [f @sink]
+    (f (assoc (labels store) :op op :level :io :bytes n))))
+
+#?(:clj
+   (defmacro measured
+     "Run `body` synchronously, reporting one event for `op` at `level` on
+      `store` — its wall time, and the exception's class if it threw (the
+      exception is rethrown). The synchronous twin of `measured-go`; konserve's
+      `async+sync` rewrites one into the other. The body appears once in the
+      expansion: with no sink it runs with one deref of overhead."
+     [store op level & body]
+     (let [catch-class (if (:ns &env) :default 'Throwable)]
+       `(let [f#  @sink
+              t0# (when f# (now-nanos))]
+          (try
+            (let [r# (do ~@body)]
+              (when f# (record! f# ~store ~op ~level t0# nil))
+              r#)
+            (catch ~catch-class e#
+              (when f# (record! f# ~store ~op ~level t0# e#))
+              (throw e#)))))))
+
+#?(:clj
+   (defmacro measured-go
+     "Run `body` in a go block and return a channel that delivers its result —
+      or its exception as a value, as `go-try-` does — reporting one event
+      when it does. Measuring on the channel rather than around the body keeps
+      a `try` out of the go block: core.async's IOC compiler does not take a
+      try/catch wrapped around a try/finally that parks. The body appears once
+      in the expansion, so a state machine is built for it once. Take with
+      `<?-`, which rethrows a delivered exception."
+     [store op level & body]
+     `(let [f#  @sink
+            t0# (when f# (now-nanos))
+            ch# (superv.async/go-try- ~@body)]
+        (if f#
+          (clojure.core.async/go
+            (let [r# (clojure.core.async/<! ch#)]
+              (record! f# ~store ~op ~level t0#
+                       (when (instance? ~(if (:ns &env) 'js/Error 'Throwable) r#) r#))
+              r#))
+          ch#))))

--- a/src/konserve/store.cljc
+++ b/src/konserve/store.cljc
@@ -112,7 +112,12 @@
    passes through untouched, which is also what makes the guard above safe."
   [store config]
   (if (and config (or (map? store) (record? store)))
-    (assoc store p/store-config-key (p/strip-credentials config))
+    (cond-> (assoc store p/store-config-key (p/strip-credentials config))
+      ;; A DefaultStore hands its :config map to every blob operation as the
+      ;; `env`, so the store's identity travels with it: that is how
+      ;; `konserve.metrics` labels the backend's own work without any store
+      ;; being wrapped. Two keys, no credentials.
+      (map? (:config store)) (update :config assoc :backend (:backend config) :id (:id config)))
     store))
 
 (defn- with-store-config

--- a/src/konserve/store.cljc
+++ b/src/konserve/store.cljc
@@ -116,8 +116,11 @@
       ;; A DefaultStore hands its :config map to every blob operation as the
       ;; `env`, so the store's identity travels with it: that is how
       ;; `konserve.metrics` labels the backend's own work without any store
-      ;; being wrapped. Two keys, no credentials.
-      (map? (:config store)) (update :config assoc :backend (:backend config) :id (:id config)))
+      ;; being wrapped. Two NAMESPACED keys, so nothing a backend keeps in that
+      ;; map is touched; no credentials.
+      (map? (:config store)) (update :config assoc
+                                     :konserve.metrics/backend  (:backend config)
+                                     :konserve.metrics/store-id (:id config)))
     store))
 
 (defn- with-store-config

--- a/src/konserve/utils.cljc
+++ b/src/konserve/utils.cljc
@@ -186,7 +186,8 @@
     <?- do
     reduce<?- reduce
     go-locked locked
-    maybe-go-locked maybe-locked})
+    maybe-go-locked maybe-locked
+    konserve.metrics/measured-go konserve.metrics/measured})
 
 #?(:clj
    (defmacro with-promise [sym & body]

--- a/test/konserve/filestore_migration_test.clj
+++ b/test/konserve/filestore_migration_test.clj
@@ -1,9 +1,9 @@
 (ns konserve.filestore-migration-test
   (:refer-clojure :exclude [get get-in keys update update-in assoc assoc-in exists? bget bassoc])
-  (:require [clojure.test :refer [deftest testing are]]
+  (:require [clojure.test :refer [deftest testing are is]]
             [konserve.old-filestore :as old-store]
             [clojure.core.async :refer [go <!!]]
-            [konserve.core :refer [get bget keys]]
+            [konserve.core :refer [get get-in bget keys]]
             [konserve.filestore :refer [connect-fs-store delete-store]]))
 
 (deftest old-filestore-v1
@@ -173,3 +173,26 @@
           {:key 5, :type :binary}
           {:key 8, :type :binary}}
         (into #{} (map #(dissoc % :last-write) list-keys))))))
+
+(deftest old-filestore-migrations-synchronously
+  ;; The migrations ran only under {:sync? false} until now: the synchronous
+  ;; path closed its FileChannel as an AsynchronousFileChannel and threw.
+  (testing "v1 edn and binary, synchronously"
+    (let [path      "/tmp/konserve-fs-migration-test-v1-sync"
+          _         (delete-store path)
+          store     (<!! (old-store/new-fs-store-v1 path))
+          _         (<!! (old-store/-assoc-in store [:e] {:v 1}))
+          _         (<!! (old-store/-bassoc store :b (byte-array (range 10))))
+          new-store (connect-fs-store path :detect-old-file-schema? true :opts {:sync? true})]
+      (is (= {:v 1} (get-in new-store [:e] nil {:sync? true})))
+      (is (= (range 10) (bget new-store :b (fn [{:keys [input-stream]}] (vec (.readAllBytes ^java.io.InputStream input-stream))) {:sync? true})))
+      (delete-store path)))
+  (testing "v2 edn, synchronously"
+    (let [path      "/tmp/konserve-fs-migration-test-v2-sync"
+          _         (delete-store path)
+          store     (<!! (old-store/new-fs-store path))
+          _         (<!! (old-store/-assoc-in store [:e] {:v 2}))
+          new-store (connect-fs-store path :detect-old-file-schema? true :opts {:sync? true})]
+      (is (= {:v 2} (get-in new-store [:e] nil {:sync? true})))
+      (delete-store path))))
+

--- a/test/konserve/metrics_test.cljc
+++ b/test/konserve/metrics_test.cljc
@@ -1,8 +1,9 @@
 (ns konserve.metrics-test
-  "Every operation reports one event to the sink, at the level it happened —
-   without any store being wrapped."
+  "Every operation reports one event to every registered sink, at the level
+   it happened — without any store being wrapped — and a sink can never harm
+   the operation it observes."
   (:require [clojure.test :refer [deftest is testing]]
-            [clojure.core.async :refer [#?(:clj <!!)]]
+            #?(:clj [clojure.core.async :refer [<!!]])
             [konserve.core :as k]
             [konserve.memory :refer [new-mem-store]]
             [konserve.metrics :as metrics]
@@ -10,69 +11,122 @@
             #?(:clj [konserve.store :as ks])))
 
 (defn- recording!
-  "Install a sink collecting into an atom; returns the atom."
-  []
+  "Register a recording sink under `id`; returns the atom it fills."
+  [id]
   (let [events (atom [])]
-    (metrics/set-sink! #(swap! events conj %))
+    (metrics/add-sink! id #(swap! events conj %))
     events))
 
-(defn- ops [events level] (->> @events (filter #(= level (:level %))) (map :op) set))
+(defn- ops [events level] (->> @events (filter #(= level (:level %))) (map :op) vec))
+
+(deftest sync-api-events-on-a-memory-store
+  ;; Synchronous only, so it runs on every platform.
+  (let [events (recording! ::t)
+        store  (new-mem-store (atom {}) {:sync? true})]
+    (try
+      (k/assoc-in store [:a] 1 {:sync? true})
+      (k/get-in store [:a] nil {:sync? true})
+      (k/update-in store [:a] inc {:sync? true})
+      (k/exists? store :a {:sync? true})
+      (k/dissoc store :a {:sync? true})
+      (k/keys store {:sync? true})
+      (testing "one :api event per call, in call order, with the store's labels"
+        (is (= [:assoc-in :get-in :update-in :exists? :dissoc :keys] (ops events :api)))
+        (is (every? #(and (number? (:nanos %)) (<= 0 (:nanos %))) @events)))
+      (testing "a failing operation reports its error and still throws"
+        (is (thrown? #?(:clj Exception :cljs js/Error)
+                     (k/update-in store [:a] (fn [_] (throw (ex-info "boom" {}))) {:sync? true})))
+        (is (= :update-in (:op (last @events))))
+        (is (some? (:error (last @events)))))
+      (finally
+        (metrics/remove-sink! ::t)))))
+
+(deftest a-sink-cannot-harm-the-operation
+  (let [events (recording! ::good)
+        store  (new-mem-store (atom {}) {:sync? true})]
+    (metrics/add-sink! ::bad (fn [_] (throw (ex-info "sink-boom" {}))))
+    (try
+      (testing "a throwing sink is logged and skipped; the operation returns its value and the other sink still sees it"
+        (is (= [nil 1] (k/assoc-in store [:a] 1 {:sync? true})))
+        (is (= 1 (k/get-in store [:a] nil {:sync? true})))
+        (is (= [:assoc-in :get-in] (ops events :api))))
+      (finally
+        (metrics/remove-sink! ::bad)
+        (metrics/remove-sink! ::good)))))
+
+(deftest no-sink-no-events
+  (let [store (new-mem-store (atom {}) {:sync? true})]
+    (is (empty? @metrics/sinks))
+    (is (= [nil 1] (k/assoc-in store [:a] 1 {:sync? true})))))
 
 #?(:clj
-   (deftest api-events-sync-and-async
-     (let [events (recording!)
+   (deftest async-api-events
+     (let [events (recording! ::t)
            store  (<!! (new-mem-store))]
        (try
-         (k/assoc-in store [:a] 1 {:sync? true})
-         (<!! (k/assoc-in store [:b] 2))
-         (k/get-in store [:a] nil {:sync? true})
-         (<!! (k/get-in store [:b]))
-         (k/update-in store [:a] inc {:sync? true})
-         (k/exists? store :a {:sync? true})
-         (<!! (k/dissoc store :b))
-         (k/bassoc store :bin (byte-array [1 2 3]) {:sync? true})
-         (testing "one :api event per call, sync and async alike"
-           (is (= #{:assoc-in :get-in :update-in :exists? :dissoc :bassoc} (ops events :api)))
-           (is (= 8 (count (filter #(= :api (:level %)) @events))))
-           (is (every? #(and (integer? (:nanos %)) (<= 0 (:nanos %))) @events)))
-         (testing "labels come from the store"
-           (is (every? #(= :memorystore (:backend %)) @events)))
-         (testing "a failing operation reports its error and still throws"
-           (is (thrown? Exception (k/update-in store [:a] (fn [_] (throw (ex-info "boom" {}))) {:sync? true})))
-           (is (= "ExceptionInfo" (:error (last @events))))
-           (is (= :update-in (:op (last @events)))))
+         (<!! (k/assoc-in store [:a] 1))
+         (<!! (k/get-in store [:a]))
+         (<!! (k/bassoc store :bin (byte-array [1 2 3])))
+         (is (= [:assoc-in :get-in :bassoc] (ops events :api)))
+         (testing "an exception delivered on the channel is reported, and still delivered"
+           (let [r (<!! (k/update-in store [:a] (fn [_] (throw (ex-info "boom" {})))))]
+             (is (instance? Throwable r))
+             (is (= "ExceptionInfo" (:error (last @events))))))
+         (testing "a throwing sink does not close the channel without a value"
+           (metrics/add-sink! ::bad (fn [_] (throw (ex-info "sink-boom" {}))))
+           (is (= 1 (<!! (k/get-in store [:a]))))
+           (metrics/remove-sink! ::bad))
          (finally
-           (metrics/set-sink! nil))))))
+           (metrics/remove-sink! ::t))))))
 
 #?(:clj
-   (deftest no-sink-no-events
-     (let [events (atom [])
-           store  (<!! (new-mem-store))]
-       (metrics/set-sink! nil)
-       (k/assoc-in store [:a] 1 {:sync? true})
-       (is (empty? @events)))))
-
-#?(:clj
-   (deftest io-and-lock-events-on-the-filestore
+   (deftest io-lock-and-bytes-events-on-the-filestore
      (let [path   (str (System/getProperty "java.io.tmpdir") "/konserve-metrics-" (random-uuid))
-           events (recording!)
+           events (recording! ::t)
            id     (random-uuid)
            store  (ks/create-store {:backend :file :path path :id id} {:sync? true})]
        (try
          (k/assoc-in store [:a] {:x 1} {:sync? true})
+         (testing "a fresh write: lock, bytes, the write itself, the API call"
+           (is (= [{:level :lock :op :lock}
+                   {:level :io :op :write-edn :bytes? true}
+                   {:level :io :op :write-edn :bytes? false}
+                   {:level :api :op :assoc-in}]
+                  (mapv #(cond-> (select-keys % [:level :op]) (= :io (:level %)) (assoc :bytes? (contains? % :bytes))) @events))))
+         (reset! events [])
+         (k/update-in store [:a :x] inc {:sync? true})
+         (testing "an update reads the old value first, labelled as such"
+           (is (= [:read-old :write-edn :write-edn] (ops events :io))))
+         (reset! events [])
          (k/get-in store [:a] nil {:sync? true})
+         (k/get-in store [:missing] nil {:sync? true})
+         (testing "a read; a miss is answered by the existence probe and reaches no blob"
+           (is (= [:read-edn] (ops events :io)))
+           (is (= [:get-in :get-in] (ops events :api)))
+           (is (every? #(not (contains? % :error)) @events)))
+         (reset! events [])
+         (k/bassoc store :bin (byte-array 100) {:sync? true})
+         (testing "binary writes report their bytes too"
+           (is (<= 100 (:bytes (first (filter :bytes @events)))))
+           (is (some #(= :write-binary (:op %)) @events)))
+         (reset! events [])
          (k/dissoc store :a {:sync? true})
-         (testing "the blob level reports the backend's own work, per blob operation"
-           (is (= #{:write-edn :read-edn :delete} (ops events :io))))
-         (testing "bytes written are their own event"
-           (let [b (first (filter :bytes @events))]
-             (is (= :write-edn (:op b)))
-             (is (pos? (:bytes b)))))
-         (testing "the lock wait is reported"
-           (is (contains? (ops events :lock) :lock)))
+         (is (= [:delete] (ops events :io)))
          (testing "every event carries the store's backend and id"
            (is (every? #(= :file (:backend %)) @events))
            (is (every? #(= id (:store-id %)) @events)))
          (finally
-           (metrics/set-sink! nil)
+           (metrics/remove-sink! ::t)
            (delete-store path))))))
+
+#?(:clj
+   (deftest multi-key-io-events
+     (let [events (recording! ::t)
+           store  (<!! (new-mem-store))]
+       (try
+         (<!! (k/multi-assoc store {:a 1 :b 2}))
+         (<!! (k/multi-get store [:a :b]))
+         (<!! (k/multi-dissoc store [:a :b]))
+         (is (= [:multi-assoc :multi-get :multi-dissoc] (ops events :api)))
+         (finally
+           (metrics/remove-sink! ::t))))))

--- a/test/konserve/metrics_test.cljc
+++ b/test/konserve/metrics_test.cljc
@@ -1,0 +1,78 @@
+(ns konserve.metrics-test
+  "Every operation reports one event to the sink, at the level it happened —
+   without any store being wrapped."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.core.async :refer [#?(:clj <!!)]]
+            [konserve.core :as k]
+            [konserve.memory :refer [new-mem-store]]
+            [konserve.metrics :as metrics]
+            #?(:clj [konserve.filestore :refer [delete-store]])
+            #?(:clj [konserve.store :as ks])))
+
+(defn- recording!
+  "Install a sink collecting into an atom; returns the atom."
+  []
+  (let [events (atom [])]
+    (metrics/set-sink! #(swap! events conj %))
+    events))
+
+(defn- ops [events level] (->> @events (filter #(= level (:level %))) (map :op) set))
+
+#?(:clj
+   (deftest api-events-sync-and-async
+     (let [events (recording!)
+           store  (<!! (new-mem-store))]
+       (try
+         (k/assoc-in store [:a] 1 {:sync? true})
+         (<!! (k/assoc-in store [:b] 2))
+         (k/get-in store [:a] nil {:sync? true})
+         (<!! (k/get-in store [:b]))
+         (k/update-in store [:a] inc {:sync? true})
+         (k/exists? store :a {:sync? true})
+         (<!! (k/dissoc store :b))
+         (k/bassoc store :bin (byte-array [1 2 3]) {:sync? true})
+         (testing "one :api event per call, sync and async alike"
+           (is (= #{:assoc-in :get-in :update-in :exists? :dissoc :bassoc} (ops events :api)))
+           (is (= 8 (count (filter #(= :api (:level %)) @events))))
+           (is (every? #(and (integer? (:nanos %)) (<= 0 (:nanos %))) @events)))
+         (testing "labels come from the store"
+           (is (every? #(= :memorystore (:backend %)) @events)))
+         (testing "a failing operation reports its error and still throws"
+           (is (thrown? Exception (k/update-in store [:a] (fn [_] (throw (ex-info "boom" {}))) {:sync? true})))
+           (is (= "ExceptionInfo" (:error (last @events))))
+           (is (= :update-in (:op (last @events)))))
+         (finally
+           (metrics/set-sink! nil))))))
+
+#?(:clj
+   (deftest no-sink-no-events
+     (let [events (atom [])
+           store  (<!! (new-mem-store))]
+       (metrics/set-sink! nil)
+       (k/assoc-in store [:a] 1 {:sync? true})
+       (is (empty? @events)))))
+
+#?(:clj
+   (deftest io-and-lock-events-on-the-filestore
+     (let [path   (str (System/getProperty "java.io.tmpdir") "/konserve-metrics-" (random-uuid))
+           events (recording!)
+           id     (random-uuid)
+           store  (ks/create-store {:backend :file :path path :id id} {:sync? true})]
+       (try
+         (k/assoc-in store [:a] {:x 1} {:sync? true})
+         (k/get-in store [:a] nil {:sync? true})
+         (k/dissoc store :a {:sync? true})
+         (testing "the blob level reports the backend's own work, per blob operation"
+           (is (= #{:write-edn :read-edn :delete} (ops events :io))))
+         (testing "bytes written are their own event"
+           (let [b (first (filter :bytes @events))]
+             (is (= :write-edn (:op b)))
+             (is (pos? (:bytes b)))))
+         (testing "the lock wait is reported"
+           (is (contains? (ops events :lock) :lock)))
+         (testing "every event carries the store's backend and id"
+           (is (every? #(= :file (:backend %)) @events))
+           (is (every? #(= id (:store-id %)) @events)))
+         (finally
+           (metrics/set-sink! nil)
+           (delete-store path))))))

--- a/test/konserve/metrics_test.cljc
+++ b/test/konserve/metrics_test.cljc
@@ -8,20 +8,23 @@
             [konserve.memory :refer [new-mem-store]]
             [konserve.metrics :as metrics]
             #?(:clj [konserve.filestore :refer [delete-store]])
+            #?(:clj [konserve.filestore])
             #?(:clj [konserve.store :as ks])))
 
 (defn- recording!
-  "Register a recording sink under `id`; returns the atom it fills."
-  [id]
-  (let [events (atom [])]
+  "Register a recording sink; returns `[id events]` — the id is fresh, so
+   tests may run in parallel."
+  []
+  (let [id     (keyword "konserve.metrics-test" (str (random-uuid)))
+        events (atom [])]
     (metrics/add-sink! id #(swap! events conj %))
-    events))
+    [id events]))
 
 (defn- ops [events level] (->> @events (filter #(= level (:level %))) (map :op) vec))
 
 (deftest sync-api-events-on-a-memory-store
   ;; Synchronous only, so it runs on every platform.
-  (let [events (recording! ::t)
+  (let [[sink events] (recording!)
         store  (new-mem-store (atom {}) {:sync? true})]
     (try
       (k/assoc-in store [:a] 1 {:sync? true})
@@ -39,10 +42,10 @@
         (is (= :update-in (:op (last @events))))
         (is (some? (:error (last @events)))))
       (finally
-        (metrics/remove-sink! ::t)))))
+        (metrics/remove-sink! sink)))))
 
 (deftest a-sink-cannot-harm-the-operation
-  (let [events (recording! ::good)
+  (let [[sink events] (recording!)
         store  (new-mem-store (atom {}) {:sync? true})]
     (metrics/add-sink! ::bad (fn [_] (throw (ex-info "sink-boom" {}))))
     (try
@@ -52,7 +55,7 @@
         (is (= [:assoc-in :get-in] (ops events :api))))
       (finally
         (metrics/remove-sink! ::bad)
-        (metrics/remove-sink! ::good)))))
+        (metrics/remove-sink! sink)))))
 
 (deftest no-sink-no-events
   (let [store (new-mem-store (atom {}) {:sync? true})]
@@ -61,7 +64,7 @@
 
 #?(:clj
    (deftest async-api-events
-     (let [events (recording! ::t)
+     (let [[sink events] (recording!)
            store  (<!! (new-mem-store))]
        (try
          (<!! (k/assoc-in store [:a] 1))
@@ -77,12 +80,12 @@
            (is (= 1 (<!! (k/get-in store [:a]))))
            (metrics/remove-sink! ::bad))
          (finally
-           (metrics/remove-sink! ::t))))))
+           (metrics/remove-sink! sink))))))
 
 #?(:clj
    (deftest io-lock-and-bytes-events-on-the-filestore
      (let [path   (str (System/getProperty "java.io.tmpdir") "/konserve-metrics-" (random-uuid))
-           events (recording! ::t)
+           [sink events] (recording!)
            id     (random-uuid)
            store  (ks/create-store {:backend :file :path path :id id} {:sync? true})]
        (try
@@ -115,13 +118,25 @@
          (testing "every event carries the store's backend and id"
            (is (every? #(= :file (:backend %)) @events))
            (is (every? #(= id (:store-id %)) @events)))
+         (testing "a store opened by the backend's own connect fn is labelled by its backing at every level alike"
+           (let [path2  (str path "-direct")
+                 direct (konserve.filestore/connect-fs-store path2 :opts {:sync? true})]
+             (try
+               (reset! events [])
+               (k/assoc-in direct [:a] 1 {:sync? true})
+               (is (= #{:backingfilestore} (set (map :backend @events))))
+               (is (every? #(nil? (:store-id %)) @events))
+               (finally (delete-store path2)))))
          (finally
-           (metrics/remove-sink! ::t)
+           (metrics/remove-sink! sink)
            (delete-store path))))))
 
 #?(:clj
-   (deftest multi-key-io-events
-     (let [events (recording! ::t)
+   ;; The memory store answers multi-key calls itself, so this covers the :api
+   ;; events; the :multi-* blob events come from a backing that implements
+   ;; PMultiWriteBackingStore, which in-tree is IndexedDB (browser suite).
+   (deftest multi-key-api-events
+     (let [[sink events] (recording!)
            store  (<!! (new-mem-store))]
        (try
          (<!! (k/multi-assoc store {:a 1 :b 2}))
@@ -129,4 +144,4 @@
          (<!! (k/multi-dissoc store [:a :b]))
          (is (= [:multi-assoc :multi-get :multi-dissoc] (ops events :api)))
          (finally
-           (metrics/remove-sink! ::t))))))
+           (metrics/remove-sink! sink))))))


### PR DESCRIPTION
`konserve.metrics`: a process-wide registry of named sinks — `(add-sink! id f)` / `(remove-sink! id)`, each a `(fn [event])` — receives one event per operation at three levels: `:api` (what a caller waits for, per public function incl. `keys`/`revision`), `:io` (the backend's own work per blob operation, below the lock, from the first byte of a backup copy or header read to the end of the move; the pre-write read is `:read-old`; `:multi-read/write/delete`; plus `:bytes` events for what a write serialized, edn and binary), `:lock` (the in-process key-lock wait). No store is wrapped and none changes identity: labels come from the config `connect-store`/`create-store` stamp on the store, now also — namespaced — into a `DefaultStore`'s `:config`, so the blob level can label itself.

Guarantees: a throwing sink is logged and skipped, never failing the operation it observed; with no sink registered the operation's own channel is returned untouched — no go block, no wrapper, one deref per measurement site. Sinks run on the operation's thread and must be thread-safe and non-blocking (documented). Blob timing lives in wrappers of their own (`read-blob`/`update-blob`/`delete-blob` around the `*` bodies) rather than inside `io-operation`'s go block, whose closure over its locals is already at the JVM's limit; measuring the async arm on the channel keeps a `try` out of go blocks that park inside a try/finally.

Tests: `konserve.metrics-test` (sync events on every platform incl. Node; async events and exception delivery; throwing sink; ordered lock/bytes/io/api events on the filestore; `:read-old`; miss without error; binary bytes; multi-key ops). Full JVM suite 268/4307, Node 69/434, format and reflection clean. README (Advanced Features → Metrics) and CHANGELOG updated.

Reviewed four times with codex gpt-5.6-sol (high); round-1 findings (throwing sink, disabled-path cost, I/O timing coverage, operation coverage, config stamps), round-2 (label consistency at every level, Throwable in the wrappers), round-3 (the legacy migration env carries :config and :sync?, multi-key errors) and round-4 (**the synchronous v1 filestore migration threw ClassCastException at its close — pre-existing on main, surfaced once the migration honoured the caller's sync mode; fixed, with synchronous migration tests**) each addressed in their own commit.

First step of the metrics plan: `replikativ.metrics` aggregates these into Prometheus histograms next; datahike's writer and HTTP layer and kabel record into the same registry.