### PR TITLE
perf(tiered): hoist the fire-and-forget invalidations out of the method bodies — 2.0 s → 0.6 s load

### DIFF
--- a/src/konserve/tiered.cljc
+++ b/src/konserve/tiered.cljc
@@ -320,6 +320,30 @@
        (finally
          (async/put! cache-lock :unlocked))))))
 
+(defn ^:private invalidate-frontend!
+  "Fire-and-forget frontend invalidation for one key. Returns the `go` channel, which every
+   caller discards — the write-around policies do not wait for the frontend to catch up.
+
+   A TOP-LEVEL fn rather than a `go` inlined in the record's method bodies: an inner `go`
+   macroexpands into a complete state machine, and the enclosing `go-try-` then runs
+   core.async's ioc transform over a body containing all of that generated code — measured at
+   a ~6x compile-time multiplier per nesting, and `async+sync` compiles each body twice. The
+   four nested blocks were most of this namespace's ~2 s load."
+  [frontend-store key opts]
+  (go (try
+        (<?- (-dissoc frontend-store key opts))
+        (catch #?(:clj Exception :cljs js/Error) e
+          (log/warn :konserve/tiered-frontend-invalidation-failed {:key key :error e})))))
+
+(defn ^:private invalidate-frontend-keys!
+  "`invalidate-frontend!` for several keys, in order. Returns the `go` channel, discarded."
+  [frontend-store keys opts]
+  (go (try
+        (doseq [k keys]
+          (<?- (-dissoc frontend-store k opts)))
+        (catch #?(:clj Exception :cljs js/Error) e
+          (log/warn :konserve/tiered-frontend-invalidation-failed {:kvs-keys keys :error e})))))
+
 (defn- complete-read-through
   "Populate one frontend read and run its write hook.
 
@@ -532,10 +556,7 @@
                    :write-around
                    ;; Write only to backend, invalidate frontend
                    (let [result (<?- (-update-in backend-store key-vec meta-up-fn up-fn opts))]
-                     (go (try
-                           (<?- (-dissoc frontend-store (first key-vec) (frontend-opts opts)))
-                           (catch #?(:clj Exception :cljs js/Error) e
-                             (log/warn :konserve/tiered-frontend-invalidation-failed {:key (first key-vec) :error e}))))
+                     (invalidate-frontend! frontend-store (first key-vec) (frontend-opts opts))
                      result)
 
                    :frontend-only
@@ -577,10 +598,7 @@
 
                    :write-around
                    (let [result (<?- (-assoc-in backend-store key-vec meta-up-fn val opts))]
-                     (go (try
-                           (<?- (-dissoc frontend-store (first key-vec) (frontend-opts opts)))
-                           (catch #?(:clj Exception :cljs js/Error) e
-                             (log/warn :konserve/tiered-frontend-invalidation-failed {:key (first key-vec) :error e}))))
+                     (invalidate-frontend! frontend-store (first key-vec) (frontend-opts opts))
                      result)
 
                    :frontend-only
@@ -646,10 +664,7 @@
 
                      :write-around
                      (let [result (<?- (-bassoc backend-store key meta-up-fn val opts))]
-                       (go (try
-                             (<?- (-dissoc frontend-store key opts))
-                             (catch #?(:clj Exception :cljs js/Error) e
-                               (log/warn :konserve/tiered-frontend-invalidation-failed {:key key :error e}))))
+                       (invalidate-frontend! frontend-store key opts)
                        result)
 
                      :frontend-only
@@ -709,11 +724,7 @@
                    :write-around
                    (let [result (<?- (-multi-assoc backend-store kvs meta-up-fn opts))]
                      ;; Invalidate all affected keys from frontend
-                     (go (try
-                           (doseq [k (kv-keys kvs)]
-                             (<?- (-dissoc frontend-store k opts)))
-                           (catch #?(:clj Exception :cljs js/Error) e
-                             (log/warn :konserve/tiered-frontend-invalidation-failed {:kvs-keys (kv-keys kvs) :error e}))))
+                     (invalidate-frontend-keys! frontend-store (kv-keys kvs) opts)
                      result)
 
                    :frontend-only


### PR DESCRIPTION
`konserve.tiered` is the most expensive namespace in the stack to load, and it turned out to be one avoidable pattern.

## Where the time goes

98% of it is a single form: the file **without** its `TieredStore` defrecord loads in **100 ms**, with it in **4.7 s** (measured at an older revision; 2.0 s at current main).

Within the record, the driver is **`go` blocks nested inside the methods' `go-try-` bodies** — the four fire-and-forget frontend invalidations under `:write-around`. An inner `go` macroexpands into a complete state machine (a `fn` with `case` dispatch over states, closures, atoms); the enclosing `go-try-` then runs core.async's ioc transform over a body that *contains* all of that generated code — and `async+sync` compiles each body twice.

Measured in isolation, 14 methods with identical bodies except for one small nested `go`:

| | |
|---|---|
| flat (`async+sync` + `go-try-` + `<?-`) | **380 ms** |
| same, one nested `go` per method | **2,394 ms** |

A ~6× multiplier per nesting. For contrast, the things one would expect to matter barely do: 21 go-blocks ≈ 300 ms, branching ≈ 2×, body size is *sublinear* (4× body → 2.3× time), `defrecord` adds nothing, and superv's `<?-` plus `async+sync` together ≈ 10%.

## The change

The four nested blocks move to two top-level fns; the method bodies call them. Same `go`, same `try`/`catch`, same reader conditional, same log keys, same fire-and-forget semantics — each helper returns the `go` channel, which every caller discards exactly as before.

**Two** helpers rather than one: three sites invalidate a single key and one iterates `kv-keys`, and they log different data (`:key` vs `:kvs-keys`). Unifying them would have meant rewriting the single-key path as a one-element loop — a behaviour change for a cosmetic gain.

The one semantic difference worth stating: `(first key-vec)`, `(frontend-opts opts)` and `(kv-keys kvs)` are now evaluated at the call site rather than inside the `go`. All three are pure functions of immutable locals, so the values are identical; only a *throw* would surface differently (in the enclosing `go-try-` instead of the inner `catch`), and none of them throws on valid input. `(kv-keys kvs)` is now computed once and passed in, where the catch previously recomputed it to the same value.

## Result

    konserve.tiered load, all deps preloaded:  2038 ms → 617 ms   (3.3×)

Suite: **288 tests, 4506 assertions, 0 failures**. `cljfmt` clean.

## Context

This came out of profiling ansatz's startup: a store-backed session pays ~16 s for konserve and ~25 s for datahike loading from source, against 1.5 s for ansatz itself once AOT-compiled. `konserve.tiered` was the single biggest line item — and it is on the default load path for every consumer via the backend registry, including those that only ever call `connect-fs-store`. Two follow-ups worth considering separately: whether the registry needs to require every backend eagerly, and the same nesting pattern in `konserve.impl.defaults` (0.98 s) and `filestore` (0.77 s).