### PR TITLE
Consume Geheimnis 0.2.40 native-image RNG fix

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
         org.replikativ/hasch {:mvn/version "0.4.100"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         ;; Includes the synchronous JVM AEAD APIs used by :aes-gcm.
-        org.replikativ/geheimnis {:mvn/version "0.2.39"}
+        org.replikativ/geheimnis {:mvn/version "0.2.40"}
         org.lz4/lz4-java {:mvn/version "1.8.0"}
         org.replikativ/logging {:mvn/version "0.1.3"}
         ;; cljs


### PR DESCRIPTION
Dependency-only bump to released Geheimnis 0.2.40, incorporating replikativ/geheimnis#11. Prevents Konserve consumers from inheriting an eagerly initialized SecureRandom that fails full native-image builds. Geheimnis JVM/CLJS/initialization CI and focused native RNG checks passed upstream. Full Datahike native validation against the released artifact is still running. No storage format, cryptographic primitive, persistence policy, or API changes.