### PR TITLE
Provision directory trees through explicit durable-parent barriers

### DIFF
--- a/doc/directory-provisioning.md
+++ b/doc/directory-provisioning.md
@@ -1,0 +1,40 @@
+# Explicit durable directory provisioning
+
+`konserve.directory-sync/provision-directory!` is an opt-in synchronous helper
+for a caller-owned local directory tree. It does not change `connect-fs-store`
+or make existing read-only connections perform writes.
+
+```clojure
+(require '[konserve.directory-sync :as directory-sync])
+(directory-sync/provision-directory! "/srv/durable-pool" "/srv/durable-pool/checkpoints/node-a")
+```
+
+The caller supplies an existing, independently provisioned durable ancestor.
+The helper cannot establish the durability of that ancestor's own name. Both
+arguments must be nonempty paths on the default filesystem; the normalized
+target must lie beneath the ancestor. It never creates the ancestor implicitly.
+
+For each descendant it creates or validates the directory, flushes the parent
+entry, and flushes the child. Retries repeat all barriers even if every directory
+now exists. Existence after a failed operation does not mean its name was made
+durable. IO failures propagate; partially created directories are left in place
+for retry, not automatically removed. Windows uses the JDK 22+ native directory
+barrier; Unix uses its directory force implementation. There is no unsafe mode.
+
+The caller must prevent concurrent rename, deletion, symlink replacement, and
+changes to ancestor resolution during provisioning and subsequent use. Existing
+symlink components within the managed path are rejected, but path checks are not
+a sandbox against hostile filesystem races. No permissions or ownership are
+changed. This operation does not freeze the tree or establish a distributed
+retention policy.
+
+Tests inject a failure at each barrier, retry existing-but-unconfirmed paths,
+check real directory barriers, and reject outside paths, missing ancestors,
+regular files and symlink components. Symlink creation tests are Unix-only;
+ordinary and injected barrier cases are included in the Windows artifact suite.
+These checks are not OS-crash/power-cut qualification.
+
+Netz adoption must bind the ancestor to its owned repository configuration and
+cover all newly created repository subdirectories before issuing durable
+receipts. Adding this helper alone does not qualify arbitrary caller-provided
+Konserve stores or repair existing unsynced ancestors outside the chosen boundary.

--- a/src/konserve/directory_sync.clj
+++ b/src/konserve/directory_sync.clj
@@ -1,7 +1,7 @@
 (ns konserve.directory-sync
   "Platform-specific directory persistence. Failures never imply rollback."
   (:import [java.nio.channels FileChannel]
-           [java.nio.file Path Paths OpenOption]))
+           [java.nio.file Path Paths OpenOption Files FileSystems LinkOption FileAlreadyExistsException]))
 
 (defn windows? []
   (.startsWith (System/getProperty "os.name" "") "Windows"))
@@ -31,3 +31,47 @@
       (windows-flush! path)
       (with-open [channel (FileChannel/open path (make-array OpenOption 0))]
         (.force channel true)))))
+
+(defn provision-directory!
+  "Synchronously provision path beneath a caller-trusted durable ancestor.
+  Both paths use the default filesystem. The ancestor must already exist and
+  its name must already be durable. The caller must exclude concurrent renames,
+  deletion and symlink replacement throughout the managed tree. This is not a
+  sandbox against hostile filesystem mutation.
+
+  Every parent/name barrier is repeated on retry, including existing entries.
+  Failures propagate and may leave directories behind; never infer rollback.
+  This opt-in operation does not change ordinary or read-only store connects."
+  [ancestor path]
+  (let [as-path (fn [p]
+                  (cond (instance? Path p) p
+                        (and (string? p) (seq p)) (Paths/get p (make-array String 0))
+                        :else (throw (ex-info "Provisioning requires a nonempty path"
+                                              {:type :konserve/invalid-provisioning-path}))))
+        ^Path ancestor (.normalize (.toAbsolutePath ^Path (as-path ancestor)))
+        ^Path path (.normalize (.toAbsolutePath ^Path (as-path path)))
+        nofollow (into-array LinkOption [LinkOption/NOFOLLOW_LINKS])
+        directory! (fn [^Path p]
+                     (when-not (Files/isDirectory p nofollow)
+                       (throw (ex-info "Provisioning requires real directory components"
+                                       {:type :konserve/invalid-provisioning-directory
+                                        :path (str p)}))))]
+    (when-not (and (= (FileSystems/getDefault) (.getFileSystem ancestor)
+                      (.getFileSystem path))
+                   (.startsWith path ancestor))
+      (throw (ex-info "Provisioning target must be beneath its default-filesystem ancestor"
+                      {:type :konserve/invalid-provisioning-path})))
+    (directory! ancestor)
+    (sync-directory! ancestor)
+    (when-not (= ancestor path)
+      (reduce (fn [^Path parent ^Path component]
+                (let [child (.resolve parent component)]
+                  (try
+                    (Files/createDirectory child (make-array java.nio.file.attribute.FileAttribute 0))
+                    (catch FileAlreadyExistsException _))
+                  (directory! child)
+                  (sync-directory! parent)
+                  (sync-directory! child)
+                  child))
+              ancestor (iterator-seq (.iterator (.relativize ancestor path)))))
+    path))

