### PR TITLE
deps: superv.async 0.3.50 → 0.3.54

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
         ;; works only if it was registered at build time.
         org.replikativ/incognito {:mvn/version "0.3.71"}
         org.replikativ/hasch {:mvn/version "0.4.100"}
-        org.replikativ/superv.async {:mvn/version "0.3.50"}
+        org.replikativ/superv.async {:mvn/version "0.3.54"}
         ;; Includes the synchronous JVM AEAD APIs used by :aes-gcm.
         org.replikativ/geheimnis {:mvn/version "0.2.40"}
         org.lz4/lz4-java {:mvn/version "1.8.0"}


### PR DESCRIPTION
Picks up replikativ/superv.async#29 — the hoist of `restarting-supervisor`'s two inner `go-loop`s — which konserve motivated: konserve reaches that namespace for `go-try-` and `<?-`, and compiles the supervisor machinery on every JVM start without ever calling it.

## What the bump is worth

In superv's own repo the namespace's marginal load over core.async went **2222 ms → 1329 ms** (medians of three fresh-JVM runs), and `restarting-supervisor` alone 1005 ms → 379 ms.

Inside konserve's tree, on a loaded machine, it is directionally there but **not cleanly separable**: superv's marginal load measured 2034 → 1920 ms (medians), and `konserve.filestore`'s full ~13 s transitive load moves by less than its own run-to-run variance. I would rather state that than quote superv's number as if it had been reproduced here — the same caveat applies to #193 and #194, whose namespace-level gains are real but sit inside a much larger, noisier total.

For context on where that total goes, profiled by self time: of `konserve.filestore`'s 12.4 s, roughly 6 s is the core.async family (`core.async` + `ioc_macros` + protocols + channels + the tools.analyzer/reader it pulls) plus `superv.async`, ~3.4 s is konserve's own namespaces, and ~3 s is serialization and caching dependencies. There is no hotspot left in konserve itself; what remains is compile volume, which only AOT addresses.

## Also in the range

0.3.51–0.3.53 bring #26 (advanced-compilation warnings in CI) and #27, a ClojureScript fix where the supervisor's stale sweep held Node's event loop open.

## Tests

**288 tests, 4506 assertions, 0 failures.**