--- a/test/konserve/directory_provisioning_test.clj
+++ b/test/konserve/directory_provisioning_test.clj
@@ -1,0 +1,82 @@
+(ns konserve.directory-provisioning-test
+  (:require [clojure.test :refer [deftest is]]
+            [konserve.directory-sync :as ds])
+  (:import [java.nio.file Files Path FileVisitOption]
+           [java.io IOException]))
+
+(defn- with-tree [f]
+  (let [root (Files/createTempDirectory "konserve-provision-"
+                                        (make-array java.nio.file.attribute.FileAttribute 0))]
+    (try (f root)
+         (finally
+           (with-open [paths (Files/walk root (make-array FileVisitOption 0))]
+             (doseq [p (reverse (sort-by #(.getNameCount ^Path %)
+                                         (iterator-seq (.iterator paths))))]
+               (Files/delete ^Path p)))))))
+
+(defn- failure [f]
+  (try (f) nil (catch Exception e e)))
+
+(deftest retries-repeat-every-required-barrier
+  (doseq [fail-at (range 1 6)]
+    (with-tree
+      (fn [^Path root]
+        (let [a (.resolve root "a") b (.resolve a "b")
+              expected [root root a a b]
+              calls (atom []) error (IOException. "injected persistence failure")]
+          (with-redefs [ds/sync-directory! (fn [p]
+                                             (swap! calls conj p)
+                                             (when (= fail-at (count @calls)) (throw error)))]
+            (is (identical? error (failure #(ds/provision-directory! root b)))))
+          (is (= (take fail-at expected) @calls))
+          (reset! calls [])
+          (with-redefs [ds/sync-directory! #(swap! calls conj %)]
+            (is (= b (ds/provision-directory! root b)))
+            (is (= expected @calls))
+            (reset! calls [])
+            (ds/provision-directory! root b)
+            (is (= expected @calls) "Existing names are not evidence of completed barriers")))))))
+
+(deftest invalid-targets-do-not-trigger-io
+  (with-tree
+    (fn [^Path root]
+      (let [calls (atom [])]
+        (with-redefs [ds/sync-directory! #(swap! calls conj %)]
+          (doseq [path [nil "" :bad (.resolve root "../outside")]]
+            (is (= :konserve/invalid-provisioning-path
+                   (:type (ex-data (failure #(ds/provision-directory! root path))))))))
+        (is (empty? @calls))))))
+
+(deftest missing-ancestor-is-not-created
+  (with-tree
+    (fn [^Path root]
+      (let [missing (.resolve root "missing")]
+        (is (= :konserve/invalid-provisioning-directory
+               (:type (ex-data (failure #(ds/provision-directory! missing (.resolve missing "child")))))))))))
+
+(deftest actual-directory-barriers
+  (with-tree
+    (fn [^Path root]
+      (is (= root (ds/provision-directory! root root)))
+      (let [path (.resolve root "a/b")]
+        (is (= path (ds/provision-directory! root path)))
+        (is (= path (ds/provision-directory! root path)))))))
+
+(deftest regular-files-are-not-directory-components
+  (with-tree
+    (fn [^Path root]
+      (let [file (.resolve root "file")]
+        (Files/createFile file (make-array java.nio.file.attribute.FileAttribute 0))
+        (is (= :konserve/invalid-provisioning-directory
+               (:type (ex-data (failure #(ds/provision-directory! root (.resolve file "child")))))))))))
+
+(deftest symlink-components-are-rejected
+  ;; Windows symlink creation requires privileges not guaranteed on CI.
+  (when-not (ds/windows?)
+    (with-tree
+      (fn [^Path root]
+        (let [target (.resolve root "target") link (.resolve root "link")]
+          (Files/createDirectory target (make-array java.nio.file.attribute.FileAttribute 0))
+          (Files/createSymbolicLink link target (make-array java.nio.file.attribute.FileAttribute 0))
+          (is (= :konserve/invalid-provisioning-directory
+                 (:type (ex-data (failure #(ds/provision-directory! root (.resolve link "child"))))))))))))

--- a/test/konserve/directory_provisioning_test.clj
+++ b/test/konserve/directory_provisioning_test.clj
@@ -1,7 +1,7 @@
 (ns konserve.directory-provisioning-test
   (:require [clojure.test :refer [deftest is]]
             [konserve.directory-sync :as ds])
-  (:import [java.nio.file Files Path FileVisitOption]
+  (:import [java.nio.file Files Path FileVisitOption LinkOption AccessDeniedException]
            [java.io IOException]))
 
 (defn- with-tree [f]
@@ -29,6 +29,10 @@
                                              (when (= fail-at (count @calls)) (throw error)))]
             (is (identical? error (failure #(ds/provision-directory! root b)))))
           (is (= (take fail-at expected) @calls))
+          (is (= (> fail-at 1) (Files/exists a (make-array LinkOption 0)))
+              "A failed ancestor barrier must prevent the first mkdir")
+          (is (= (> fail-at 3) (Files/exists b (make-array LinkOption 0)))
+              "A failed parent/name barrier must prevent descending further")
           (reset! calls [])
           (with-redefs [ds/sync-directory! #(swap! calls conj %)]
             (is (= b (ds/provision-directory! root b)))
@@ -36,6 +40,18 @@
             (reset! calls [])
             (ds/provision-directory! root b)
             (is (= expected @calls) "Existing names are not evidence of completed barriers")))))))
+
+(deftest access-denied-is-never-a-successful-barrier
+  (with-tree
+    (fn [^Path root]
+      (let [target (.resolve root "child")
+            denied (AccessDeniedException. (str root))]
+        (doseq [windows? [false true]]
+          (with-redefs [ds/windows? (constantly windows?)
+                        ds/sync-directory! (fn [_] (throw denied))]
+            (is (identical? denied (failure #(ds/provision-directory! root target))))
+            (is (not (Files/exists target (make-array LinkOption 0)))
+                "Permission failure must not create descendants on either platform")))))))
 
 (deftest invalid-targets-do-not-trigger-io
   (with-tree

--- a/test/windows-durability/RunKonserve.ps1
+++ b/test/windows-durability/RunKonserve.ps1
@@ -40,7 +40,7 @@ if ($env:GITHUB_STEP_SUMMARY) {
 
 $cp = (Get-Content probe-results/artifact.cp -Raw).Trim()
 java --enable-native-access=ALL-UNNAMED -cp $cp clojure.main -e `
-    "(require 'konserve.directory-sync-test 'konserve.filestore-test 'konserve.mmap-test 'konserve.simulation-crash-test) (let [r (clojure.test/run-tests 'konserve.directory-sync-test 'konserve.filestore-test 'konserve.mmap-test 'konserve.simulation-crash-test)] (shutdown-agents) (System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))" |
+    "(require 'konserve.directory-sync-test 'konserve.directory-provisioning-test 'konserve.filestore-test 'konserve.mmap-test 'konserve.simulation-crash-test) (let [r (clojure.test/run-tests 'konserve.directory-sync-test 'konserve.directory-provisioning-test 'konserve.filestore-test 'konserve.mmap-test 'konserve.simulation-crash-test)] (shutdown-agents) (System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))" |
     Tee-Object probe-results/konserve-windows-integration.txt | Out-Host
 if ($LASTEXITCODE -ne 0) { throw 'Konserve Windows integration failed' }
 java --enable-native-access=ALL-UNNAMED -cp $cp clojure.main "$PSScriptRoot/process-crash.clj" |


### PR DESCRIPTION
Separate opt-in provisioning increment from the native release dependency fix. Adds konserve.directory-sync/provision-directory! with an existing, caller-trusted durable ancestor. Walks descendants and repeats parent/child barriers even on retry of existing directories. Rejects outside paths, missing ancestors, regular files and symlink components. IO failures propagate; no rollback/deletion or changes to ordinary/read-only connect-fs-store. Caller must exclude concurrent filesystem mutation; this is not a hostile-filesystem sandbox or power-loss qualification. Six local tests / 36 assertions pass, including all five barrier failure positions for a two-level tree. Added to the Windows packaged-artifact suite. Draft pending Windows/full-suite checks and adoption into owned Netz storage paths.